### PR TITLE
BETA: Register pixie.is-a.dev

### DIFF
--- a/domains/pixie.json
+++ b/domains/pixie.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Salmontrap26283627",
+        "email": "soudeur-epicier.0x@icloud.com"
+    },
+    "record": {
+        "URL": "https://html-starter-seven-umber.vercel.app/"
+    }
+}


### PR DESCRIPTION
Added `pixie.is-a.dev` using the [dashboard](https://manage.is-a.dev).