### PR TITLE
BETA: Register eclair.is-a.dev

### DIFF
--- a/domains/eclair.json
+++ b/domains/eclair.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "assjgejcitif",
+        "email": "fluffy@dmc.chat"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `eclair.is-a.dev` using the [dashboard](https://manage.is-a.dev).