### PR TITLE
BETA: Register rizky.is-a.dev

### DIFF
--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "schummler",
+        "email": "markwilkens102@gmail.com"
+    },
+    "record": {
+        "CNAME": "schummler.github.io"
+    }
+}


### PR DESCRIPTION
Added `rizky.is-a.dev` using the [dashboard](https://manage.is-a.dev).