### PR TITLE
BETA: Register kurokami.is-a.dev

### DIFF
--- a/domains/kurokami.json
+++ b/domains/kurokami.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "k3rokami",
+        "email": "honghongleong2@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `kurokami.is-a.dev` using the [dashboard](https://manage.is-a.dev).