### PR TITLE
BETA: Register hexagon.is-a.dev

### DIFF
--- a/domains/hexagon.json
+++ b/domains/hexagon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Hexagon9648",
+        "email": "ahmednabil.programer@gmail.com"
+    },
+    "record": {
+        "TXT": "coming soon"
+    }
+}


### PR DESCRIPTION
Added `hexagon.is-a.dev` using the [dashboard](https://manage.is-a.dev).