### PR TITLE
BETA: Register zilong.is-a.dev

### DIFF
--- a/domains/zilong.json
+++ b/domains/zilong.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "al1103",
+        "email": "phamtuan72az@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `zilong.is-a.dev` using the [dashboard](https://manage.is-a.dev).