### PR TITLE
BETA: Register canarddu38.is-a.dev

### DIFF
--- a/domains/canarddu38.json
+++ b/domains/canarddu38.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "canarddu38",
+        "email": "julescanardcoin@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `canarddu38.is-a.dev` using the [dashboard](https://manage.is-a.dev).