### PR TITLE
BETA: Register _discord.window5.is-a.dev

### DIFF
--- a/domains/_discord.window5.json
+++ b/domains/_discord.window5.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Window5000",
+        "email": "spam.window5.spam@gmail.com"
+    },
+    "record": {
+        "TXT": "dh=3452cc6f1642d3d206dd6b5cf3cbb7deb837ecd9"
+    }
+}


### PR DESCRIPTION
Added `_discord.window5.is-a.dev` using the [dashboard](https://manage.is-a.dev).