### PR TITLE
add explict reminder

### DIFF
--- a/docs/hosted-at/github-pages.md
+++ b/docs/hosted-at/github-pages.md
@@ -17,7 +17,7 @@ Create a json file inside the `domains` directory (`domains/<subdomain>.json`) w
     "twitter": "your-twitter-username"
   },
   "record": {
-    "CNAME": "github-username.github.io"
+    "CNAME": "<replace-this-with-your-github-username>.github.io"
   }
 }
 ```


### PR DESCRIPTION
yk some weird gang thought you need to have `github-username.github.io` as their cname, such as #2093 