### PR TITLE
BETA: Register spirit.is-a.dev

### DIFF
--- a/domains/spirit.json
+++ b/domains/spirit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "codedotspirit",
+        "email": "louisescher@proton.me"
+    },
+    "record": {
+        "A": ["185.245.61.41"]
+    }
+}


### PR DESCRIPTION
Added `spirit.is-a.dev` using the [dashboard](https://manage.is-a.dev).