### PR TITLE
BETA: Register nickooms.is-a.dev

### DIFF
--- a/domains/nickooms.json
+++ b/domains/nickooms.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "nickooms",
+        "email": "oomsni@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `nickooms.is-a.dev` using the [dashboard](https://manage.is-a.dev).