### PR TITLE
BETA: Register ander.is-a.dev

### DIFF
--- a/domains/ander.json
+++ b/domains/ander.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "anderctrl",
+        "email": "ander.ctrl.alt.supr@gmail.com"
+    },
+    "record": {
+        "CNAME": "ytdl-web.onrender.com"
+    }
+}


### PR DESCRIPTION
Added `ander.is-a.dev` using the [dashboard](https://manage.is-a.dev).