### PR TITLE
BETA: Register hellscaped.is-a.dev

### DIFF
--- a/domains/hellscaped.json
+++ b/domains/hellscaped.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Hellscaped",
+        "email": "tappsyo@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `hellscaped.is-a.dev` using the [dashboard](https://manage.is-a.dev).