### PR TITLE
BETA: Register zhxck.is-a.dev

### DIFF
--- a/domains/zhxck.json
+++ b/domains/zhxck.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "zh4ck",
+        "email": "zhacxk@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `zhxck.is-a.dev` using the [dashboard](https://manage.is-a.dev).