### PR TITLE
BETA: Register spike.is-a.dev

### DIFF
--- a/domains/spike.json
+++ b/domains/spike.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "superspike7",
+        "email": "spikevinz@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `spike.is-a.dev` using the [dashboard](https://manage.is-a.dev).