### PR TITLE
BETA: Register lemon.is-a.dev

### DIFF
--- a/domains/lemon.json
+++ b/domains/lemon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "PassiveLemon",
+        "email": "lemonl3mn@protonmail.com"
+    },
+    "record": {
+        "CNAME": "citrus-tree.xyz"
+    }
+}


### PR DESCRIPTION
Added `lemon.is-a.dev` using the [dashboard](https://manage.is-a.dev).