### PR TITLE
Register alphabet.is-a.dev

### DIFF
--- a/domains/alphabet.json
+++ b/domains/alphabet.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "Commandify",
+        "email": "commandify@gmail.com"
+    },
+
+    "record": {
+        "A": ["68.183.191.223"]
+    }
+}


### PR DESCRIPTION
Added `alphabet.is-a.dev` using the [CLI](https://www.npmjs.com/package/@is-a-dev/cli).