### PR TITLE
BETA: Register fasdaa.is-a.dev

### DIFF
--- a/domains/fasdaa.json
+++ b/domains/fasdaa.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "boomer4boomer",
+        "email": "abdulkx06epic@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `fasdaa.is-a.dev` using the [dashboard](https://manage.is-a.dev).