### PR TITLE
BETA: Register shad.is-a.dev

### DIFF
--- a/domains/shad.json
+++ b/domains/shad.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Maverick00001",
+        "email": "saksham.access@yahoo.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=shad.is-a.dev,7e07cc57fb499d83d301"
+    }
+}


### PR DESCRIPTION
Added `shad.is-a.dev` using the [dashboard](https://manage.is-a.dev).