### PR TITLE
BETA: Register caodoc.is-a.dev

### DIFF
--- a/domains/caodoc.json
+++ b/domains/caodoc.json
@@ -4,6 +4,6 @@
         "email": "dochicao2306@gmail.com"
     },
     "record": {
-        "URL": "caodoc.github.io"
+        "CNAME": "caodoc.github.io"
     }
 }

--- a/domains/caodoc.json
+++ b/domains/caodoc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "caodoc",
+        "email": "dochicao2306@gmail.com"
+    },
+    "record": {
+        "URL": "caodoc.github.io"
+    }
+}


### PR DESCRIPTION
Added `caodoc.is-a.dev` using the [dashboard](https://manage.is-a.dev).