### PR TITLE
BETA: Register boston2029.is-a.dev

### DIFF
--- a/domains/boston2029.json
+++ b/domains/boston2029.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "boston2029",
+        "email": "boston2029@outlook.com"
+    },
+    "record": {
+        "CNAME": "215de2e6-27df-4710-82aa-ae0cfa6f19bc.id.repl.co"
+    }
+}


### PR DESCRIPTION
Added `boston2029.is-a.dev` using the [dashboard](https://manage.is-a.dev).