### PR TITLE
BETA: Register toasta.is-a.dev

### DIFF
--- a/domains/toasta.json
+++ b/domains/toasta.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "thetoasta",
+        "email": "nolanp678@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `toasta.is-a.dev` using the [dashboard](https://manage.is-a.dev).