### PR TITLE
BETA: Register motortruck1221.is-a.dev

### DIFF
--- a/domains/motortruck1221.json
+++ b/domains/motortruck1221.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MotorTruck1221",
+        "email": "tuckerj0606@icloud.com"
+    },
+    "record": {
+        "CNAME": "motortruck1221.github.io"
+    }
+}


### PR DESCRIPTION
Added `motortruck1221.is-a.dev` using the [dashboard](https://manage.is-a.dev).