### PR TITLE
BETA: Register kryclopz.is-a.dev

### DIFF
--- a/domains/kryclopz.json
+++ b/domains/kryclopz.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "kryclopz-development",
+        "email": "officialkryclopz@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `kryclopz.is-a.dev` using the [dashboard](https://manage.is-a.dev).