### PR TITLE
Add netlify and vercel warning.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,5 @@ You can read the [domains.json file api reference](./domains-json.md) for more i
 * [For hashnode blogs](./hosted-at/hashnode.md)
 * [For other services](./hosted-at/others.md)
 
+### Vercel & Netlify Note
+You will encounter an SSL certificate issue when using Vercel and Netlify. Neither service will work with our domains. It is recommend to use [Github Pages](https://github.com/is-a-dev/register/blob/add-hosting-warning/docs/hosted-at/github-pages.md) or [Railway](https://railway.app/) instead.


### PR DESCRIPTION
This will add a warning when using Netlify or Vercel as your hosting provider since neither service works with our domains.


also i did the commit message wrong lol, it's supposed to say ``add vercel, netlify warning``