### PR TITLE
BETA: Register hirako.is-a.dev

### DIFF
--- a/domains/hirako.json
+++ b/domains/hirako.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hirakotm",
+        "email": "hirakoo@proton.me"
+    },
+    "record": {
+        "CNAME": "website-5xr.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `hirako.is-a.dev` using the [dashboard](https://manage.is-a.dev).