### PR TITLE
BETA: Register kntlpop.is-a.dev

### DIFF
--- a/domains/kntlpop.json
+++ b/domains/kntlpop.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "suhujetlag5",
+        "email": "suhujetlag5@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `kntlpop.is-a.dev` using the [dashboard](https://manage.is-a.dev).