### PR TITLE
BETA: Register visionavtr.is-a.dev

### DIFF
--- a/domains/visionavtr.json
+++ b/domains/visionavtr.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "creatize",
+        "email": "lada_862@mail.ru"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `visionavtr.is-a.dev` using the [dashboard](https://manage.is-a.dev).