### PR TITLE
BETA: Register dart.is-a.dev

### DIFF
--- a/domains/dart.json
+++ b/domains/dart.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Daboss0001",
+        "email": "thehawkcompany@gmail.com"
+    },
+    "record": {
+        "CNAME": "www"
+    }
+}


### PR DESCRIPTION
Added `dart.is-a.dev` using the [dashboard](https://manage.is-a.dev).