### PR TITLE
BETA: Register geniucker.is-a.dev

### DIFF
--- a/domains/geniucker.json
+++ b/domains/geniucker.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Geniucker",
+        "email": "wolf2003rain@163.com"
+    },
+    "record": {
+        "CNAME": "geniucker.github.io"
+    }
+}


### PR DESCRIPTION
Added `geniucker.is-a.dev` using the [dashboard](https://manage.is-a.dev).