### PR TITLE
Change avg.is-a.dev from a CNAME to a URL redirect

### DIFF
--- a/domains/avg.json
+++ b/domains/avg.json
@@ -7,6 +7,6 @@
     "twitter": "avghelper"
   },
   "record": {
-    "URL": "averagehelper.github.io"
+    "URL": "https://averagehelper.github.io"
   }
 }

--- a/domains/avg.json
+++ b/domains/avg.json
@@ -7,6 +7,6 @@
     "twitter": "avghelper"
   },
   "record": {
-    "CNAME": "averagehelper.github.io"
+    "URL": "averagehelper.github.io"
   }
 }


### PR DESCRIPTION
Experimenting around. I'd like both domains to point to the same place, so I figure redirecting one to the other should work fine.