### PR TITLE
BETA: Register uberkey.is-a.dev

### DIFF
--- a/domains/uberkey.json
+++ b/domains/uberkey.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "uberkey",
+        "email": "postmordial@gmail.com"
+    },
+    "record": {
+        "CNAME": "uberkey.github.io"
+    }
+}


### PR DESCRIPTION
Added `uberkey.is-a.dev` using the [dashboard](https://manage.is-a.dev).