### PR TITLE
BETA: Register jnnr.is-a.dev

### DIFF
--- a/domains/jnnr.json
+++ b/domains/jnnr.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RashTagC",
+        "email": "gj48208@gmail.com"
+    },
+    "record": {
+        "TXT": "1"
+    }
+}


### PR DESCRIPTION
Added `jnnr.is-a.dev` using the [dashboard](https://manage.is-a.dev).