### PR TITLE
BETA: Register quantamphysics.is-a.dev

### DIFF
--- a/domains/quantamphysics.json
+++ b/domains/quantamphysics.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Quantamyt",
+        "email": "Sujataghosal05@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `quantamphysics.is-a.dev` using the [dashboard](https://manage.is-a.dev).