### PR TITLE
Update hazelnut.is-a.dev

### DIFF
--- a/domains/hazelnut.json
+++ b/domains/hazelnut.json
@@ -4,6 +4,8 @@
         "email": "hazelnutzhoney@gmail.com"
     },
     "record": {
-        "CNAME": "TheMrRedstone.github.io"
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
     }
 }


### PR DESCRIPTION
Updated `hazelnut.is-a.dev` using the [dashboard](https://manage.is-a.dev).