### PR TITLE
Register graphql.is-a.dev

### DIFF
--- a/domains/graphql.json
+++ b/domains/graphql.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "Amir-Lotfi",
+        "email": "amir79976@gmail.com"
+    },
+
+    "record": {
+        "A": ["5.196.130.53"]
+    }
+}


### PR DESCRIPTION
Added `graphql.is-a.dev` using the [CLI](https://www.npmjs.com/package/@is-a-dev/cli).