### PR TITLE
BETA: Register gooplancton.is-a.dev

### DIFF
--- a/domains/gooplancton.json
+++ b/domains/gooplancton.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "gooplancton",
+        "email": "gooplancton@outlook.com"
+    },
+    "record": {
+        "A": ["93.93.117.164"]
+    }
+}


### PR DESCRIPTION
Added `gooplancton.is-a.dev` using the [dashboard](https://manage.is-a.dev).