### PR TITLE
BETA: Register logan2005.is-a.dev

### DIFF
--- a/domains/logan2005.json
+++ b/domains/logan2005.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "soviet783",
+        "email": "logannorman2005@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `logan2005.is-a.dev` using the [dashboard](https://manage.is-a.dev).