### PR TITLE
BETA: Register zhaiguangpeng.is-a.dev

### DIFF
--- a/domains/zhaiguangpeng.json
+++ b/domains/zhaiguangpeng.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "coopercoder",
+        "email": "whitetiger0127@163.com"
+    },
+    "record": {
+        "CNAME": "zhaiguangpeng.love"
+    }
+}


### PR DESCRIPTION
Added `zhaiguangpeng.is-a.dev` using the [dashboard](https://manage.is-a.dev).