### PR TITLE
BETA: Register rayrsn.is-a.dev

### DIFF
--- a/domains/rayrsn.json
+++ b/domains/rayrsn.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Rayrsn",
+        "email": "ramtin.015@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `rayrsn.is-a.dev` using the [dashboard](https://manage.is-a.dev).