### PR TITLE
BETA: Register aware.is-a.dev

### DIFF
--- a/domains/aware.json
+++ b/domains/aware.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "AngerminecraftYT",
+        "email": "david.boltong@icloud.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `aware.is-a.dev` using the [dashboard](https://manage.is-a.dev).