### PR TITLE
BETA: Register frnz.is-a.dev

### DIFF
--- a/domains/frnz.json
+++ b/domains/frnz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "frnzvls",
+        "email": "frenzvalios@gmail.com"
+    },
+    "record": {
+        "CNAME": "9852bfa8-fbf3-4b5f-8787-41a0dc0191fd.id.repl.co"
+    }
+}


### PR DESCRIPTION
Added `frnz.is-a.dev` using the [dashboard](https://manage.is-a.dev).