### PR TITLE
Update aqua.json

### DIFF
--- a/domains/aqua.json
+++ b/domains/aqua.json
@@ -6,7 +6,7 @@
       },
 
       "record": {
-        "CNAME": "aquaquokka.github.io"
+        "URL": "https://aquaquokka.github.io/"
       }
     }
   


### PR DESCRIPTION
Converted CNAME to URL due to bad redirect to
https://aqua.is-a.dev/AquaQuokkaAquaQuokkaAquaQ...

For some reason it kept redirecting

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Discord or Twitter) so we can contact you. -->


## Website Link/Preview
<!-- Please provide a link or preview of your website below. -->
