### PR TITLE
BETA: Register gapindang.is-a.dev

### DIFF
--- a/domains/gapindang.json
+++ b/domains/gapindang.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "pindang-cloud",
+        "email": "gavinku890@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `gapindang.is-a.dev` using the [dashboard](https://manage.is-a.dev).