### PR TITLE
BETA: Register l7neg.is-a.dev

### DIFF
--- a/domains/l7neg.json
+++ b/domains/l7neg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "L7NEG",
+        "email": "mahmodealking467@gmail.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=l7neg.is-a.dev,ae34d7e99e82dc28368c"
+    }
+}


### PR DESCRIPTION
Added `l7neg.is-a.dev` using the [dashboard](https://manage.is-a.dev).