### PR TITLE
BETA: Register b5i.is-a.dev

### DIFF
--- a/domains/b5i.json
+++ b/domains/b5i.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "b5i",
+        "email": "bollengier.antoine@icloud.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `b5i.is-a.dev` using the [dashboard](https://manage.is-a.dev).