### PR TITLE
BETA: Register alexandresoftware.is-a.dev

### DIFF
--- a/domains/AlexandreSoftware.json
+++ b/domains/AlexandreSoftware.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AlexandreSoftware",
+        "email": "xandrf@protonmail.com"
+    },
+    "record": {
+        "URL": "https://alexandresoftware.github.io/"
+    }
+}


### PR DESCRIPTION
Added `alexandresoftware.is-a.dev` using the [dashboard](https://manage.is-a.dev).