### PR TITLE
BETA: Register drive.is-a.dev

### DIFF
--- a/domains/drive.json
+++ b/domains/drive.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "drupalshift",
+        "email": "hamed.asaleh@yahoo.com"
+    },
+    "record": {
+        "A": ["139.162.211.13"]
+    }
+}


### PR DESCRIPTION
Added `drive.is-a.dev` using the [dashboard](https://manage.is-a.dev).