### PR TITLE
BETA: Register fariz.is-a.dev

### DIFF
--- a/domains/fariz.json
+++ b/domains/fariz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "farizrifqi",
+        "email": "farizrifqi26@gmail.com"
+    },
+    "record": {
+        "CNAME": "funny-banoffee-bda4cb.netlify.app"
+    }
+}


### PR DESCRIPTION
Added `fariz.is-a.dev` using the [dashboard](https://manage.is-a.dev).