### PR TITLE
BETA: Register kronifer.is-a.dev

### DIFF
--- a/domains/kronifer.json
+++ b/domains/kronifer.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Kronifer",
+        "email": "dillonr5@live.wsd1.org"
+    },
+    "record": {
+        "A": ["172.178.61.66"]
+    }
+}


### PR DESCRIPTION
Added `kronifer.is-a.dev` using the [dashboard](https://manage.is-a.dev).