### PR TITLE
BETA: Register chasecraft.is-a.dev

### DIFF
--- a/domains/chasecraft.json
+++ b/domains/chasecraft.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "chasecraft88",
+        "email": "chase88gizmo@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `chasecraft.is-a.dev` using the [dashboard](https://manage.is-a.dev).