### PR TITLE
BETA: Register vezironi.is-a.dev

### DIFF
--- a/domains/vezironi.json
+++ b/domains/vezironi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "VezirOni",
+        "email": "vezironi@yandex.com"
+    },
+    "record": {
+        "URL": "https://vezironi.github.io/vezir/"
+    }
+}


### PR DESCRIPTION
Added `vezironi.is-a.dev` using the [dashboard](https://manage.is-a.dev).