### PR TITLE
BETA: Register block.is-a.dev

### DIFF
--- a/domains/block.json
+++ b/domains/block.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "CookieTriste",
+        "email": "romain.tocsin@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `block.is-a.dev` using the [dashboard](https://manage.is-a.dev).