### PR TITLE
BETA: Register baptiste.is-a.dev

### DIFF
--- a/domains/baptiste.json
+++ b/domains/baptiste.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "BapRx",
+        "email": "rouxbaptiste@outlook.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `baptiste.is-a.dev` using the [dashboard](https://manage.is-a.dev).