### PR TITLE
BETA: Update rizky.is-a.dev

### DIFF
--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-        "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"schummler.github.io"}]""
+        "CNAME": "schummler.github.io"
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-        "CNAME": "stellaris.rf.gd"
+        "CNAME": ""[{"type":"CNAME","value":"Schummler.github.io","allowMultiple":false}]""
     }
 }

--- a/domains/rizky.json
+++ b/domains/rizky.json
@@ -4,6 +4,6 @@
         "email": "markwilkens102@gmail.com"
     },
     "record": {
-        "CNAME": ""[{"type":"CNAME","value":"Schummler.github.io","allowMultiple":false}]""
+        "CNAME": ""[{"type":"CNAME","allowMultiple":false,"value":"schummler.github.io"}]""
     }
 }


### PR DESCRIPTION
Updated `rizky.is-a.dev` using the [dashboard](https://manage.is-a.dev).