### PR TITLE
BETA: Register ryanzam.is-a.dev

### DIFF
--- a/domains/ryanzam.json
+++ b/domains/ryanzam.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ryanzam",
+        "email": "ryanzam2005@yahoo.com"
+    },
+    "record": {
+        "CNAME": "icy-coast-0d7690d03.3.azurestaticapps.net"
+    }
+}


### PR DESCRIPTION
Added `ryanzam.is-a.dev` using the [dashboard](https://manage.is-a.dev).