### PR TITLE
BETA: Register flytri.is-a.dev

### DIFF
--- a/domains/flytri.json
+++ b/domains/flytri.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "FlyTri",
+        "email": "vominhtri28032010@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all",
+        "MX": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `flytri.is-a.dev` using the [dashboard](https://manage.is-a.dev).