### PR TITLE
BETA: Register goobric.is-a.dev

### DIFF
--- a/domains/goobric.json
+++ b/domains/goobric.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "goobric",
+        "email": "goobric@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `goobric.is-a.dev` using the [dashboard](https://manage.is-a.dev).