### PR TITLE
BETA: Register azul.is-a.dev

### DIFF
--- a/domains/azul.json
+++ b/domains/azul.json
@@ -6,6 +6,6 @@
     "record": {
         "A": ["217.174.245.249"],
         "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
-        "MX": "hosts.is-a.dev"
+        "MX": ["hosts.is-a.dev"]
     }
 }

--- a/domains/azul.json
+++ b/domains/azul.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "TheRealGeoDash2019",
+        "email": "TheRealGeoDash2019@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `azul.is-a.dev` using the [dashboard](https://manage.is-a.dev).