### PR TITLE
BETA: Update valowolf.is-a.dev

### DIFF
--- a/domains/valowolf.json
+++ b/domains/valowolf.json
@@ -1,11 +1,9 @@
 {
-  "owner": {
-    "username": "ValoWolf",
-    "email": "starfleet.valowolf@gmail.com",
-    "twitter": "ValoWolf",
-    "discord": "valowolf"
-  },
-  "record": {
-    "URL": "https://valowolf.carrd.co"
-  }
+    "owner": {
+        "username": "ValoWolf",
+        "email": "starfleet.valowolf@gmail.com"
+    },
+    "record": {
+            "CNAME": "hosts.is-a.dev"
+    }
 }


### PR DESCRIPTION
Updated `valowolf.is-a.dev` using the [dashboard](https://manage.is-a.dev).