### PR TITLE
BETA: Register endouven.is-a.dev

### DIFF
--- a/domains/endouven.json
+++ b/domains/endouven.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "endouven",
+        "email": "brunophm@gmail.com"
+    },
+    "record": {
+        "CNAME": "endouven.github.io"
+    }
+}


### PR DESCRIPTION
Added `endouven.is-a.dev` using the [dashboard](https://manage.is-a.dev).