### PR TITLE
feat: adds support for MX and TXT records

### DIFF
--- a/docs/domains-json.md
+++ b/docs/domains-json.md
@@ -21,7 +21,7 @@ In the owner object, the fields `username` and `email` are required. You can how
   "owner": {
     "username": "github-username",
     "email": "any@email"
-  },
+  }
 }
 ```
 
@@ -32,7 +32,7 @@ If you don't wish to share your email address here, please share your twitter or
     "username": "github-username",
     "email": "",
     "twitter": "twitter-handle"
-  },
+  }
 }
 ```
 
@@ -46,14 +46,14 @@ This is a link to your website repository or your github account. This is purely
 
 
 ### record (required)
-This is where you specify how you want to link to your server/webpage.
+This is where you specify the DNS records you wish to use.
 
-Currently, only `CNAME`, `A`, `URL` record types are supported.
+The supported record types are: `CNAME`, `A`, `URL`, `MX` and `TXT`
 
 Here's a few different use cases for the given record types -
 
 * **CNAME**
-CNAME must be a host name (Eg - `something.tld`)
+CNAME must be a host name (Eg - `something.tld`). CNAME cannot be used in conjunction with any other record types.
 ```json
 {
   "record": {
@@ -86,3 +86,25 @@ A record must be a list of ips
 }
 ```
 
+* **MX**
+MX must be a list of host names
+```json
+{
+  "record": {
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ]
+  }
+}
+```
+
+* **TXT**
+TXT can be any string value
+```json
+{
+  "record": {
+    "TXT": "hello world"
+  }
+}
+```

--- a/domains/akshay-n.json
+++ b/domains/akshay-n.json
@@ -6,6 +6,10 @@
     "email": "phenax5@gmail.com"
   },
   "record": {
-    "CNAME": "phenax.github.io"
+    "TXT": "v=spf1 include:spf.improvmx.com ~all",
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ]
   }
 }

--- a/domains/akshay-n.json
+++ b/domains/akshay-n.json
@@ -1,5 +1,5 @@
 {
-  "description": "Akshay's portfolio website and blog",
+  "description": "Akshay's email alias",
   "repo": "https://github.com/phenax/phenax.github.io",
   "owner": {
     "username": "phenax",

--- a/domains/akshay.json
+++ b/domains/akshay.json
@@ -6,6 +6,10 @@
     "email": "phenax5@gmail.com"
   },
   "record": {
-    "CNAME": "phenax.github.io"
+    "CNAME": "phenax.github.io",
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ]
   }
 }

--- a/domains/dipan.json
+++ b/domains/dipan.json
@@ -6,6 +6,6 @@
     "email": "dipanroy@mindwebs.org"
   },
   "record": {
-    "A": "115.187.62.14"
+    "A": ["115.187.62.14"]
   }
 }

--- a/scripts/register-domains.js
+++ b/scripts/register-domains.js
@@ -4,7 +4,7 @@ const { domainService: dc } = require('../utils/domain-service');
 const { getDomains: gd } = require('../utils/get-domain');
 
 // Allow TXT records while publishing (for pcl validation)
