### PR TITLE
BETA: Register phthallo.is-a.dev

### DIFF
--- a/domains/phthallo.json
+++ b/domains/phthallo.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "phthallo",
+        "email": "annabel.quach@gihs.sa.edu.au"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `phthallo.is-a.dev` using the [dashboard](https://manage.is-a.dev).