### PR TITLE
BETA: Update wan.is-a.dev

### DIFF
--- a/domains/wan.json
+++ b/domains/wan.json
@@ -4,6 +4,6 @@
         "email": "taio6@duck.com"
     },
     "record": {
-        "URL": "https://helix-pullover-d4c.notion.site/wansie-3655baf5f6de40cc8be7aa8cbf67f095"
+            "CNAME": "wansies.github.io"
     }
 }


### PR DESCRIPTION
Updated `wan.is-a.dev` using the [dashboard](https://manage.is-a.dev).