### PR TITLE
feat(validation): adds exception for github verification records

### DIFF
--- a/tests/validations.test.js
+++ b/tests/validations.test.js
@@ -58,6 +58,7 @@ describe('validateDomainData', () => {
     { ...defaultDomain, name: 'a.b' },
     { ...defaultDomain, name: 'ww2.baa' },
     { ...defaultDomain, name: 'help.baa' },
+    { ...defaultDomain, name: '_github-pages-challenge-is-a-dev' },
   ];
 
   const validCases = [
@@ -78,6 +79,9 @@ describe('validateDomainData', () => {
     { ...defaultDomain, record: { A: ['1.1.1.1'], MX: ['mx1.example.com'] } },
     { ...defaultDomain, name: 'gogo.foo.bar' },
     { ...defaultDomain, name: 'ww9.baa' },
+    { ...defaultDomain, name: '_github-pages-challenge-phenax.akshay' },
+    { ...defaultDomain, name: '_github-pages-challenge-hello01-ga' },
+    { ...defaultDomain, name: '_github-pages-challenge-hello01_ga' },
   ];
 
   it('should return false for invalid data', () => {

--- a/utils/invalid-domains.json
+++ b/utils/invalid-domains.json
@@ -11,5 +11,6 @@
   "ww1",
   "ww2",
   "ww3",
-  "ww4"
+  "ww4",
+  "_github-pages-challenge-is-a-dev"
 ]

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -33,10 +33,16 @@ const validateDomainData = validate({
       and([
         R.is(String),
         R.compose(
-          R.all(and([
-            R.compose(between(2, 100), R.length),
-            testRegex(/^[a-z0-9-]+$/g),
-            R.complement(R.includes(R.__, INVALID_NAMES)),
+          R.all(or([
+            and([
+              testRegex(/^_github-pages-challenge-[a-z0-9-_]+$/i), // Exception for github verification records
+              R.complement(R.includes(R.__, INVALID_NAMES)),
+            ]),
+            and([
+              R.compose(between(2, 100), R.length),
+              testRegex(/^[a-z0-9-]+$/g),
+              R.complement(R.includes(R.__, INVALID_NAMES)),
+            ])
           ])),
           R.split('.'),
         ),

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -25,6 +25,8 @@ const validateMXRecord = type => and([
   R.propSatisfies(R.all(isValidDomain), type),
 ]);
 
+const checkRestrictedNames = R.complement(R.includes(R.__, INVALID_NAMES))
+
 const validateDomainData = validate({
   name: {
     reason: 'The name of the file is invalid. It must be lowercased, alphanumeric and each component must be more than 2 characters long',
@@ -36,12 +38,12 @@ const validateDomainData = validate({
           R.all(or([
             and([
               testRegex(/^_github-pages-challenge-[a-z0-9-_]+$/i), // Exception for github verification records
-              R.complement(R.includes(R.__, INVALID_NAMES)),
+              checkRestrictedNames,
             ]),
             and([
               R.compose(between(2, 100), R.length),
               testRegex(/^[a-z0-9-]+$/g),
-              R.complement(R.includes(R.__, INVALID_NAMES)),
+              checkRestrictedNames,
             ])
           ])),
           R.split('.'),


### PR DESCRIPTION
Added a hard-coded exception github verification urls for now, to remove the current blocker. If github comes up with an alternative way to verify pages, we can remove this.

Later on, we can also work on a workflow that creates a pr to remove all stale domain verification record files monthly.

Fixes #3385 