### PR TITLE
BETA: Register spaace.is-a.dev

### DIFF
--- a/domains/spaace.json
+++ b/domains/spaace.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Spaace-Save",
+        "email": "coelhoaiden@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `spaace.is-a.dev` using the [dashboard](https://manage.is-a.dev).