### PR TITLE
BETA: Register jagi.is-a.dev

### DIFF
--- a/domains/jagi.json
+++ b/domains/jagi.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "javhaa07",
+        "email": "jjagi02@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `jagi.is-a.dev` using the [dashboard](https://manage.is-a.dev).