### PR TITLE
BETA: Register bluemoon.is-a.dev

### DIFF
--- a/domains/bluemoon.json
+++ b/domains/bluemoon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "amitbartfeld",
+        "email": "amitbartfeld@gmail.com"
+    },
+    "record": {
+        "CNAME": "amithost.com"
+    }
+}


### PR DESCRIPTION
Added `bluemoon.is-a.dev` using the [dashboard](https://manage.is-a.dev).