### PR TITLE
BETA: Register pixelwhiz.is-a.dev

### DIFF
--- a/domains/pixelwhiz.json
+++ b/domains/pixelwhiz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "pixelwhiz",
+        "email": "daffa01futn@gmail.com"
+    },
+    "record": {
+        "CNAME": "pixelwhiz.github.io"
+    }
+}


### PR DESCRIPTION
Added `pixelwhiz.is-a.dev` using the [dashboard](https://manage.is-a.dev).