### PR TITLE
BETA: Register eacbypasser.is-a.dev

### DIFF
--- a/domains/eacbypasser.json
+++ b/domains/eacbypasser.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "EacBypasser",
+        "email": "tyroxtech@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `eacbypasser.is-a.dev` using the [dashboard](https://manage.is-a.dev).