### PR TITLE
BETA: Register chase.is-a.dev

### DIFF
--- a/domains/chase.json
+++ b/domains/chase.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "trir44",
+        "email": "621969@kernhigh.org"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `chase.is-a.dev` using the [dashboard](https://manage.is-a.dev).