### PR TITLE
BETA: Register rum1ka.is-a.dev

### DIFF
--- a/domains/rum1ka.json
+++ b/domains/rum1ka.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "prpjzz",
+        "email": "groovemusic4399@pm.me"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `rum1ka.is-a.dev` using the [dashboard](https://manage.is-a.dev).