### PR TITLE
BETA: Register noobdi.is-a.dev

### DIFF
--- a/domains/noobdi.json
+++ b/domains/noobdi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MatrixCoder001",
+        "email": "ngsidbro@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/matrixcoder0101/gss-botwa"
+    }
+}


### PR DESCRIPTION
Added `noobdi.is-a.dev` using the [dashboard](https://manage.is-a.dev).