### PR TITLE
BETA: Register nobody.is-a.dev

### DIFF
--- a/domains/nobody.json
+++ b/domains/nobody.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "mr-adrien",
+        "email": "adrienansari@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `nobody.is-a.dev` using the [dashboard](https://manage.is-a.dev).