### PR TITLE
BETA: Register justcody.is-a.dev

### DIFF
--- a/domains/justcody.json
+++ b/domains/justcody.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "JWeinelt",
+        "email": "julian.weinelt@outlook.de"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `justcody.is-a.dev` using the [dashboard](https://manage.is-a.dev).