### PR TITLE
Update link.json

### DIFF
--- a/domains/link.json
+++ b/domains/link.json
@@ -1,11 +1,11 @@
 {
-  "description": "Url's Overview",
+  "description": "( A redirect link ) Url's Overview",
   "repo": "https://github.com/leecheeyong/leecheeyong",
   "owner": {
     "username": "leecheeyong",
     "email": "tribejoe.gg@gmail.com"
   },
-  "record": {
-    "CNAME": "3393f496-d1a6-4633-a49d-b46cb0229417.repl.co"
+   "record": {
+    "URL": "https://links.is-a.dev"
   }
 }


### PR DESCRIPTION
i'm not sure if i'm allowed to do so but link.is-a.dev was registered before on replit and replit sets the previous user as the owner ( #463 ) and so i couldn't link to it. But since I've already set some permanent configs, i need a 302 redirect to the new domain. before doing so you can check https://link.is-a.dev/__repl and its linking to the previous user's account.  