### PR TITLE
BETA: Register kramiikk.is-a.dev

### DIFF
--- a/domains/kramiikk.json
+++ b/domains/kramiikk.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "kramiikk",
+        "email": "hifund@yandex.ru"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `kramiikk.is-a.dev` using the [dashboard](https://manage.is-a.dev).