### PR TITLE
BETA: Register kresswell.is-a.dev

### DIFF
--- a/domains/kresswell.json
+++ b/domains/kresswell.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Kresswell",
+        "email": "simonecresswell@outlook.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `kresswell.is-a.dev` using the [dashboard](https://manage.is-a.dev).