### PR TITLE
BETA: Register dantae.is-a.dev

### DIFF
--- a/domains/dantae.json
+++ b/domains/dantae.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Thedogecraft",
+        "email": "dantaealt@gmail.com"
+    },
+    "record": {
+        "CNAME": "nativegames.net"
+    }
+}


### PR DESCRIPTION
Added `dantae.is-a.dev` using the [dashboard](https://manage.is-a.dev).