### PR TITLE
BETA: Register ap.sami.is-a.dev

### DIFF
--- a/domains/ap.sami.json
+++ b/domains/ap.sami.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "obstructed",
+        "email": "scamstur@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `ap.sami.is-a.dev` using the [dashboard](https://manage.is-a.dev).