### PR TITLE
BETA: Register don.is-a.dev

### DIFF
--- a/domains/don.json
+++ b/domains/don.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "DonDoesStuff",
+        "email": "lgamerlivestudios@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `don.is-a.dev` using the [dashboard](https://manage.is-a.dev).