### PR TITLE
BETA: Register arctix.is-a.dev

### DIFF
--- a/domains/arctix.json
+++ b/domains/arctix.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Sibu07",
+        "email": "sarbes60@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `arctix.is-a.dev` using the [dashboard](https://manage.is-a.dev).