### PR TITLE
BETA: Register _github-pages-challenge-linuzzx.linusx.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-linuzzx.linusx.json
+++ b/domains/_github-pages-challenge-linuzzx.linusx.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "linuzzx",
+        "email": "GalaxyLinus@gmail.com"
+    },
+    "record": {
+        "TXT": "029ab228dfd885b308be6aef43066d"
+    }
+}


### PR DESCRIPTION
Added `_github-pages-challenge-linuzzx.linusx.is-a.dev` using the [dashboard](https://manage.is-a.dev).