### PR TITLE
Add GitHub Pages verification for devon.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-D-Pow.devon.json
+++ b/domains/_github-pages-challenge-D-Pow.devon.json
@@ -1,0 +1,10 @@
+{
+    "description": "GitHub Pages verification for devon.is-a.dev",
+    "owner": {
+        "username": "D-Pow",
+        "email": "D-Pow@users.noreply.github.com"
+    },
+    "record": {
+        "TXT": "cec54b510828f770750c1b17cad7f2"
+    }
+}

--- a/domains/devon.json
+++ b/domains/devon.json
@@ -3,7 +3,7 @@
     "repo": "https://github.com/D-Pow/d-pow.github.io",
     "owner": {
         "username": "D-Pow",
-        "email": "dpow9373@gmail.com"
+        "email": "D-Pow@users.noreply.github.com"
     },
     "record": {
         "CNAME": "d-pow.github.io"


### PR DESCRIPTION
## Website Link/Preview
[https://d-pow.github.io](https://d-pow.github.io)

The page has been active for a while, but GitHub just recently requested verification of the domain name.