### PR TITLE
BETA: Register mediasoup-sfu.is-a.dev

### DIFF
--- a/domains/mediasoup-sfu.json
+++ b/domains/mediasoup-sfu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vocaotri",
+        "email": "vocaotri789@gmail.com"
+    },
+    "record": {
+        "CNAME": "asdasd"
+    }
+}


### PR DESCRIPTION
Added `mediasoup-sfu.is-a.dev` using the [dashboard](https://manage.is-a.dev).