### PR TITLE
BETA: Register phantomdev.is-a.dev

### DIFF
--- a/domains/phantomdev.json
+++ b/domains/phantomdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "siddddss",
+        "email": "discordacoforsid@gmail.com"
+    },
+    "record": {
+        "A": ["129.213.82.186"]
+    }
+}


### PR DESCRIPTION
Added `phantomdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).