### PR TITLE
BETA: Register parpok.is-a.dev

### DIFF
--- a/domains/parpok.json
+++ b/domains/parpok.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "parpok",
+        "email": "patrykpucilowski40@gmail.com"
+    },
+    "record": {
+        "CNAME": "parpok.xyz"
+    }
+}


### PR DESCRIPTION
Added `parpok.is-a.dev` using the [dashboard](https://manage.is-a.dev).