### PR TITLE
BETA: Register neuron.is-a.dev

### DIFF
--- a/domains/neuron.json
+++ b/domains/neuron.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "wooga123",
+        "email": "torinnn28@outlook.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `neuron.is-a.dev` using the [dashboard](https://manage.is-a.dev).