### PR TITLE
BETA: Register adioblu.is-a.dev

### DIFF
--- a/domains/adioblu.json
+++ b/domains/adioblu.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "adyoblu",
+        "email": "adyoblu2000@yahoo.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `adioblu.is-a.dev` using the [dashboard](https://manage.is-a.dev).