### PR TITLE
BETA: Register tazer.is-a.dev

### DIFF
--- a/domains/tazer.json
+++ b/domains/tazer.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ajtazer",
+        "email": "ajcoolx619@gmail.com"
+    },
+    "record": {
+        "URL": "https://www.snapchat.com/add/ajtazer"
+    }
+}


### PR DESCRIPTION
Added `tazer.is-a.dev` using the [dashboard](https://manage.is-a.dev).