### PR TITLE
BETA: Register clay.is-a.dev

### DIFF
--- a/domains/clay.json
+++ b/domains/clay.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ClaytonTDM",
+        "email": "claytontdm@gmail.com"
+    },
+    "record": {
+        "CNAME": "claytontdm.github.io"
+    }
+}


### PR DESCRIPTION
Added `clay.is-a.dev` using the [dashboard](https://manage.is-a.dev).