### PR TITLE
BETA: Update shept.is-a.dev

### DIFF
--- a/domains/shept.json
+++ b/domains/shept.json
@@ -4,8 +4,6 @@
         "email": "maxiheinrich007@yahoo.com"
     },
     "record": {
-        "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
-        "TXT": "v=spf1 include:spf.improvmx.com ~all",
-        "CNAME": "mcshept.github.io"
+        "CNAME": ""[{"type":"MX","value":"mx1.improvmx.com;mx2.improvmx.com","allowMultiple":true},{"type":"CNAME","allowMultiple":false,"value":"mcshept.github.io"}]""
     }
 }

--- a/domains/shept.json
+++ b/domains/shept.json
@@ -4,7 +4,12 @@
         "email": "maxiheinrich007@yahoo.com"
     },
     "record": {
-        "CNAME": "mcshept.github.io",
+        "A": [
+            "185.199.108.153",
+            "185.199.109.153",
+            "185.199.110.153",
+            "185.199.111.153"
+        ],
         "MX": [
             "mx1.improvmx.com",
             "mx2.improvmx.com"

--- a/domains/shept.json
+++ b/domains/shept.json
@@ -4,6 +4,6 @@
         "email": "maxiheinrich007@yahoo.com"
     },
     "record": {
-        "MX": ["mx1.improvmx.com"]
+        "CNAME": ""[{"type":"MX","value":"mx1.improvmx.com;mx2.improvmx.com","allowMultiple":true},{"type":"CNAME","allowMultiple":false,"value":"mcshept.github.io"}]""
     }
 }

--- a/domains/shept.json
+++ b/domains/shept.json
@@ -4,6 +4,11 @@
         "email": "maxiheinrich007@yahoo.com"
     },
     "record": {
-        "CNAME": ""[{"type":"MX","value":"mx1.improvmx.com;mx2.improvmx.com","allowMultiple":true},{"type":"CNAME","allowMultiple":false,"value":"mcshept.github.io"}]""
+        "CNAME": "mcshept.github.io",
+        "MX": [
+            "mx1.improvmx.com",
+            "mx2.improvmx.com"
+        ],
+        "TXT": "v=spf1 include:spf.improvmx.com ~all"
     }
 }

--- a/domains/shept.json
+++ b/domains/shept.json
@@ -4,6 +4,8 @@
         "email": "maxiheinrich007@yahoo.com"
     },
     "record": {
-        "CNAME": ""[{"type":"MX","value":"mx1.improvmx.com;mx2.improvmx.com","allowMultiple":true},{"type":"CNAME","allowMultiple":false,"value":"mcshept.github.io"}]""
+        "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
+        "TXT": "v=spf1 include:spf.improvmx.com ~all",
+        "CNAME": "mcshept.github.io"
     }
 }


### PR DESCRIPTION
Updated `shept.is-a.dev` using the [dashboard](https://manage.is-a.dev).