### PR TITLE
BETA: Update caodoc.is-a.dev

### DIFF
--- a/domains/caodoc.json
+++ b/domains/caodoc.json
@@ -1,12 +1,9 @@
 {
-    "description": "Ducca's Hideout. Place of a student who interested in front-end and competitive programming.",
-    "repo": "https://github.com/caodoc/caodoc.github.io",
     "owner": {
         "username": "caodoc",
-        "email": "",
-        "discord": "caodoc"
+        "email": "dochicao2306@gmail.com"
     },
     "record": {
-        "CNAME": "caodoc.github.io"
+            "CNAME": "caodoc.github.io"
     }
 }


### PR DESCRIPTION
Updated `caodoc.is-a.dev` using the [dashboard](https://manage.is-a.dev).