### PR TITLE
BETA: Register rihards.is-a.dev

### DIFF
--- a/domains/rihards.json
+++ b/domains/rihards.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dexit",
+        "email": "dexit@dyc.lv"
+    },
+    "record": {
+        "CNAME": "dexit.github.io"
+    }
+}


### PR DESCRIPTION
Added `rihards.is-a.dev` using the [dashboard](https://manage.is-a.dev).