### PR TITLE
BETA: Register _discord.orangeleaf36.is-a.dev..is-a.dev

### DIFF
--- a/domains/_discord.orangeleaf36.is-a.dev..json
+++ b/domains/_discord.orangeleaf36.is-a.dev..json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "OrangeLeafDev",
+        "email": "caluzajacob07@gmail.com"
+    },
+    "record": {
+        "TXT": "dh=fd757429248d1d7f7f7a50d6541e6516a43ff6ff"
+    }
+}


### PR DESCRIPTION
Added `_discord.orangeleaf36.is-a.dev..is-a.dev` using the [dashboard](https://manage.is-a.dev).