### PR TITLE
BETA: Register shady.is-a.dev

### DIFF
--- a/domains/shady.json
+++ b/domains/shady.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "u4pak",
+        "email": "kruzshadybot@gmail.com"
+    },
+    "record": {
+        "A": ["162.248.101.107"]
+    }
+}


### PR DESCRIPTION
Added `shady.is-a.dev` using the [dashboard](https://manage.is-a.dev).