### PR TITLE
BETA: Register blob.is-a.dev

### DIFF
--- a/domains/blob.json
+++ b/domains/blob.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "BlobDeveloper",
+        "email": "blob.dev@protonmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `blob.is-a.dev` using the [dashboard](https://manage.is-a.dev).