### PR TITLE
BETA: Register sadiz.is-a.dev

### DIFF
--- a/domains/sadiz.json
+++ b/domains/sadiz.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Sadishru",
+        "email": "hellosadish@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `sadiz.is-a.dev` using the [dashboard](https://manage.is-a.dev).