### PR TITLE
BETA: Register nubi.is-a.dev

### DIFF
--- a/domains/nubi.json
+++ b/domains/nubi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "nubi1337",
+        "email": "jutendo112233@gmail.com"
+    },
+    "record": {
+        "A": ["45.142.107.232"]
+    }
+}


### PR DESCRIPTION
Added `nubi.is-a.dev` using the [dashboard](https://manage.is-a.dev).