### PR TITLE
BETA: Register nyde.is-a.dev

### DIFF
--- a/domains/nyde.json
+++ b/domains/nyde.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "justnyde",
+        "email": "justnyde2123@gmail.com"
+    },
+    "record": {
+        "URL": "https://nyde.live/"
+    }
+}


### PR DESCRIPTION
Added `nyde.is-a.dev` using the [dashboard](https://manage.is-a.dev).