### PR TITLE
BETA: Register pawix.is-a.dev

### DIFF
--- a/domains/pawix.json
+++ b/domains/pawix.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "PawiX25",
+        "email": "wyrebakpawel@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `pawix.is-a.dev` using the [dashboard](https://manage.is-a.dev).