### PR TITLE
BETA: Register gitea.apoloz.is-a.dev

### DIFF
--- a/domains/gitea.apoloz.json
+++ b/domains/gitea.apoloz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tolyod",
+        "email": "anatoliy.poloz@gmail.com"
+    },
+    "record": {
+        "A": ["185.185.71.114"]
+    }
+}


### PR DESCRIPTION
Added `gitea.apoloz.is-a.dev` using the [dashboard](https://manage.is-a.dev).