### PR TITLE
BETA: Register dnoxl.is-a.dev

### DIFF
--- a/domains/dnoxl.json
+++ b/domains/dnoxl.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Dnoxl",
+        "email": "ifbimgamer@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `dnoxl.is-a.dev` using the [dashboard](https://manage.is-a.dev).