### PR TITLE
BETA: Register notzsfell.is-a.dev

### DIFF
--- a/domains/notzsfell.json
+++ b/domains/notzsfell.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "zsfell",
+        "email": "felinzkvic@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `notzsfell.is-a.dev` using the [dashboard](https://manage.is-a.dev).