### PR TITLE
BETA: Register blockbreaker.is-a.dev

### DIFF
--- a/domains/blockbreaker.json
+++ b/domains/blockbreaker.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TheBlockbreaker",
+        "email": "burstsgodly@gmail.com"
+    },
+    "record": {
+        "TXT": "did=did:plc:agavl34uosnej4h54haas6aj"
+    }
+}


### PR DESCRIPTION
Added `blockbreaker.is-a.dev` using the [dashboard](https://manage.is-a.dev).