### PR TITLE
Register enderxcodeingdev.is-a.dev

### DIFF
--- a/domains/enderxcodeingdev.json
+++ b/domains/enderxcodeingdev.json
@@ -1,0 +1,11 @@
+
+{
+  "owner": {
+    "username": "664848",
+    "email": "theoverseer@zohomail.com"
+  },
+  "record": {
+    "URL": "1"
+  }
+}
+  


### PR DESCRIPTION
Added `enderxcodeingdev` via the registration website.