### PR TITLE
BETA: Register taskforce.is-a.dev

### DIFF
--- a/domains/taskforce.json
+++ b/domains/taskforce.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Diablo2009",
+        "email": "wettsteintalon9@gmail.com"
+    },
+    "record": {
+        "CNAME": "diablo2009.github.io"
+    }
+}


### PR DESCRIPTION
Added `taskforce.is-a.dev` using the [dashboard](https://manage.is-a.dev).