### PR TITLE
BETA: Register lorimc.is-a.dev

### DIFF
--- a/domains/lorimc.json
+++ b/domains/lorimc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lori28167",
+        "email": "lorenzo.cozzaglio@outlook.it"
+    },
+    "record": {
+        "URL": "sandstone.falix.gg"
+    }
+}


### PR DESCRIPTION
Added `lorimc.is-a.dev` using the [dashboard](https://manage.is-a.dev).