### PR TITLE
BETA: Register alx.is-a.dev

### DIFF
--- a/domains/alx.json
+++ b/domains/alx.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "michaelradu",
+        "email": "miihairadu@gmail.com"
+    },
+    "record": {
+        "CNAME": "apex-loadbalancer.netlify.com"
+    }
+}


### PR DESCRIPTION
Added `alx.is-a.dev` using the [dashboard](https://manage.is-a.dev).