### PR TITLE
BETA: Register leogoetz.is-a.dev

### DIFF
--- a/domains/leogoetz.json
+++ b/domains/leogoetz.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "vLeov",
+        "email": "leo.goetz2008@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `leogoetz.is-a.dev` using the [dashboard](https://manage.is-a.dev).