### PR TITLE
daniel-shuy.json: Use A record instead of CNAME

### DIFF
--- a/domains/daniel-shuy.json
+++ b/domains/daniel-shuy.json
@@ -4,6 +4,8 @@
     "email": "daniel_shuy@hotmail.com"
   },
   "record": {
-    "CNAME": "hashnode.network"
+    "A": [
+      "76.76.21.21"
+    ]
   }
 }


### PR DESCRIPTION
Hashnode uses Vercel, which prevents `CNAME` from being used (see #249, #489)

If this works, [docs/hosted-at/hashnode.md](https://github.com/is-a-dev/register/blob/main/docs/hosted-at/hashnode.md) should be updated as well