### PR TITLE
BETA: Register rize.is-a.dev

### DIFF
--- a/domains/rize.json
+++ b/domains/rize.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "l1gm4b4lls",
+        "email": "mejmayfoof@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `rize.is-a.dev` using the [dashboard](https://manage.is-a.dev).