### PR TITLE
Update hzmi.json to use hzmi.xyz over hzmi.me

### DIFF
--- a/domains/hzmi.json
+++ b/domains/hzmi.json
@@ -6,6 +6,6 @@
     "email": "contact@hzmi.xyz"
   },
   "record": {
-    "URL": "https://hzmi.me"
+    "URL": "https://hzmi.xyz"
   }
 }


### PR DESCRIPTION
https://hzmi.me is dead, I want to wait for dotme TLD to become available on Cloudflare Registrar, Use https://hzmi.xyz for now