### PR TITLE
BETA: Register noicemath.is-a.dev

### DIFF
--- a/domains/noicemath.json
+++ b/domains/noicemath.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "andydrew727",
+        "email": "0793620@student.osceolaschools.net"
+    },
+    "record": {
+        "URL": "https://theniceman.netlify.app/"
+    }
+}


### PR DESCRIPTION
Added `noicemath.is-a.dev` using the [dashboard](https://manage.is-a.dev).