### PR TITLE
BETA: Register slag.is-a.dev

### DIFF
--- a/domains/share.nazi.json
+++ b/domains/share.nazi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HoaQuyingVN",
+        "email": "phu.hoa.dp@gmail.com"
+    },
+    "record": {
+        "CNAME": "70bfd18f-3803-484f-aa67-668867ecbac1.id.repl.co"
+    }
+}

--- a/domains/slag.json
+++ b/domains/slag.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HoaQuyingVN",
+        "email": "phu.hoa.dp@gmail.com"
+    },
+    "record": {
+        "TXT": "replit-verify=8380e029-9159-4779-b0de-40628d3b1a1b"
+    }
+}


### PR DESCRIPTION
Added `slag.is-a.dev` using the [dashboard](https://manage.is-a.dev).