### PR TITLE
BETA: Register systemm32.is-a.dev

### DIFF
--- a/domains/systemm32.json
+++ b/domains/systemm32.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "System32-0101",
+        "email": "didunoxd@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `systemm32.is-a.dev` using the [dashboard](https://manage.is-a.dev).