### PR TITLE
garlic-os: Point to my server

### DIFF
--- a/domains/garlic-os.json
+++ b/domains/garlic-os.json
@@ -5,7 +5,10 @@
         "username": "garlic-os",
         "email": "sisdfk@gmail.com"
     },
+{
     "record": {
-        "CNAME": "garlic-os.github.io"
+        "A": [
+            "78.47.88.228"
+        ]
     }
 }

--- a/domains/garlic-os.json
+++ b/domains/garlic-os.json
@@ -5,10 +5,7 @@
         "username": "garlic-os",
         "email": "sisdfk@gmail.com"
     },
-{
     "record": {
-        "A": [
-            "78.47.88.228"
-        ]
+        "A": ["78.47.88.228"]
     }
 }


### PR DESCRIPTION
I have a VPS I plan to do some backend stuff with and I'd like to point my is-a.dev domain to it. Right now I'm just having it redirect to my github.io site.

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Discord or Twitter) so we can contact you. -->


## Website Link/Preview
<!-- Please provide a link or preview of your website below. -->
http://78.47.88.228/
