### PR TITLE
BETA: Register buc.is-a.dev

### DIFF
--- a/domains/buc.json
+++ b/domains/buc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AtlasL1",
+        "email": "loxingle1@gmail.com"
+    },
+    "record": {
+        "TXT": "c78bc18dc07ede858c2f852c59f6bb"
+    }
+}


### PR DESCRIPTION
Added `buc.is-a.dev` using the [dashboard](https://manage.is-a.dev).