### PR TITLE
BETA: Register fabiannecosta.is-a.dev

### DIFF
--- a/domains/fabiannecosta.json
+++ b/domains/fabiannecosta.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AnneCosta",
+        "email": "fabiannecs@hotmail.com"
+    },
+    "record": {
+        "CNAME": "annecosta.github.io"
+    }
+}


### PR DESCRIPTION
Added `fabiannecosta.is-a.dev` using the [dashboard](https://manage.is-a.dev).