### PR TITLE
BETA: Register apa.is-a.dev

### DIFF
--- a/domains/apa.json
+++ b/domains/apa.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "eyesmad",
+        "email": "eagam0002@mymail.lausd.net"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `apa.is-a.dev` using the [dashboard](https://manage.is-a.dev).