### PR TITLE
BETA: Update oreo.is-a.dev

### DIFF
--- a/domains/oreo.json
+++ b/domains/oreo.json
@@ -1,12 +1,9 @@
 {
-    "description": "A website for YummyOreo",
-    "repo": "https://github.com/YummyOreo/yummyoreo.github.io",
     "owner": {
         "username": "YummyOreo",
-        "email": "bobgim20@gmail.com",
-        "twitter": "YummyOreo3"
+        "email": "bobgim20@gmail.com"
     },
     "record": {
-        "CNAME": "yummyoreo.github.io"
+            "CNAME": "yummyoreo.github.io"
     }
 }


### PR DESCRIPTION
Updated `oreo.is-a.dev` using the [dashboard](https://manage.is-a.dev).