### PR TITLE
BETA: Register 70a5.is-a.dev

### DIFF
--- a/domains/70a5.json
+++ b/domains/70a5.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "70A5",
+        "email": "joas.van.der.eerden@outlook.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `70a5.is-a.dev` using the [dashboard](https://manage.is-a.dev).