### PR TITLE
BETA: Register mathzds.is-a.dev

### DIFF
--- a/domains/mathzds.json
+++ b/domains/mathzds.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mathzds",
+        "email": "pedrofilhodev@gmail.com"
+    },
+    "record": {
+        "URL": "mathzds.vercel.app/"
+    }
+}


### PR DESCRIPTION
Added `mathzds.is-a.dev` using the [dashboard](https://manage.is-a.dev).