### PR TITLE
BETA: Register raystatic.is-a.dev

### DIFF
--- a/domains/rahul.ray.json
+++ b/domains/rahul.ray.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "raystatic",
+        "email": "rahul9650ray@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}

--- a/domains/rahulray.json
+++ b/domains/rahulray.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "raystatic",
+        "email": "rahul9650ray@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}

--- a/domains/raystatic.json
+++ b/domains/raystatic.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "raystatic",
+        "email": "rahul9650ray@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `raystatic.is-a.dev` using the [dashboard](https://manage.is-a.dev).