### PR TITLE
BETA: Register rikatori.is-a.dev

### DIFF
--- a/domains/rikatori.json
+++ b/domains/rikatori.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hanh713",
+        "email": "nguyendanghanh713@gmail.com"
+    },
+    "record": {
+        "TXT": "_github-pages-challenge-hanh713.rikatori"
+    }
+}


### PR DESCRIPTION
Added `rikatori.is-a.dev` using the [dashboard](https://manage.is-a.dev).