### PR TITLE
Register matbak.is-a.dev

### DIFF
--- a/domains/matbak.json
+++ b/domains/matbak.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "matbakdev",
+        "email": "matbakdev@protonmail.com"
+    },
+
+    "record": {
+        "CNAME": "matbakdev.github.io"
+    }
+}


### PR DESCRIPTION
Added `matbak.is-a.dev` using the [CLI](https://www.npmjs.com/package/@is-a-dev/cli).