### PR TITLE
BETA: Register notfenixio.is-a.dev

### DIFF
--- a/domains/notfenixio.json
+++ b/domains/notfenixio.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NotFenixio",
+        "email": "josueart40@gmail.com"
+    },
+    "record": {
+        "CNAME": "notfenixio.github.io"
+    }
+}


### PR DESCRIPTION
Added `notfenixio.is-a.dev` using the [dashboard](https://manage.is-a.dev).