### PR TITLE
BETA: Register marcel.kitzbichler.is-a.dev

### DIFF
--- a/domains/marcel.kitzbichler.json
+++ b/domains/marcel.kitzbichler.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Marcel-Kitzbichler",
+        "email": "marcel.kitzbichler@gmail.com"
+    },
+    "record": {
+        "CNAME": "marcel.kitzbichler.tirol"
+    }
+}


### PR DESCRIPTION
Added `marcel.kitzbichler.is-a.dev` using the [dashboard](https://manage.is-a.dev).