### PR TITLE
BETA: Register shad.is-a.dev

### DIFF
--- a/domains/shad.json
+++ b/domains/shad.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Maverick00001",
+        "email": "saksham.access@yahoo.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `shad.is-a.dev` using the [dashboard](https://manage.is-a.dev).