### PR TITLE
BETA: Register logxnic.is-a.dev

### DIFF
--- a/domains/logxnic.json
+++ b/domains/logxnic.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Nexus-sudo",
+        "email": "loganlarwood2019@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `logxnic.is-a.dev` using the [dashboard](https://manage.is-a.dev).