### PR TITLE
BETA: Register woxdev.is-a.dev

### DIFF
--- a/domains/woxdev.json
+++ b/domains/woxdev.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "WoxDev",
+        "email": "januardhodicky06@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `woxdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).