### PR TITLE
BETA: Register orange.is-a.dev

### DIFF
--- a/domains/orange.json
+++ b/domains/orange.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "sahmed011",
+        "email": "sufyanmishal@gmail.com"
+    },
+    "record": {
+        "TXT": "dh=7e7e671a8b44d02fde9ab6f6df7baf94086c96fd"
+    }
+}


### PR DESCRIPTION
Added `orange.is-a.dev` using the [dashboard](https://manage.is-a.dev).