### PR TITLE
BETA: Register blinx.is-a.dev

### DIFF
--- a/domains/blinx.json
+++ b/domains/blinx.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "cabingory",
+        "email": "blinxduh@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `blinx.is-a.dev` using the [dashboard](https://manage.is-a.dev).