### PR TITLE
BETA: Register con.is-a.dev

### DIFF
--- a/domains/con.json
+++ b/domains/con.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Sheathed",
+        "email": "xixenco@gmail.com"
+    },
+    "record": {
+        "CNAME": "cyanraze.github.io"
+    }
+}


### PR DESCRIPTION
Added `con.is-a.dev` using the [dashboard](https://manage.is-a.dev).