### PR TITLE
BETA: Register adev.is-a.dev

### DIFF
--- a/domains/adev.json
+++ b/domains/adev.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "NotJack173",
+        "email": "NotJack137@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `adev.is-a.dev` using the [dashboard](https://manage.is-a.dev).