### PR TITLE
BETA: Register xian.is-a.dev

### DIFF
--- a/domains/xian.json
+++ b/domains/xian.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "xian-docdocil",
+        "email": "xian.docdocil@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `xian.is-a.dev` using the [dashboard](https://manage.is-a.dev).