### PR TITLE
BETA: Register gaetanodev.is-a.dev

### DIFF
--- a/domains/gaetanodev.json
+++ b/domains/gaetanodev.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "GaetanoDEV",
+        "email": "gaetanocastaldo00@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `gaetanodev.is-a.dev` using the [dashboard](https://manage.is-a.dev).