### PR TITLE
Update jeremy.json

### DIFF
--- a/domains/jeremy.json
+++ b/domains/jeremy.json
@@ -6,7 +6,7 @@
       },
 
       "record": {
-        "URL": "https://dev.jeremys.social"
+        "URL": "http://dev.jeremys.social"
       }
     }
   


### PR DESCRIPTION
redirects can't use ssl, which is why this has to be a http domain to work

To make our job easier, please spend time to review your application before submitting. 

<!-- To check a checkbox, replace [] with [x] -->
#### Add a x between [] if you meet that requirement example `[x]`
- [x ] You're not using Vercel or Netlify.
- [x ] You have completed your website, there's no type of placeholder at the website. **This requirement can be raised if the domain you're registering is for emails**
  - Link to website: http://dev.jeremys.social
- [x ] The website is reachable.
- [x ] The CNAME record doesn't contain any slash.
- [ x] There's enough information at the `owner` field.
   - You should have your email presented. If you don't want to share email, you can leave email an empty string (`""`) and add any other social such as Discord/Twitter/etc.
 
 #### Feel free to join our discord server for more updates or any help related to the service :D - https://discord.gg/PZCGHz4RhQ
<!--  Feel free to join the discord server for any help to talk to other developers :) - https://discord.gg/PZCGHz4RhQ -->
