### PR TITLE
BETA: Register moca.is-a.dev

### DIFF
--- a/domains/moca.json
+++ b/domains/moca.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "MocaSrour",
+        "email": "mukarramsrour@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `moca.is-a.dev` using the [dashboard](https://manage.is-a.dev).