### PR TITLE
Add TXT record for Vercel domain verification

### DIFF
--- a/domains/matt3o0.json
+++ b/domains/matt3o0.json
@@ -4,7 +4,7 @@
         "email": "duvbolone@gmail.com"
     },
     "record": {
-        "TXT": "vc-domain-verify=matt3o0.is-a.dev,e8fb674868d7b5680b6a"
+        "TXT": "vc-domain-verify=matt3o0.is-a.dev,e8fb674868d7b5680b6a",
         "URL": "https://matt3o0.vercel.app"
     }
 }

--- a/domains/matt3o0.json
+++ b/domains/matt3o0.json
@@ -4,6 +4,7 @@
         "email": "duvbolone@gmail.com"
     },
     "record": {
+        "TXT": "vc-domain-verify=matt3o0.is-a.dev,e8fb674868d7b5680b6a"
         "URL": "https://matt3o0.vercel.app"
     }
 }


### PR DESCRIPTION
## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Discord or Twitter) so we can contact you. -->


## Website Link/Preview
<!-- Please provide a link or preview of your website below. -->
https://matt3o0.vercel.app

## Comments
Vercel told me to add a TXT record. I want to do this so that when I go to `https://matt3o0.is-a.dev/` it will still stay in the browser, instead of changing/redirecting to `https://matt3o0.vercel.app/`. I'm unsure if this works, but Vercel told me that this is the way. If it's supposed to be done in another way, please comment here on the PR.