### PR TITLE
BETA: Register harrystudy.is-a.dev

### DIFF
--- a/domains/harrystudy.json
+++ b/domains/harrystudy.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "hongglong",
+        "email": "dylanluong3@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}

--- a/domains/harrythenegro.json
+++ b/domains/harrythenegro.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "hongglong",
+        "email": "dylanluong3@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `harrystudy.is-a.dev` using the [dashboard](https://manage.is-a.dev).