### PR TITLE
Added Email forwarding to Discord

### DIFF
--- a/domains/mail.om.json
+++ b/domains/mail.om.json
@@ -1,0 +1,19 @@
+{
+  "repo": "https://github.com/omxpro/portfolio-cf",
+  "description": "My email forwarder to discord",
+  "owner": {
+    "username": "omxpro",
+    "email": "omsenjalia+email@gmail.com",
+    "discord": "OmxproYT#1165"
+  },
+  "record": {
+    "A": [
+      "198.27.83.178"
+    ],
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": "v=spf1 include:spf.improvmx.com ~all"
+  }
+}


### PR DESCRIPTION
To make our job easier, please spend time to review your application before submitting. 

<!-- To check a checkbox, replace [] with [x] -->
#### Add a x between [] if you meet that requirement example `[x]`
- [x] You're not using Vercel or Netlify.
- [x] You have completed your website, there's no type of placeholder at the website. **This requirement can be raised if the domain you're registering is for emails**
  - Link to website: 
- [x] The website is reachable.
- [x] The CNAME record doesn't contain any slash.
- [x] There's enough information at the `owner` field.
   - You should have your email presented. If you don't want to share email, you can leave email an empty string (`""`) and add any other social such as Discord/Twitter/etc.
 
 #### Feel free to join our discord server for more updates or any help related to the service :D - https://discord.gg/PZCGHz4RhQ
<!--  Feel free to join the discord server for any help to talk to other developers :) - https://discord.gg/PZCGHz4RhQ -->
