### PR TITLE
BETA: Register xash.is-a.dev

### DIFF
--- a/domains/xash.json
+++ b/domains/xash.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "7xa5h",
+        "email": "xash4492@gmail.com"
+    },
+    "record": {
+        "CNAME": "7xa5h.github.io"
+    }
+}


### PR DESCRIPTION
Added `xash.is-a.dev` using the [dashboard](https://manage.is-a.dev).