### PR TITLE
BETA: Register brunormoura.is-a.dev

### DIFF
--- a/domains/brunormoura.json
+++ b/domains/brunormoura.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Jujubalandia",
+        "email": "brunormoura@gmail.com"
+    },
+    "record": {
+        "TXT": "brunormoura.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `brunormoura.is-a.dev` using the [dashboard](https://manage.is-a.dev).