### PR TITLE
BETA: Register xianglingclient.is-a.dev

### DIFF
--- a/domains/xianglingclient.json
+++ b/domains/xianglingclient.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tunglamnoob6719",
+        "email": "tunglamnoob@protonmail.com"
+    },
+    "record": {
+        "CNAME": "0"
+    }
+}


### PR DESCRIPTION
Added `xianglingclient.is-a.dev` using the [dashboard](https://manage.is-a.dev).