### PR TITLE
BETA: Register ds+gamer.is-a.dev

### DIFF
--- a/domains/ds+gamer.json
+++ b/domains/ds+gamer.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "DhruvGamingzsoft",
+        "email": "dgashost@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `ds+gamer.is-a.dev` using the [dashboard](https://manage.is-a.dev).