### PR TITLE
BETA: Register luzivr.is-a.dev

### DIFF
--- a/domains/luzivr.json
+++ b/domains/luzivr.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "zjeffro",
+        "email": "jdvanlear@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `luzivr.is-a.dev` using the [dashboard](https://manage.is-a.dev).