### PR TITLE
BETA: Register rolte.is-a.dev

### DIFF
--- a/domains/rolte.json
+++ b/domains/rolte.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "xRolTe",
+        "email": "ibrahimolgun48@gmail.com"
+    },
+    "record": {
+        "CNAME": "1"
+    }
+}


### PR DESCRIPTION
Added `rolte.is-a.dev` using the [dashboard](https://manage.is-a.dev).