-const getRecords = R.compose(R.toPairs, R.pick(VALID_RECORD_TYPES.concat(['TXT'])));
+const getRecords = R.compose(R.toPairs, R.pick(VALID_RECORD_TYPES));
 
 const toHostList = R.chain(data => {
   const rs = getRecords(data.record);

--- a/scripts/register-domains.js
+++ b/scripts/register-domains.js
@@ -10,18 +10,19 @@ const toHostList = R.chain(data => {
   const rs = getRecords(data.record);
 
   return R.chain(([recordType, urls]) =>
-    (Array.isArray(urls) ? urls : [urls]).map(url => ({
+    (Array.isArray(urls) ? urls : [urls]).map((url, index) => ({
       name: data.name,
       type: recordType,
       address: (recordType === 'CNAME' ? `${url}`.toLowerCase() : `${url}`).replace(/\/$/g, ''),
       ttl: TTL,
+      ...(recordType === 'MX' ? { priority: index + 20 } : {})
     }))
-  , rs);
+    , rs);
 });
 
-const registerDomains = async ({ domainService, getDomains, log = () => {} }) => {
+const registerDomains = async ({ domainService, getDomains, log = () => { } }) => {
   const domains = await getDomains().then(toHostList);
-  
+
   if (domains.length === 0)
     return Promise.reject(new Error('Nothing to register'));
 

--- a/tests/domain-service.test.js
+++ b/tests/domain-service.test.js
@@ -1,6 +1,6 @@
 const R = require('ramda');
 const { getDomainService, diffRecords } = require('../utils/domain-service');
-const {DOMAIN_DOMAIN} = require('../utils/constants');
+const { DOMAIN_DOMAIN } = require('../utils/constants');
 
 const getCpanel = ({ zone, addZone, removeZone, redir, addRedir, removeRedir } = {}) => ({
   zone: {
@@ -115,16 +115,18 @@ describe('Domain service', () => {
   const addRedir = jest.fn(async () => ({}));
   const removeRedir = jest.fn(async () => ({}));
 
-  const mockDS = ({ zones, redirections }) => getDomainService({ cpanel: getCpanel({
-    zone: async () => zones,
-    redir: async () => redirections,
-    addZone,
-    addRedir,
-    removeZone,
-    removeRedir,
-  }) });
+  const mockDS = ({ zones, redirections }) => getDomainService({
+    cpanel: getCpanel({
+      zone: async () => zones,
+      redir: async () => redirections,
+      addZone,
+      addRedir,
+      removeZone,
+      removeRedir,
+    })
+  });
 
-  const getRecordCalls = recfn => recfn.mock.calls.map(R.head).map(R.pick(['name', 'type', 'address', 'redirect', 'domain', 'line']));
+  const getRecordCalls = recfn => recfn.mock.calls.map(R.head).map(R.pick(['name', 'type', 'address', 'redirect', 'domain', 'line', 'priority']));
 
   beforeEach(() => {
     addZone.mockClear();
@@ -187,11 +189,13 @@ describe('Domain service', () => {
         { name: 'a', type: 'CNAME', address: 'boo' },
         { name: 'b', type: 'CNAME', address: 'goo' },
         { name: 'c', type: 'A', address: '12.131321.213' },
+        { name: 'c', type: 'MX', address: 'foobar.com', priority: 2 },
       ]);
 
-      expect(addZone).toBeCalledTimes(1);
+      expect(addZone).toBeCalledTimes(2);
       expect(getRecordCalls(addZone)).toEqual([
         { name: 'c', type: 'A', address: '12.131321.213' },
+        { name: 'c', type: 'MX', address: 'foobar.com', priority: 2 },
       ]);
       expect(removeZone).toBeCalledTimes(0);
     });

--- a/tests/domain-service.test.js
+++ b/tests/domain-service.test.js
@@ -2,7 +2,7 @@ const R = require('ramda');
 const { getDomainService, diffRecords } = require('../utils/domain-service');
 const { DOMAIN_DOMAIN } = require('../utils/constants');
 
-const getCpanel = ({ zone, addZone, removeZone, redir, addRedir, removeRedir } = {}) => ({
+const getCpanel = ({ zone, addZone, removeZone, redir, addRedir, removeRedir, addEmail, removeEmail } = {}) => ({
   zone: {
     fetch: (_) => zone(),
     add: (rec) => addZone(rec),
@@ -12,6 +12,10 @@ const getCpanel = ({ zone, addZone, removeZone, redir, addRedir, removeRedir } =
     fetch: (_) => redir(),
     add: (rec) => addRedir(rec),
     remove: (rec) => removeRedir(rec),
+  },
+  email: {
+    add: (rec) => addEmail(rec),
+    remove: (rec) => removeEmail(rec),
   },
 });
 
@@ -114,25 +118,33 @@ describe('Domain service', () => {
   const removeZone = jest.fn(async () => ({}));
   const addRedir = jest.fn(async () => ({}));
   const removeRedir = jest.fn(async () => ({}));
+  const addEmail = jest.fn(async () => ({}));
+  const removeEmail = jest.fn(async () => ({}));
 
   const mockDS = ({ zones, redirections }) => getDomainService({
     cpanel: getCpanel({
       zone: async () => zones,
       redir: async () => redirections,
       addZone,
+      addEmail,
       addRedir,
       removeZone,
       removeRedir,
+      removeEmail,
     })
   });
 
-  const getRecordCalls = recfn => recfn.mock.calls.map(R.head).map(R.pick(['name', 'type', 'address', 'redirect', 'domain', 'line', 'priority']));
+  const getRecordCalls = recfn => recfn.mock.calls
+    .map(R.head)
+    .map(R.pick(['name', 'type', 'address', 'redirect', 'domain', 'line', 'priority', 'exchanger']));
 
   beforeEach(() => {
     addZone.mockClear();
     removeZone.mockClear();
     addRedir.mockClear();
     removeRedir.mockClear();
+    addEmail.mockClear();
+    removeEmail.mockClear();
   });
 
   describe('getHosts', () => {
@@ -192,12 +204,18 @@ describe('Domain service', () => {
         { name: 'c', type: 'MX', address: 'foobar.com', priority: 2 },
       ]);
 
-      expect(addZone).toBeCalledTimes(2);
+      expect(addZone).toBeCalledTimes(1);
       expect(getRecordCalls(addZone)).toEqual([
         { name: 'c', type: 'A', address: '12.131321.213' },
-        { name: 'c', type: 'MX', address: 'foobar.com', priority: 2 },
       ]);
+
+      expect(addEmail).toBeCalledTimes(1);
+      expect(getRecordCalls(addEmail)).toEqual([
+        { domain: 'c.is-a.dev', exchanger: 'foobar.com', priority: 2 },
+      ]);
+
       expect(removeZone).toBeCalledTimes(0);
+      expect(removeEmail).toBeCalledTimes(0);
     });
 
     it('should update matching host and set it', async () => {
@@ -256,6 +274,9 @@ describe('Domain service', () => {
         { line: 2, name: 'b', type: 'A', address: '1' },
         { line: 3, name: 'b', type: 'A', address: '2' },
         { line: 4, name: 'c', type: 'CNAME', address: 'hello.com' },
+        { line: 5, name: 'c', type: 'MX', address: 'mx1.hello.com', priority: 20 },
+        { line: 6, name: 'c', type: 'MX', address: 'mx2.hello.com', priority: 21 },
+        { line: 7, name: 'b', type: 'MX', address: 'foo.bar', priority: 20 },
       ];
       const redirections = [
         { domain: `b.${DOMAIN_DOMAIN}`, destination: 'https://foobar.com' },
@@ -275,6 +296,8 @@ describe('Domain service', () => {
         { name: 'd', type: 'CNAME', address: 'helo.com' },
         { name: 'd', type: 'URL', address: 'https://hhh.com' },
         { name: 'x', type: 'URL', address: 'https://example69.com' },
+        { name: 'c', type: 'MX', address: 'mx2.hello.com', priority: 21 },
+        { name: 'a', type: 'MX', address: 'example.com', priority: 20 },
       ]);
 
       expect(addZone).toBeCalledTimes(3);
@@ -287,6 +310,17 @@ describe('Domain service', () => {
       expect(getRecordCalls(removeZone)).toEqual([
         { line: 1 },
       ]);
+
+      expect(addEmail).toBeCalledTimes(1);
+      expect(getRecordCalls(addEmail)).toEqual([
+        { domain: 'a.is-a.dev', exchanger: 'example.com', priority: 20 },
+      ]);
+      expect(removeEmail).toBeCalledTimes(2);
+      expect(getRecordCalls(removeEmail)).toEqual([
+        { domain: 'c.is-a.dev', exchanger: 'mx1.hello.com', priority: 20 },
+        { domain: 'b.is-a.dev', exchanger: 'foo.bar', priority: 20 },
+      ]);
+
       expect(addRedir).toBeCalledTimes(3);
       expect(getRecordCalls(addRedir)).toEqual([
         { domain: `b.${DOMAIN_DOMAIN}`, type: 'permanent', redirect: 'https://wowow.com' },

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -14,6 +14,10 @@ const getCpanel = ({ zone, addZone, removeZone, redir, addRedir, removeRedir } =
     add: (rec) => addRedir(rec),
     remove: (rec) => removeRedir(rec),
   },
+  email: {
+    add: (rec) => addEmail(rec),
+    remove: (rec) => removeEmail(rec),
+  },
 });
 
 describe('toHostList', () => {
@@ -43,15 +47,19 @@ describe('registerDomains', () => {
   const removeZone = jest.fn(async () => ({}));
   const addRedir = jest.fn(async () => ({}));
   const removeRedir = jest.fn(async () => ({}));
+  const addEmail = jest.fn(async () => ({}));
+  const removeEmail = jest.fn(async () => ({}));
 
   const mockDS = ({ zones, redirections }) => getDomainService({
     cpanel: getCpanel({
       zone: async () => zones,
       redir: async () => redirections,
       addZone,
+      addEmail,
       addRedir,
       removeZone,
       removeRedir,
+      removeEmail,
     })
   });
 
@@ -60,6 +68,8 @@ describe('registerDomains', () => {
     removeZone.mockClear();
     addRedir.mockClear();
     removeRedir.mockClear();
+    addEmail.mockClear();
+    removeEmail.mockClear();
   });
 
   it('should register the new set of hosts generated from domains list', async () => {

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -22,6 +22,7 @@ describe('toHostList', () => {
       { name: 'akshay', record: { CNAME: 'phenax.github.io' } },
       { name: 'foobar', record: { CNAME: 'v.io' } },
       { name: 'xx', record: { A: ['1.2.3.4', '5.6.3.2', '1.2.31.1'] } },
+      { name: 'xx', record: { CNAME: 'foobar.com', MX: ['as.com', 'f.com'] } },
     ]);
 
     expect(res).toEqual([
@@ -30,6 +31,9 @@ describe('toHostList', () => {
       { name: 'xx', type: 'A', address: '1.2.3.4', ttl: TTL },
       { name: 'xx', type: 'A', address: '5.6.3.2', ttl: TTL },
       { name: 'xx', type: 'A', address: '1.2.31.1', ttl: TTL },
+      { name: 'xx', type: 'CNAME', address: 'foobar.com', ttl: TTL },
+      { name: 'xx', type: 'MX', address: 'as.com', priority: 20, ttl: TTL },
+      { name: 'xx', type: 'MX', address: 'f.com', priority: 21, ttl: TTL },
     ]);
   });
 });
@@ -40,14 +44,16 @@ describe('registerDomains', () => {
   const addRedir = jest.fn(async () => ({}));
   const removeRedir = jest.fn(async () => ({}));
 
-  const mockDS = ({ zones, redirections }) => getDomainService({ cpanel: getCpanel({
-    zone: async () => zones,
-    redir: async () => redirections,
-    addZone,
-    addRedir,
-    removeZone,
-    removeRedir,
-  }) });
+  const mockDS = ({ zones, redirections }) => getDomainService({
+    cpanel: getCpanel({
+      zone: async () => zones,
+      redir: async () => redirections,
+      addZone,
+      addRedir,
+      removeZone,
+      removeRedir,
+    })
+  });
 
   beforeEach(() => {
     addZone.mockClear();

--- a/tests/validations.test.js
+++ b/tests/validations.test.js
@@ -53,7 +53,9 @@ describe('validateDomainData', () => {
     { ...defaultDomain, record: { CNAME: 'https://foobar.com' } },
     { ...defaultDomain, record: { URL: 'foobar.com' } },
     { ...defaultDomain, record: { CNAME: 'foobar.com', A: ['11.22.22.33'] } },
+    { ...defaultDomain, record: { CNAME: 'foobar.com', MX: ['ALT4.ASPMX.L.GOOGLE.COM'] } },
     ...INVALID_NAMES.map(name => ({ ...defaultDomain, name })).slice(0, 1),
+    { ...defaultDomain, record: { TXT: ['foobar wow nice!!!'] } },
   ];
 
   const validCases = [
@@ -69,7 +71,9 @@ describe('validateDomainData', () => {
     { ...defaultDomain, record: { CNAME: 'aa.sd' } },
     { ...defaultDomain, record: { URL: 'https://foobar.com' } },
     { ...defaultDomain, record: { URL: 'http://foobar.com/foobar/' } },
-    { ...defaultDomain, record: { CNAME: 'foobar.com', MX: ['ALT4.ASPMX.L.GOOGLE.COM'] } },
+    { ...defaultDomain, record: { MX: ['ALT4.ASPMX.L.GOOGLE.COM'] } },
+    { ...defaultDomain, record: { TXT: 'foobar wow nice!!!' } },
+    { ...defaultDomain, record: { A: ['1.1.1.1'], MX: ['mx1.example.com'] } },
   ];
 
   it('should return false for invalid data', () => {

--- a/tests/validations.test.js
+++ b/tests/validations.test.js
@@ -1,4 +1,5 @@
 const { validateDomainData, isValidDomain } = require('../utils/validations');
+const INVALID_NAMES = require('../utils/invalid-domains.json');
 
 const defaultDomain = {
   name: 'aaa',
@@ -52,6 +53,7 @@ describe('validateDomainData', () => {
     { ...defaultDomain, record: { CNAME: 'https://foobar.com' } },
     { ...defaultDomain, record: { URL: 'foobar.com' } },
     { ...defaultDomain, record: { CNAME: 'foobar.com', A: ['11.22.22.33'] } },
+    ...INVALID_NAMES.map(name => ({ ...defaultDomain, name })).slice(0, 1),
   ];
 
   const validCases = [

--- a/tests/validations.test.js
+++ b/tests/validations.test.js
@@ -1,4 +1,4 @@
-const { validateDomainData } = require('../utils/validations');
+const { validateDomainData, isValidDomain } = require('../utils/validations');
 
 const defaultDomain = {
   name: 'aaa',
@@ -12,6 +12,25 @@ const defaultDomain = {
 };
 
 const getstroflen = len => Array(len).fill('a').join('');
+
+describe('isValidMX', () => {
+  it('should be valid mx record', () => {
+    const cases = [
+      { mx: 'foobar.com', result: true },
+      { mx: 'as.as', result: true },
+      { mx: 'ASPMX.L.GOOGLE.COM', result: true },
+      { mx: 'ALT4.ASPMX.L.GOOGLE.COM', result: true },
+      { mx: 'hello', result: false },
+      { mx: 'helalsds-asd5sjdsd.com', result: true },
+      { mx: 'helalsds?asd5sjdsd.com', result: false },
+      { mx: 'helalsds_asd5sjdsd.com', result: false },
+    ];
+
+    cases.forEach(({ mx, result }) => {
+      expect(isValidDomain(mx)).toBe(result);
+    });
+  });
+});
 
 describe('validateDomainData', () => {
   const invalidCases = [
@@ -32,6 +51,7 @@ describe('validateDomainData', () => {
     { ...defaultDomain, record: { CNAME: 'http://foobar.com' } },
     { ...defaultDomain, record: { CNAME: 'https://foobar.com' } },
     { ...defaultDomain, record: { URL: 'foobar.com' } },
+    { ...defaultDomain, record: { CNAME: 'foobar.com', A: ['11.22.22.33'] } },
   ];
 
   const validCases = [
@@ -44,9 +64,10 @@ describe('validateDomainData', () => {
       ...defaultDomain,
       description: getstroflen(99),
     },
-    { ...defaultDomain, record: { CNAME: 'aa.sd', URL: '121,3213' } },
+    { ...defaultDomain, record: { CNAME: 'aa.sd' } },
     { ...defaultDomain, record: { URL: 'https://foobar.com' } },
     { ...defaultDomain, record: { URL: 'http://foobar.com/foobar/' } },
+    { ...defaultDomain, record: { CNAME: 'foobar.com', MX: ['ALT4.ASPMX.L.GOOGLE.COM'] } },
   ];
 
   it('should return false for invalid data', () => {
@@ -60,7 +81,7 @@ describe('validateDomainData', () => {
   it('should return true if the name is valid', () => {
     validCases.forEach(data => {
       const { valid, errors } = validateDomainData(data);
-      if (!valid) console.log(errors);
+      if (!valid) console.log(JSON.stringify(errors, null, 2));
       expect(valid).toBe(true);
       expect(errors).toEqual([]);
     });

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -21,12 +21,12 @@ const DOMAINS_PATH = require('path').resolve('domains');
 module.exports = {
   ENV,
   IS_TEST,
-  VALID_RECORD_TYPES: ['CNAME', 'A', 'URL'],
+  VALID_RECORD_TYPES: ['CNAME', 'A', 'URL', 'MX'],
   DOMAIN_DOMAIN: DOMAIN_DOMAIN || 'booboo.xyz',
   DOMAIN_USER: IS_TEST ? 'testuser' : DOMAIN_USER,
   DOMAIN_API_KEY: IS_TEST ? 'testkey' : DOMAIN_API_KEY,
   DOMAIN_API_HOST: IS_TEST ? 'example.com' : DOMAIN_API_HOST,
   DOMAIN_API_PORT: IS_TEST ? 6969 : DOMAIN_API_PORT,
   DOMAINS_PATH,
-  TTL: 5*60*60,
+  TTL: 5 * 60 * 60,
 };

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -21,7 +21,7 @@ const DOMAINS_PATH = require('path').resolve('domains');
 module.exports = {
   ENV,
   IS_TEST,
-  VALID_RECORD_TYPES: ['CNAME', 'A', 'URL', 'MX'],
+  VALID_RECORD_TYPES: ['CNAME', 'A', 'URL', 'MX', 'TXT'],
   DOMAIN_DOMAIN: DOMAIN_DOMAIN || 'booboo.xyz',
   DOMAIN_USER: IS_TEST ? 'testuser' : DOMAIN_USER,
   DOMAIN_API_KEY: IS_TEST ? 'testkey' : DOMAIN_API_KEY,

--- a/utils/domain-service.js
+++ b/utils/domain-service.js
@@ -12,11 +12,12 @@ const recordToRedirection = ({ name, address }) => ({
   redirect_wildcard: 1,
   redirect_www: 1,
 });
-const recordToZone = ({ name, type, address, id }) => ({
+const recordToZone = ({ name, type, address, id, priority }) => ({
   line: id,
   name,
   type,
   address,
+  ...(type === 'MX' ? { priority } : {}),
   ...(type === 'CNAME' ? { cname: address } : {}),
   ...(type === 'TXT' ? { txtdata: address } : {}),
 });

--- a/utils/invalid-domains.json
+++ b/utils/invalid-domains.json
@@ -1,0 +1,12 @@
+[
+  "help",
+  "support",
+  "no-reply",
+  "noreply",
+  "notifications",
+  "notification",
+  "ww1",
+  "ww2",
+  "ww3",
+  "ww4"
+]

--- a/utils/lib/cpanel.js
+++ b/utils/lib/cpanel.js
@@ -4,7 +4,6 @@ const qs = require('qs');
 const { DOMAIN_API_HOST, DOMAIN_API_PORT, DOMAIN_USER, DOMAIN_API_KEY, DOMAIN_DOMAIN } = require('../constants');
 
 const CpanelClient = (options) => {
-  // TODO: Make defaultQuery functional
   const api = ({ basePath = '', action = '' }) => (module, func, defaultQuery = {}) => (q = {}) => {
     const query = {
       ...defaultQuery,

--- a/utils/lib/cpanel.js
+++ b/utils/lib/cpanel.js
@@ -35,7 +35,7 @@ const CpanelClient = (options) => {
   return {
     zone: {
       // { customonly, domain }
-      //     -> { cpanelresult: { data[{ class, ttl, name, line, Line, cname, type, record }] } }
+      //     -> [{ class, ttl, name, line, Line, cname, type, record }]
       fetch: R.compose(
         p => p.then(R.pathOr([], ['cpanelresult', 'data'])),
         api2('ZoneEdit', 'fetchzone_records', { customonly: 1, domain: options.domain })
@@ -44,13 +44,14 @@ const CpanelClient = (options) => {
       // { name, type(A|CNAME), cname, address, ttl }
       //     -> {}
       add: api2('ZoneEdit', 'add_zone_record', { domain: options.domain }),
+
       // { line }
       //     -> {}
       remove: api2('ZoneEdit', 'remove_zone_record', { domain: options.domain }),
     },
     redirection: {
       // {}
-      //     -> { domain, destination }
+      //     -> [{ domain, destination }]
       fetch: R.compose(
         p => p.then(R.pathOr([], ['data'])),
         uapi('Mime', 'list_redirects'),
@@ -59,12 +60,22 @@ const CpanelClient = (options) => {
       // { domain, redirect, type(permanent|tmp), redirect_wildcard(0|1), redirect(0|1|2) }
       //     -> {}
       add: uapi('Mime', 'add_redirect'),
+
       // { domain }
       //     -> {}
       remove: uapi('Mime', 'delete_redirect'),
     },
     file: {
       write: uapi('Fileman', 'save_file_content', { from_charset: 'UTF-8', to_charset: 'UTF-8', fallback: 1 }),
+    },
+    email: {
+      // { domain, exchanger, priority }
+      //     -> {}
+      add: uapi('Email', 'add_mx', { alwaysaccept: 'auto' }),
+
+      // { domain, exchanger, priority }
+      //     -> {}
+      remove: uapi('Email', 'delete_mx', { alwaysaccept: 'auto' }),
     },
   };
 };

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -1,6 +1,7 @@
 const R = require('ramda');
 const { VALID_RECORD_TYPES } = require('./constants');
 const { or, and, validate, between, testRegex, withLengthEq, withLengthGte } = require('./helpers');
+const INVALID_NAMES = require('./invalid-domains.json');
 
 const isValidURL = testRegex(/^https?:\/\//ig);
 
@@ -41,6 +42,7 @@ const validateDomainData = validate({
       and([
         R.compose(between(2, 100), R.length),
         testRegex(/^[a-z0-9-]+$/g),
+        R.complement(R.includes(R.__, INVALID_NAMES)),
       ])
     ]),
   },

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -4,16 +4,33 @@ const { or, and, validate, between, testRegex, withLengthEq, withLengthGte } = r
 
 const isValidURL = testRegex(/^https?:\/\//ig);
 
+const isValidDomain = testRegex(/^(([a-z0-9\-]+)\.)+[a-z]+$/ig)
+
+// TODO: Add priority to records
+
+const allowMXRecord = R.compose(
+  R.ifElse(R.includes('MX'), withLengthEq(2), withLengthEq(1)),
+  R.keys,
+);
+
 const validateCnameRecord = key => and([
   R.propSatisfies(R.is(String), key),
-  R.compose(withLengthEq(1), R.reject(R.equals('URL')), R.keys),
-  R.propSatisfies(withLengthGte(3), key),
-  R.propSatisfies(R.complement(isValidURL), key),
+  allowMXRecord,
+  R.propSatisfies(withLengthGte(4), key),
+  R.propSatisfies(isValidDomain, key),
+  //R.propSatisfies(R.complement(isValidURL), key),
 ]);
 
 const validateARecord = key => and([
-  R.compose(withLengthEq(1), R.keys),
+  allowMXRecord,
   R.propSatisfies(withLengthGte(1), key),
+  R.propIs(Array, key),
+]);
+
+const validateMXRecord = key => and([
+  R.propSatisfies(withLengthGte(1), key),
+  R.propSatisfies(R.all(isValidDomain), key),
+  R.propIs(Array, key),
 ]);
 
 const validateDomainData = validate({
@@ -35,7 +52,7 @@ const validateDomainData = validate({
       R.is(Object),
       R.complement(R.isEmpty),
       R.where({
-        username: and([ R.is(String), withLengthGte(1) ]),
+        username: and([R.is(String), withLengthGte(1)]),
         email: R.is(String),
       }),
     ]),
@@ -46,13 +63,14 @@ const validateDomainData = validate({
       R.is(Object),
       R.compose(R.isEmpty, R.difference(R.__, VALID_RECORD_TYPES), R.keys),
       R.cond([
-        [R.has('CNAME'),  validateCnameRecord('CNAME')],
-        [R.has('A'),      validateARecord('A')],
-        [R.has('URL'),    R.propSatisfies(isValidURL, 'URL')],
+        [R.has('CNAME'), validateCnameRecord('CNAME')],
+        [R.has('A'), validateARecord('A')],
+        [R.has('URL'), R.propSatisfies(isValidURL, 'URL')],
+        [R.has('MX'), validateMXRecord('MX')],
         [R.T, R.T],
       ]),
     ]),
   },
 });
 
-module.exports = { validateDomainData };
+module.exports = { validateDomainData, isValidDomain };


### PR DESCRIPTION
Fixes #844

- [X] Add and test MX
- [X] Add and test TXT
- [X] Add proper validation for CNAME and restrict usage with MX records
- [X] Add restricted list of domain names
- [X] Update docs
- [x] Update maintainer docs
