### PR TITLE
BETA: Register errornointernet.is-a.dev

### DIFF
--- a/domains/errornointernet.json
+++ b/domains/errornointernet.json
@@ -6,6 +6,6 @@
     "record": {
         "A": ["217.174.245.249"],
         "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
-        "MX": "hosts.is-a.dev"
+        "MX": ["hosts.is-a.dev"]
     }
 }

--- a/domains/errornointernet.json
+++ b/domains/errornointernet.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "ErrorNoInternet",
+        "email": "error.nointernet@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `errornointernet.is-a.dev` using the [dashboard](https://manage.is-a.dev).