### PR TITLE
BETA: Register nqdev.is-a.dev

### DIFF
--- a/domains/nqdev.json
+++ b/domains/nqdev.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "nguyenquy0710",
+        "email": "nguyenquy.1096@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `nqdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).