### PR TITLE
BETA: Register intel-playz.is-a.dev

### DIFF
--- a/domains/intel-playz.json
+++ b/domains/intel-playz.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "IntelPlayZ-1337",
+        "email": "Intel-PlayZ.1337@proton.me"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `intel-playz.is-a.dev` using the [dashboard](https://manage.is-a.dev).