### PR TITLE
BETA: Register adev.is-a.dev

### DIFF
--- a/domains/adev.json
+++ b/domains/adev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Xpki",
+        "email": "hackerboi8900@gmail.com"
+    },
+    "record": {
+        "CNAME": "bro"
+    }
+}


### PR DESCRIPTION
Added `adev.is-a.dev` using the [dashboard](https://manage.is-a.dev).