### PR TITLE
BETA: Register unixtz.is-a.dev

### DIFF
--- a/domains/unixtz.json
+++ b/domains/unixtz.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "Iamunix",
+        "email": "abdulhaulerashid@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `unixtz.is-a.dev` using the [dashboard](https://manage.is-a.dev).