### PR TITLE
BETA: Register parovoz.is-a.dev

### DIFF
--- a/domains/parovoz.json
+++ b/domains/parovoz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "parov0z",
+        "email": "andrey.android7890@mail.ru"
+    },
+    "record": {
+        "CNAME": "parovoz.tw1.ru"
+    }
+}


### PR DESCRIPTION
Added `parovoz.is-a.dev` using the [dashboard](https://manage.is-a.dev).