### PR TITLE
BETA: Register rama.is-a.dev

### DIFF
--- a/domains/rama.json
+++ b/domains/rama.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ramavats",
+        "email": "guy55222@gmail.com"
+    },
+    "record": {
+        "CNAME": "www"
+    }
+}


### PR DESCRIPTION
Added `rama.is-a.dev` using the [dashboard](https://manage.is-a.dev).