### PR TITLE
BETA: Register snipc.is-a.dev

### DIFF
--- a/domains/snipc.json
+++ b/domains/snipc.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "NotSnipc",
+        "email": "snipc.mail@proton.me"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `snipc.is-a.dev` using the [dashboard](https://manage.is-a.dev).