### PR TITLE
BETA: Register yacineboussoufa.is-a.dev

### DIFF
--- a/domains/yacineboussoufa.json
+++ b/domains/yacineboussoufa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "YacineBoussoufa",
+        "email": "yacine.boussoufa.yb@gmail.com"
+    },
+    "record": {
+        "CNAME": "yacineboussoufa.it.eu.org"
+    }
+}


### PR DESCRIPTION
Added `yacineboussoufa.is-a.dev` using the [dashboard](https://manage.is-a.dev).