### PR TITLE
BETA: Register liam-h.is-a.dev

### DIFF
--- a/domains/liam-h.json
+++ b/domains/liam-h.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Lonyx-H",
+        "email": "liam.hedin.pro@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `liam-h.is-a.dev` using the [dashboard](https://manage.is-a.dev).