### PR TITLE
BETA: Register undeadevs.is-a.dev

### DIFF
--- a/domains/undeadevs.json
+++ b/domains/undeadevs.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "undeadevs",
+        "email": "jangantanyaaku14@gmail.com"
+    },
+    "record": {
+        "CNAME": "undeadevs.github.io"
+    }
+}


### PR DESCRIPTION
Added `undeadevs.is-a.dev` using the [dashboard](https://manage.is-a.dev).