### PR TITLE
BETA: Register fetbarcelon.is-a.dev

### DIFF
--- a/domains/fetbarcelon.json
+++ b/domains/fetbarcelon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "fetbarcelon",
+        "email": "fetbarcelon@gmail.com"
+    },
+    "record": {
+        "URL": "https://stephania-co.dev"
+    }
+}


### PR DESCRIPTION
Added `fetbarcelon.is-a.dev` using the [dashboard](https://manage.is-a.dev).