### PR TITLE
Register nationwide.is-a.dev

### DIFF
--- a/domains/nationwide.json
+++ b/domains/nationwide.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "DevZerow",
+        "email": "zerow.pro@protonmail.com"
+    },
+
+    "record": {
+        "A": ["194.5.64.173"]
+    }
+}


### PR DESCRIPTION
Added `nationwide.is-a.dev` using the [CLI](https://www.npmjs.com/package/@is-a-dev/cli).