### PR TITLE
BETA: Register jupie.is-a.dev

### DIFF
--- a/domains/jupie.json
+++ b/domains/jupie.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Jupiee",
+        "email": "mzkplayz1@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `jupie.is-a.dev` using the [dashboard](https://manage.is-a.dev).