### PR TITLE
BETA: Register marin.is-a.dev

### DIFF
--- a/domains/marin.json
+++ b/domains/marin.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "bardiotmarin",
+        "email": "bardiot.marin@gmail.com"
+    },
+    "record": {
+        "URL": "www.marin.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `marin.is-a.dev` using the [dashboard](https://manage.is-a.dev).