### PR TITLE
BETA: Register zerolandcode.is-a.dev

### DIFF
--- a/domains/zerolandcode.json
+++ b/domains/zerolandcode.json
@@ -4,6 +4,6 @@
         "email": "rolteoln@gmail.com"
     },
     "record": {
-        "URL": "https://zerolandcode.github.io/zerolandcodesite/"
+        "CNAME": "zerolandcode.github.io"
     }
 }

--- a/domains/zerolandcode.json
+++ b/domains/zerolandcode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zerolandcode",
+        "email": "rolteoln@gmail.com"
+    },
+    "record": {
+        "URL": "https://zerolandcode.github.io/zerolandcodesite/"
+    }
+}


### PR DESCRIPTION
Added `zerolandcode.is-a.dev` using the [dashboard](https://manage.is-a.dev).