### PR TITLE
BETA: Register gamedevdylan.is-a.dev

### DIFF
--- a/domains/gamedevdylan.json
+++ b/domains/gamedevdylan.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "GameDeveloperDylan",
+        "email": "dylan10109101010910@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `gamedevdylan.is-a.dev` using the [dashboard](https://manage.is-a.dev).