### PR TITLE
BETA: Register maceng.is-a.dev

### DIFF
--- a/domains/maceng.json
+++ b/domains/maceng.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "MacengBOT",
+        "email": "macengbot@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `maceng.is-a.dev` using the [dashboard](https://manage.is-a.dev).