### PR TITLE
BETA: Register just-muzz.is-a.dev

### DIFF
--- a/domains/just-muzz.json
+++ b/domains/just-muzz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "just-Muzz",
+        "email": "idrisking759@gmail.com"
+    },
+    "record": {
+        "CNAME": "just-muzz.is-a.dev"
+    }
+}

--- a/domains/muzzammil.json
+++ b/domains/muzzammil.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "just-Muzz",
+        "email": "idrisking759@gmail.com"
+    },
+    "record": {
+        "URL": "muzzammil.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `just-muzz.is-a.dev` using the [dashboard](https://manage.is-a.dev).