### PR TITLE
BETA: Register lori28167.is-a.dev

### DIFF
--- a/domains/lori28167.json
+++ b/domains/lori28167.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "lori28167",
+        "email": "lorenzo.cozzaglio@outlook.it"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `lori28167.is-a.dev` using the [dashboard](https://manage.is-a.dev).