### PR TITLE
BETA: Register borna.is-a.dev

### DIFF
--- a/domains/borna.json
+++ b/domains/borna.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "boki01",
+        "email": "boki.stefan2008@gmail.com"
+    },
+    "record": {
+        "CNAME": "boki01.github.io"
+    }
+}


### PR DESCRIPTION
Added `borna.is-a.dev` using the [dashboard](https://manage.is-a.dev).