### PR TITLE
BETA: Register b6ck.is-a.dev

### DIFF
--- a/domains/allah.json
+++ b/domains/allah.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lorcadev",
+        "email": "lorcadeveloper@gmail.com"
+    },
+    "record": {
+        "URL": "https://repulsivereflectinglist.elitemods.repl.co"
+    }
+}

--- a/domains/b6ck.json
+++ b/domains/b6ck.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lorcadev",
+        "email": "lorcadeveloper@gmail.com"
+    },
+    "record": {
+        "CNAME": "6bf00940-7caf-4236-b26b-a6bd428ecd20.id.repl.co"
+    }
+}


### PR DESCRIPTION
Added `b6ck.is-a.dev` using the [dashboard](https://manage.is-a.dev).