### PR TITLE
BETA: Register git.is-a.dev

### DIFF
--- a/domains/git.json
+++ b/domains/git.json
@@ -6,6 +6,6 @@
     "record": {
         "A": ["217.174.245.249"],
         "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
-        "MX": "hosts.is-a.dev"
+        "MX": ["hosts.is-a.dev"]
     }
 }

--- a/domains/git.json
+++ b/domains/git.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "git-hoe",
+        "email": "haxer@disroot.org"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `git.is-a.dev` using the [dashboard](https://manage.is-a.dev).