### PR TITLE
BETA: Register kuat.is-a.dev

### DIFF
--- a/domains/kuat.json
+++ b/domains/kuat.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "kramiikk",
+        "email": "hifund@yandex.ru"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `kuat.is-a.dev` using the [dashboard](https://manage.is-a.dev).