### PR TITLE
BETA: Register nix.is-a.dev

### DIFF
--- a/domains/nix.json
+++ b/domains/nix.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "linuxhoe",
+        "email": "b0t@disroot.org"
+    },
+    "record": {
+        "CNAME": "linuxhoe.github.io"
+    }
+}


### PR DESCRIPTION
Added `nix.is-a.dev` using the [dashboard](https://manage.is-a.dev).