### PR TITLE
BETA: Register wap.is-a.dev

### DIFF
--- a/domains/wap.json
+++ b/domains/wap.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "kramiikk",
+        "email": "hifund@yandex.ru"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `wap.is-a.dev` using the [dashboard](https://manage.is-a.dev).