### PR TITLE
BETA: Register cheraph.is-a.dev

### DIFF
--- a/domains/cheraph.json
+++ b/domains/cheraph.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "cheraphp",
+        "email": "kesencimert@gmail.com"
+    },
+    "record": {
+        "CNAME": "cheraph"
+    }
+}


### PR DESCRIPTION
Added `cheraph.is-a.dev` using the [dashboard](https://manage.is-a.dev).