### PR TITLE
BETA: Register yuzuki.is-a.dev

### DIFF
--- a/domains/yuzuki.json
+++ b/domains/yuzuki.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "SuzukiYuzuki",
+        "email": "hotococoa104@gmail.com"
+    },
+    "record": {
+        "CNAME": "suzukiyuzuki.github.io"
+    }
+}


### PR DESCRIPTION
Added `yuzuki.is-a.dev` using the [dashboard](https://manage.is-a.dev).