### PR TITLE
BETA: Register xeno.is-a.dev

### DIFF
--- a/domains/xeno.json
+++ b/domains/xeno.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Aether1777",
+        "email": "bkevin39415@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `xeno.is-a.dev` using the [dashboard](https://manage.is-a.dev).