### PR TITLE
BETA: Register filo.is-a.dev

### DIFF
--- a/domains/filo.json
+++ b/domains/filo.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Filo6699",
+        "email": "karka2-6@rambler.ru"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `filo.is-a.dev` using the [dashboard](https://manage.is-a.dev).