### PR TITLE
BETA: Update rizky.is-a.dev

### DIFF
--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-            "CNAME": "minthook.tk"
+            "CNAME": ""[{"type":"CNAME","value":"schummler.github.io","allowMultiple":false}]""
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-            "CNAME": ""[{"type":"CNAME","value":"rizky.is-a.dev","allowMultiple":false}]""
+            "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"Rizky.is-a.dev"}]""
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-            "CNAME": ""[{"type":"CNAME","value":"schummler.github.io","allowMultiple":false}]""
+            "CNAME": ""[{"type":"CNAME","value":"rizky.is-a.dev","allowMultiple":false}]""
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-        "CNAME": "schummler.github.io"
+            "URL": "schummler.github.io"
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-            "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"Schummler.github.io"}]""
+            "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"stellaris.rf.gd"}]""
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-            "URL": "schummler.github.io"
+            "CNAME": "minthook.tk"
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-            "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"Rizky.is-a.dev"}]""
+            "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"Schummler.github.io"}]""
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-            "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"stellaris.rf.gd"}]""
+        "CNAME": "stellaris.rf.gd"
     }
 }


### PR DESCRIPTION
Updated `rizky.is-a.dev` using the [dashboard](https://manage.is-a.dev).