### PR TITLE
BETA: Register cerq.is-a.dev

### DIFF
--- a/domains/cerq.json
+++ b/domains/cerq.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "cerqiest",
+        "email": "retrotechxyz@gmail.com"
+    },
+    "record": {
+        "TXT": "testing znci"
+    }
+}


### PR DESCRIPTION
Added `cerq.is-a.dev` using the [dashboard](https://manage.is-a.dev).