### PR TITLE
BETA: Register allancoding.is-a.dev

### DIFF
--- a/domains/allancoding.json
+++ b/domains/allancoding.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "allancoding",
+        "email": "allancoding.dev@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `allancoding.is-a.dev` using the [dashboard](https://manage.is-a.dev).