### PR TITLE
BETA: Register voonyuan.is-a.dev

### DIFF
--- a/domains/voonyuan.json
+++ b/domains/voonyuan.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "VonYuan",
+        "email": "voonyuan11@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `voonyuan.is-a.dev` using the [dashboard](https://manage.is-a.dev).