### PR TITLE
BETA: Register i2rys.is-a.dev

### DIFF
--- a/domains/i2rys.json
+++ b/domains/i2rys.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "I2rys",
+        "email": "i2rys@protonmail.com"
+    },
+    "record": {
+        "URL": "https://i2rys.vercel.app/"
+    }
+}


### PR DESCRIPTION
Added `i2rys.is-a.dev` using the [dashboard](https://manage.is-a.dev).