### PR TITLE
BETA: Register forgetful.is-a.dev

### DIFF
--- a/domains/forgetful.json
+++ b/domains/forgetful.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "forgetfulskybro",
+        "email": "forgetfulskybro9@gmail.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=forgetful.is-a.dev,73b39d14384af5b55397"
+    }
+}


### PR DESCRIPTION
Added `forgetful.is-a.dev` using the [dashboard](https://manage.is-a.dev).