### PR TITLE
BETA: Register koopa.is-a.dev

### DIFF
--- a/domains/koopa.json
+++ b/domains/koopa.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "KoopaCode",
+        "email": "AndrewLife92@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}

--- a/domains/koopacode.json
+++ b/domains/koopacode.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "KoopaCode",
+        "email": "AndrewLife92@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `koopa.is-a.dev` using the [dashboard](https://manage.is-a.dev).