### PR TITLE
BETA: Register picosvelte.zarqi.is-a.dev

### DIFF
--- a/domains/picosvelte.zarqi.json
+++ b/domains/picosvelte.zarqi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zarqizoubir",
+        "email": "zarqi.ezzoubair@etu.uae.ac.ma"
+    },
+    "record": {
+        "CNAME": "zarqizoubir.github.io"
+    }
+}


### PR DESCRIPTION
Added `picosvelte.zarqi.is-a.dev` using the [dashboard](https://manage.is-a.dev).