### PR TITLE
BETA: Register jams.is-a.dev

### DIFF
--- a/domains/jams.json
+++ b/domains/jams.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "g1gabyteDEV",
+        "email": "jamesmarke7@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `jams.is-a.dev` using the [dashboard](https://manage.is-a.dev).