### PR TITLE
BETA: Register algoarchive.is-a.dev

### DIFF
--- a/domains/algoarchive.json
+++ b/domains/algoarchive.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+       "username": "justdont0",
+       "email": "hello.and.ios@gmail.com",
+       "discord": "981586348198735912"
+    },
+
+    "record": {
+        "CNAME": "justdont0.github.io"
+    }
+}


### PR DESCRIPTION
Added `algoarchive.is-a.dev` using the Discord bot.