### PR TITLE
BETA: Register blog.ron.is-a.dev

### DIFF
--- a/domains/blog.ron.json
+++ b/domains/blog.ron.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "itsrn",
+        "email": "shalom@itsron.space"
+    },
+    "record": {
+        "CNAME": "itsrn.github.io"
+    }
+}


### PR DESCRIPTION
Added `blog.ron.is-a.dev` using the [dashboard](https://manage.is-a.dev).