### PR TITLE
BETA: Register valdemar.is-a.dev

### DIFF
--- a/domains/valdemar.json
+++ b/domains/valdemar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "valdemar-dev",
+        "email": "graveyarddev@proton.me"
+    },
+    "record": {
+        "CNAME": "vladdydaddy.vercel.app"
+    }
+}


### PR DESCRIPTION
Added `valdemar.is-a.dev` using the [dashboard](https://manage.is-a.dev).