### PR TITLE
BETA: Register nxn.is-a.dev

### DIFF
--- a/domains/nxn.json
+++ b/domains/nxn.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NxnRmz",
+        "email": "nxnrmz@gmail.com"
+    },
+    "record": {
+        "TXT": "rmz"
+    }
+}


### PR DESCRIPTION
Added `nxn.is-a.dev` using the [dashboard](https://manage.is-a.dev).