### PR TITLE
BETA: Register moca.is-a.dev

### DIFF
--- a/domains/moca.json
+++ b/domains/moca.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MocaSrour",
+        "email": "mukarramsrour@gmail.com"
+    },
+    "record": {
+        "CNAME": "mocasrour.github.io"
+    }
+}


### PR DESCRIPTION
Added `moca.is-a.dev` using the [dashboard](https://manage.is-a.dev).