### PR TITLE
BETA: Register noflare.is-a.dev

### DIFF
--- a/domains/noflare.json
+++ b/domains/noflare.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Noflare",
+        "email": "Noflare.dev@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `noflare.is-a.dev` using the [dashboard](https://manage.is-a.dev).