### PR TITLE
BETA: Register imat.is-a.dev

### DIFF
--- a/domains/imat.json
+++ b/domains/imat.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "iMatx",
+        "email": "adam.essakhi16+github@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `imat.is-a.dev` using the [dashboard](https://manage.is-a.dev).