### PR TITLE
BETA: Register dumprr.is-a.dev

### DIFF
--- a/domains/dumprr.json
+++ b/domains/dumprr.json
@@ -4,6 +4,6 @@
         "email": "duhhhmprr@proton.me"
     },
     "record": {
-        "URL": "https://dumprr.github.io/"
+        "CNAME": "dumprr.github.io"
     }
 }

--- a/domains/dumprr.json
+++ b/domains/dumprr.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dumprr",
+        "email": "umi.thezendev@gmail.com"
+    },
+    "record": {
+        "URL": "https://dumprr.github.io/"
+    }
+}

--- a/domains/dumprr.json
+++ b/domains/dumprr.json
@@ -1,7 +1,7 @@
 {
     "owner": {
         "username": "dumprr",
-        "email": "umi.thezendev@gmail.com"
+        "email": "duhhhmprr@proton.me"
     },
     "record": {
         "URL": "https://dumprr.github.io/"


### PR DESCRIPTION
Added `dumprr.is-a.dev` using the [dashboard](https://manage.is-a.dev).