### PR TITLE
BETA: Register 21z.is-a.dev

### DIFF
--- a/domains/21z.json
+++ b/domains/21z.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "21Z",
+        "email": "hamdankalliyil@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `21z.is-a.dev` using the [dashboard](https://manage.is-a.dev).