### PR TITLE
BETA: Register jumanji.is-a.dev

### DIFF
--- a/domains/jumanji.json
+++ b/domains/jumanji.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "heyjumanji",
+        "email": "madhuchutiya.unhinge650@silomails.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `jumanji.is-a.dev` using the [dashboard](https://manage.is-a.dev).