### PR TITLE
BETA: Update linusx.is-a.dev

### DIFF
--- a/domains/linusx.json
+++ b/domains/linusx.json
@@ -1,11 +1,9 @@
 {
-    "description": "Just my personal website, static on github pages. Generated with hugo",
-    "repo": "https://github.com/linuzzx/linuzzx.github.io",
     "owner": {
         "username": "linuzzx",
-        "email": "galaxylinus@gmail.com"
+        "email": "GalaxyLinus@gmail.com"
     },
     "record": {
-        "CNAME": "linuzzx.github.io"
+            "CNAME": "hosts.is-a.dev"
     }
-} 
+}


### PR DESCRIPTION
Updated `linusx.is-a.dev` using the [dashboard](https://manage.is-a.dev).