### PR TITLE
BETA: Register gcc.is-a.dev

### DIFF
--- a/domains/gcc.json
+++ b/domains/gcc.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "zachcool",
+        "email": "zach24willow@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `gcc.is-a.dev` using the [dashboard](https://manage.is-a.dev).