### PR TITLE
BETA: Register dgyt.is-a.dev

### DIFF
--- a/domains/dgyt.json
+++ b/domains/dgyt.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dgyt0007",
+        "email": "gamershaily@yandex.com"
+    },
+    "record": {
+        "TXT": "dfbbc7b469577e76e2c4a867d7d2ce"
+    }
+}


### PR DESCRIPTION
Added `dgyt.is-a.dev` using the [dashboard](https://manage.is-a.dev).