### PR TITLE
BETA: Register sinomor.is-a.dev

### DIFF
--- a/domains/sinomor.json
+++ b/domains/sinomor.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Sinomor",
+        "email": "navifull7@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `sinomor.is-a.dev` using the [dashboard](https://manage.is-a.dev).