### PR TITLE
BETA: Register devhub.is-a.dev

### DIFF
--- a/domains/devhub.json
+++ b/domains/devhub.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "justDarian",
+        "email": "Darian.mohaseb@gmail.com"
+    },
+    "record": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Added `devhub.is-a.dev` using the [dashboard](https://manage.is-a.dev).