### PR TITLE
BETA: Register deadcode.is-a.dev

### DIFF
--- a/domains/deadcode.json
+++ b/domains/deadcode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RichardKanshen",
+        "email": "djmaker@centrum.sk"
+    },
+    "record": {
+        "CNAME": "deadcodegames.github.io"
+    }
+}

--- a/domains/deadcode.json
+++ b/domains/deadcode.json
@@ -1,7 +1,7 @@
 {
     "owner": {
         "username": "RichardKanshen",
-        "email": "djmaker@centrum.sk"
+        "email": "richard@kanshen.click"
     },
     "record": {
         "CNAME": "deadcodegames.github.io"


### PR DESCRIPTION
Added `deadcode.is-a.dev` using the [dashboard](https://manage.is-a.dev).