### PR TITLE
BETA: Register dgyt.is-a.dev

### DIFF
--- a/domains/dgyt.json
+++ b/domains/dgyt.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BedrockBandaYT",
+        "email": "cshaily38@outlook.com"
+    },
+    "record": {
+        "URL": "zerotwo.42web.io"
+    }
+}


### PR DESCRIPTION
Added `dgyt.is-a.dev` using the [dashboard](https://manage.is-a.dev).