### PR TITLE
Update invalidnoah.is-a.dev

### DIFF
--- a/domains/invalidnoah.json
+++ b/domains/invalidnoah.json
@@ -1,12 +1,11 @@
 {
-    "description": "Describe the use of this subdomain",
-    "repo": "https://github.com/InvalidNoah/InvalidNoah.github.io",
     "owner": {
         "username": "InvalidNoah",
-        "email": "me@noahist.live",
-        "twitter": "noahlikespmmp"
+        "email": "info.famegames@gmail.com"
     },
     "record": {
-        "CNAME": "invalidnoah.github.io"
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
     }
-} 
+}

--- a/domains/noah.json
+++ b/domains/noah.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "InvalidNoah",
+    "email": "zjustmarcel@gmail.com",
+    "discord": "eynoah#0",
+    "twitter": "NoahLikesPMMP"
+  }
+}


### PR DESCRIPTION
Updated `invalidnoah.is-a.dev` using the [dashboard](https://manage.is-a.dev).