### PR TITLE
BETA: Register koru.is-a.dev

### DIFF
--- a/domains/koru.json
+++ b/domains/koru.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "justkorudev",
+        "email": "popetopotolo@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `koru.is-a.dev` using the [dashboard](https://manage.is-a.dev).