### PR TITLE
BETA: Register wolflangtw.is-a.dev

### DIFF
--- a/domains/wolflangtw.json
+++ b/domains/wolflangtw.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "wolflangtw",
+        "email": "wolflang.channel@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `wolflangtw.is-a.dev` using the [dashboard](https://manage.is-a.dev).