### PR TITLE
BETA: Register yarnball.is-a.dev

### DIFF
--- a/domains/yarnball.json
+++ b/domains/yarnball.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "yarnball",
+        "email": "yconomos@gmail.com"
+    },
+    "record": {
+        "CNAME": "test.com"
+    }
+}


### PR DESCRIPTION
Added `yarnball.is-a.dev` using the [dashboard](https://manage.is-a.dev).