### PR TITLE
BETA: Register sephrost.is-a.dev

### DIFF
--- a/domains/sephrost.json
+++ b/domains/sephrost.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Sephrost",
+        "email": "lorenzato.fabi13@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `sephrost.is-a.dev` using the [dashboard](https://manage.is-a.dev).