### PR TITLE
BETA: Update caodoc.is-a.dev

### DIFF
--- a/domains/caodoc.json
+++ b/domains/caodoc.json
@@ -4,6 +4,6 @@
         "email": "dochicao2306@gmail.com"
     },
     "record": {
-        "CNAME": "caodoc.github.io"
+            "CNAME": "caodoc.github.io"
     }
 }


### PR DESCRIPTION
Updated `caodoc.is-a.dev` using the [dashboard](https://manage.is-a.dev).