### PR TITLE
BETA: Register genevera.is-a.dev

### DIFF
--- a/domains/genevera.json
+++ b/domains/genevera.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "genevera",
+        "email": "genevera.codes+github@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `genevera.is-a.dev` using the [dashboard](https://manage.is-a.dev).