### PR TITLE
BETA: Register orangeleaf36.is-a.dev

### DIFF
--- a/domains/orangeleaf36.json
+++ b/domains/orangeleaf36.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "OrangeLeafDev",
+        "email": "caluzajacob07@gmail.com"
+    },
+    "record": {
+        "CNAME": "orangeleafdev.github.io"
+    }
+}


### PR DESCRIPTION
Added `orangeleaf36.is-a.dev` using the [dashboard](https://manage.is-a.dev).