### PR TITLE
BETA: Update stacksyz.is-a.dev

### DIFF
--- a/domains/stacksyz.json
+++ b/domains/stacksyz.json
@@ -4,6 +4,6 @@
         "email": "thedevmonke@gmail.com"
     },
     "record": {
-        "CNAME": "83b4876d-be97-4b01-b48b-f133a84abd2f.id.repl.co"
+            "TXT": "replit-verify=83b4876d-be97-4b01-b48b-f133a84abd2f"
     }
 }

--- a/domains/stacksyz.json
+++ b/domains/stacksyz.json
@@ -4,6 +4,6 @@
         "email": "thedevmonke@gmail.com"
     },
     "record": {
-            "TXT": "replit-verify=83b4876d-be97-4b01-b48b-f133a84abd2f"
+            "CNAME": "83b4876d-be97-4b01-b48b-f133a84abd2f.id.repl.co"
     }
 }


### PR DESCRIPTION
Updated `stacksyz.is-a.dev` using the [dashboard](https://manage.is-a.dev).