### PR TITLE
BETA: Register hntr.is-a.dev

### DIFF
--- a/domains/hntr.json
+++ b/domains/hntr.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "HunterAPI",
+        "email": "forsynapse123@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `hntr.is-a.dev` using the [dashboard](https://manage.is-a.dev).