### PR TITLE
BETA: Register kainer.is-a.dev

### DIFF
--- a/domains/kainer.json
+++ b/domains/kainer.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "ue5377",
+        "email": "kai.ner.h13r@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `kainer.is-a.dev` using the [dashboard](https://manage.is-a.dev).