### PR TITLE
BETA: Register toasty.is-a.dev

### DIFF
--- a/domains/toasty.json
+++ b/domains/toasty.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "toastyyyxd",
+        "email": "asaeasaeasae.x10@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `toasty.is-a.dev` using the [dashboard](https://manage.is-a.dev).