### PR TITLE
feat(validation): bump node to v16

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,10 +9,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Setup node v15
+      - name: Setup node v16
         uses: actions/setup-node@v1
         with:
-          node-version: '15'
+          node-version: '16'
       - name: Install dependencies
         uses: borales/actions-yarn@v2.0.0
         with:


### PR DESCRIPTION
The CI constantly gets stuck on installing Node v15, so I think updating it to v16 should work better.

Please let me know if it will not work.