### PR TITLE
BETA: Register arenawars.is-a.dev

### DIFF
--- a/domains/arenawars.json
+++ b/domains/arenawars.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "arenawars2023",
+        "email": "arenawars@proton.me"
+    },
+    "record": {
+        "CNAME": "arenawars2023.github.io"
+    }
+}


### PR DESCRIPTION
Added `arenawars.is-a.dev` using the [dashboard](https://manage.is-a.dev).