### PR TITLE
BETA: Register tanx-009.is-a.dev

### DIFF
--- a/domains/tanx-009.json
+++ b/domains/tanx-009.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TanX-009",
+        "email": "tanmaymuley009@gmail.com"
+    },
+    "record": {
+        "URL": "https://tanx-009.gitlab.io/portfolio"
+    }
+}


### PR DESCRIPTION
Added `tanx-009.is-a.dev` using the [dashboard](https://manage.is-a.dev).