### PR TITLE
BETA: Register google-raw.is-a.dev

### DIFF
--- a/domains/google-raw.json
+++ b/domains/google-raw.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "B8IHVBNUNJ12",
+        "email": "numn6943@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `google-raw.is-a.dev` using the [dashboard](https://manage.is-a.dev).