### PR TITLE
BETA: Register ghalibcraft.is-a.dev

### DIFF
--- a/domains/ghalibcraft.json
+++ b/domains/ghalibcraft.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Ghalib-craftLeProgrammeur",
+        "email": "ghalibmezeghiche2012@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `ghalibcraft.is-a.dev` using the [dashboard](https://manage.is-a.dev).