### PR TITLE
BETA: Register lacyx.is-a.dev

### DIFF
--- a/domains/lacyx.json
+++ b/domains/lacyx.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "LacyXosu",
+        "email": "nozoska@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `lacyx.is-a.dev` using the [dashboard](https://manage.is-a.dev).