### PR TITLE
BETA: Register defalco64.is-a.dev

### DIFF
--- a/domains/defalco64.json
+++ b/domains/defalco64.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "aadarshKsingh",
+        "email": "aadarshkumarsingh198@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `defalco64.is-a.dev` using the [dashboard](https://manage.is-a.dev).