### PR TITLE
BETA: Register repressoh.is-a.dev

### DIFF
--- a/domains/repressoh.json
+++ b/domains/repressoh.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Repressoh",
+        "email": "casealby@protonmail.com"
+    },
+    "record": {
+        "CNAME": "repressoh.github.io"
+    }
+}


### PR DESCRIPTION
Added `repressoh.is-a.dev` using the [dashboard](https://manage.is-a.dev).