### PR TITLE
Redirect tca.is-a.dev to toasted.is-a.dev

### DIFF
--- a/domains/tca.json
+++ b/domains/tca.json
@@ -1,12 +1,11 @@
 {
   "description": "TCA's official portfolio, if you can call it that.",
-  "repo": "https://github.com/NotTCA/devsite",
+  "repo": "https://github.com/ToastifyDev/devsite",
   "owner": {
-    "username": "NotTCA",
-    "email": "me@nottca.tk",
-    "twitter": "https://twitter.com/imTCA_"
+    "username": "ToastifyDev",
+    "email": "hey@toastify.tk"
   },
   "record": {
-    "CNAME": "nottca.github.io"
+    "URL": "https://toasted.is-a.dev"
   }
 }


### PR DESCRIPTION
## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [X] The file is in the `domains` folder and is in the JSON format.
- [X] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [X ] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [X ] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [ ] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [X] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Discord or Twitter) so we can contact you. -->


## Website Link/Preview
<!-- Please provide a link or preview of your website below. -->
https://toasted.is-a.dev

## Background
My name used to be TCA, but I've recently changed names to ToastedToast or Toastify. This PR will make it so `tca.is-a.dev` will redirect to the new website, `toasted.is-a.dev`.
