### PR TITLE
BETA: Register window5.is-a.dev

### DIFF
--- a/domains/window5.json
+++ b/domains/window5.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Window5000",
+        "email": "spam.window5.spam@gmail.com"
+    },
+    "record": {
+        "CNAME": "window5000.github.io"
+    }
+}


### PR DESCRIPTION
Added `window5.is-a.dev` using the [dashboard](https://manage.is-a.dev).