### PR TITLE
BETA: Register xorisx.is-a.dev

### DIFF
--- a/domains/xorisx.json
+++ b/domains/xorisx.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "vividcolorss",
+        "email": "68936a@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `xorisx.is-a.dev` using the [dashboard](https://manage.is-a.dev).