### PR TITLE
BETA: Register fumi.is-a.dev

### DIFF
--- a/domains/fumi.json
+++ b/domains/fumi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MrTakedi",
+        "email": "tristankirbehbuller@gmail.com"
+    },
+    "record": {
+        "URL": "https://social.vivaldi.net/@kirbeh"
+    }
+}

--- a/domains/kirbeh.json
+++ b/domains/kirbeh.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MrTakedi",
+        "email": "tristankirbehbuller@gmail.com"
+    },
+    "record": {
+        "URL": "https://social.vivaldi.net/@kirbeh"
+    }
+}


### PR DESCRIPTION
Added `fumi.is-a.dev` using the [dashboard](https://manage.is-a.dev).