### PR TITLE
Change record type of mburguete.is-a.dev

### DIFF
--- a/domains/mburguete.json
+++ b/domains/mburguete.json
@@ -6,6 +6,6 @@
     "email": "marianoburguete@gmail.com"
   },
   "record": {
-    "URL": "https://nai98x.github.io"
+    "CNAME": "nai98x.github.io"
   }
 }


### PR DESCRIPTION
- Changed the txt record to a CNAME one.

To make our job easier, please spend time to review your application before submitting. 

<!-- To check a checkbox, replace [] with [x] -->
#### Add a x between [] if you meet that requirement example `[x]`
- [x] You're not using Vercel or Netlify.
- [x] You have completed your website, there's no type of placeholder at the website. **This requirement can be raised if the domain you're registering is for emails**
  - Link to website: 
- [x] The website is reachable.
- [x] The CNAME record doesn't contain any slash.
- [x] There's enough information at the `owner` field.
   - You should have your email presented. If you don't want to share email, you can leave email an empty string (`""`) and add any other social such as Discord/Twitter/etc.
 
 #### Feel free to join our discord server for more updates or any help related to the service :D - https://discord.gg/PZCGHz4RhQ
<!--  Feel free to join the discord server for any help to talk to other developers :) - https://discord.gg/PZCGHz4RhQ -->
