### PR TITLE
BETA: Register ringoxd.is-a.dev

### DIFF
--- a/domains/ringoxd.json
+++ b/domains/ringoxd.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "ringo360",
+        "email": "nep360i@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `ringoxd.is-a.dev` using the [dashboard](https://manage.is-a.dev).