### PR TITLE
BETA: Register rubin.is-a.dev

### DIFF
--- a/domains/rubin.json
+++ b/domains/rubin.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "rubiin",
+        "email": "roobin.bhandari@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `rubin.is-a.dev` using the [dashboard](https://manage.is-a.dev).