### PR TITLE
BETA: Register optidium.is-a.dev

### DIFF
--- a/domains/optidium.json
+++ b/domains/optidium.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "XMODERLIVE",
+        "email": "majumdernupur888@gmail.com"
+    },
+    "record": {
+        "CNAME": "xmoderlive.github.io"
+    }
+}


### PR DESCRIPTION
Added `optidium.is-a.dev` using the [dashboard](https://manage.is-a.dev).