### PR TITLE
BETA: Register johnevermore.is-a.dev

### DIFF
--- a/domains/johnevermore.json
+++ b/domains/johnevermore.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Atr-e",
+        "email": "eatr577@gmail.com"
+    },
+    "record": {
+        "CNAME": "galatic.hop.sh"
+    }
+}


### PR DESCRIPTION
Added `johnevermore.is-a.dev` using the [dashboard](https://manage.is-a.dev).