### PR TITLE
Add psj.is-a.dev

### DIFF
--- a/domains/psj.json
+++ b/domains/psj.json
@@ -1,0 +1,10 @@
+{
+  "owner":{
+           "username":"philphirn",
+           "email":"locusapp1@gmail.com"
+           },
+  "record":{
+            "TXT":"google-site-verification=iIr4JuqXdsX6yZNXnto6mPv5ouBqd17F6fXhs_edBCU",
+            "CNAME":"gv-2yeydifrrtrhvs.dv.googlehosted.com"
+            }
+}

--- a/domains/psj.json
+++ b/domains/psj.json
@@ -4,7 +4,6 @@
            "email":"locusapp1@gmail.com"
            },
   "record":{
-            "TXT":"google-site-verification=iIr4JuqXdsX6yZNXnto6mPv5ouBqd17F6fXhs_edBCU",
-            "CNAME":"gv-2yeydifrrtrhvs.dv.googlehosted.com"
+            "CNAME":"philphirn.github.io"
             }
 }

--- a/emkt3s7nipkc.psj.json
+++ b/emkt3s7nipkc.psj.json
@@ -1,9 +1,0 @@
-{
-  "owner":{
-           "username":"philphirn",
-           "email":"locusapp1@gmail.com"
-          },
-  "record":{
-            "CNAME":"gv-2yeydifrrtrhvs.dv.googlehosted.com"
-           }
-}

--- a/emkt3s7nipkc.psj.json
+++ b/emkt3s7nipkc.psj.json
@@ -1,0 +1,9 @@
+{
+  "owner":{
+           "username":"philphirn",
+           "email":"locusapp1@gmail.com"
+          },
+  "record":{
+            "CNAME":"gv-2yeydifrrtrhvs.dv.googlehosted.com"
+           }
+}


### PR DESCRIPTION
Adds psj.is-a.dev

See if you really don't support `TXT` records please put the following `CNAME` record :

Host/Label : `emkt3s7nipkc.psj.is-a.dev.`
Destination/Target : `gv-2yeydifrrtrhvs.dv.googlehosted.com`

The reason is that I want Google to verify psj.is-a.dev
If you have any questions/queries please comment here or email me on the email address given in json file.