### PR TITLE
BETA: Register marioannier.is-a.dev

### DIFF
--- a/domains/marioannier.json
+++ b/domains/marioannier.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "marioannier",
+        "email": "mario.annier@gmail.com"
+    },
+    "record": {
+        "CNAME": "marioannier.github.io"
+    }
+}


### PR DESCRIPTION
Added `marioannier.is-a.dev` using the [dashboard](https://manage.is-a.dev).