### PR TITLE
BETA: Register seizedforge.is-a.dev

### DIFF
--- a/domains/seizedforge.json
+++ b/domains/seizedforge.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "GamebringerDev",
+        "email": "gamebringerdev@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `seizedforge.is-a.dev` using the [dashboard](https://manage.is-a.dev).