### PR TITLE
BETA: Register gautham.is-a.dev

### DIFF
--- a/domains/gautham.json
+++ b/domains/gautham.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "inkilu",
+        "email": "gauthamgkm@gmail.com"
+    },
+    "record": {
+        "CNAME": "inkilu.github.io"
+    }
+}


### PR DESCRIPTION
Added `gautham.is-a.dev` using the [dashboard](https://manage.is-a.dev).