### PR TITLE
BETA: Register clarex.is-a.dev

### DIFF
--- a/domains/clarex.json
+++ b/domains/clarex.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "clarexdev",
+        "email": "erenclarex@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `clarex.is-a.dev` using the [dashboard](https://manage.is-a.dev).