### PR TITLE
BETA: Register skyopg.is-a.dev

### DIFF
--- a/domains/skyopg.json
+++ b/domains/skyopg.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "LLKO101",
+        "email": "yo1sefooop@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `skyopg.is-a.dev` using the [dashboard](https://manage.is-a.dev).