### PR TITLE
BETA: Register noah.is-a.dev

### DIFF
--- a/domains/noah.json
+++ b/domains/noah.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NoahPrm",
+        "email": "noah.parmentier@icloud.com"
+    },
+    "record": {
+        "A": ["185.143.241.106"]
+    }
+}


### PR DESCRIPTION
Added `noah.is-a.dev` using the [dashboard](https://manage.is-a.dev).