### PR TITLE
BETA: Register nexacopic.is-a.dev

### DIFF
--- a/domains/nexacopic.json
+++ b/domains/nexacopic.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "nexacopic",
+        "email": "nexacopic@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `nexacopic.is-a.dev` using the [dashboard](https://manage.is-a.dev).