### PR TITLE
BETA: Register zhougonglai.is-a.dev

### DIFF
--- a/domains/zhougonglai.json
+++ b/domains/zhougonglai.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "zhougonglai",
+        "email": "838048635@qq.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `zhougonglai.is-a.dev` using the [dashboard](https://manage.is-a.dev).