### PR TITLE
BETA: Register tinergy.is-a.dev

### DIFF
--- a/domains/tinergy.json
+++ b/domains/tinergy.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Tinergy",
+        "email": "goh_z@live.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `tinergy.is-a.dev` using the [dashboard](https://manage.is-a.dev).