### PR TITLE
BETA: Register monissh.is-a.dev

### DIFF
--- a/domains/monissh.json
+++ b/domains/monissh.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Monsstor",
+        "email": "itsamemonissh@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `monissh.is-a.dev` using the [dashboard](https://manage.is-a.dev).