### PR TITLE
BETA: Register radsteve.is-a.dev

### DIFF
--- a/domains/radsteve.json
+++ b/domains/radsteve.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "radstevee",
+        "email": "radsteve@radsteve.net"
+    },
+    "record": {
+        "A": ["2.205.42.22"]
+    }
+}


### PR DESCRIPTION
Added `radsteve.is-a.dev` using the [dashboard](https://manage.is-a.dev).