### PR TITLE
BETA: Register rebokdev.is-a.dev

### DIFF
--- a/domains/rebokdev.json
+++ b/domains/rebokdev.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "rebokdev",
+        "email": "rebok@duck.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `rebokdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).