### PR TITLE
BETA: Register lap.is-a.dev

### DIFF
--- a/domains/lap.json
+++ b/domains/lap.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "ItsLap",
+        "email": "alexanderpaulwheeler15@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `lap.is-a.dev` using the [dashboard](https://manage.is-a.dev).