### PR TITLE
BETA: Register eden.is-a.dev

### DIFF
--- a/domains/eden.json
+++ b/domains/eden.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "EdenQwQ",
+        "email": "lsahlm1eden@gmail.com"
+    },
+    "record": {
+        "CNAME": "edenqwq.github.io"
+    }
+}


### PR DESCRIPTION
Added `eden.is-a.dev` using the [dashboard](https://manage.is-a.dev).