### PR TITLE
BETA: Update notaussie.is-a.dev

### DIFF
--- a/domains/notaussie.json
+++ b/domains/notaussie.json
@@ -1,11 +1,9 @@
 {
-    "description": "Personal site / Portafolio.",
-    "repo": "https://github.com/NotAussie/NotAussieIsADev/",
     "owner": {
         "username": "NotAussie",
         "email": "Aussie_Okay@protonmail.com"
     },
     "record": {
-        "CNAME": "notaussie.github.io"
+            "TXT": "90da8fed0d12ac5285430df6f5daa9"
     }
 }


### PR DESCRIPTION
Updated `notaussie.is-a.dev` using the [dashboard](https://manage.is-a.dev).