### PR TITLE
BETA: Register devgd.is-a.dev

### DIFF
--- a/domains/devgd.json
+++ b/domains/devgd.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Dev8H24",
+        "email": "devsteamgaming91@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `devgd.is-a.dev` using the [dashboard](https://manage.is-a.dev).