### PR TITLE
BETA: Register bruhx.is-a.dev

### DIFF
--- a/domains/bruhx.json
+++ b/domains/bruhx.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Bruhxz54",
+        "email": "pollyx73@gmail.com"
+    },
+    "record": {
+        "URL": "https://hypertabs-2.yosgardamian1.repl.co/"
+    }
+}


### PR DESCRIPTION
Added `bruhx.is-a.dev` using the [dashboard](https://manage.is-a.dev).