### PR TITLE
BETA: Register akpi.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-akpi816218.akpi.json
+++ b/domains/_github-pages-challenge-akpi816218.akpi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "akpi816218",
+        "email": "816218@seq.org"
+    },
+    "record": {
+        "TXT": "4a9225a324ec0fdb1e52cfd629e439"
+    }
+}

--- a/domains/akpi.json
+++ b/domains/akpi.json
@@ -1,9 +1,0 @@
-{
-    "owner": {
-        "username": "akpi816218",
-        "email": "816218@seq.org"
-    },
-    "record": {
-        "CNAME": "akpi816218.github.io"
-    }
-}

--- a/domains/akpi.json
+++ b/domains/akpi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "akpi816218",
+        "email": "816218@seq.org"
+    },
+    "record": {
+        "CNAME": "akpi816218.github.io"
+    }
+}


### PR DESCRIPTION
Added `akpi.is-a.dev` using the [dashboard](https://manage.is-a.dev).

`_github-pages-challenge-akpi816218.akpi.is-a.dev` for GitHub Pages domain verification