### PR TITLE
BETA: Register geckopico.is-a.dev

### DIFF
--- a/domains/geckopico.json
+++ b/domains/geckopico.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "davior",
+        "email": "david.iorlano@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `geckopico.is-a.dev` using the [dashboard](https://manage.is-a.dev).