### PR TITLE
BETA: Register halokod.is-a.dev

### DIFF
--- a/domains/halokod.json
+++ b/domains/halokod.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "denizkuzey06",
+        "email": "kralpasa1993@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `halokod.is-a.dev` using the [dashboard](https://manage.is-a.dev).