### PR TITLE
BETA: Register bashafk.is-a.dev

### DIFF
--- a/domains/bashafk.json
+++ b/domains/bashafk.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "IbrahimKhan2004",
+        "email": "OfficialIbrahimKhan2004@proton.me"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `bashafk.is-a.dev` using the [dashboard](https://manage.is-a.dev).