### PR TITLE
BETA: Register jbugel.is-a.dev

### DIFF
--- a/domains/jbugel.json
+++ b/domains/jbugel.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "jbugel-lol",
+        "email": "jbugel.lol.github@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `jbugel.is-a.dev` using the [dashboard](https://manage.is-a.dev).