### PR TITLE
BETA: Register xenapp.is-a.dev

### DIFF
--- a/domains/xenapp.json
+++ b/domains/xenapp.json
@@ -4,6 +4,6 @@
         "email": "wienerwolf77@gmail.com"
     },
     "record": {
-        "TXT": "e8ervtqg_bno4xnob40f7rgseijrvp72jkhd-siwl0o"
+        "CNAME": "joysteem.web.app"
     }
 }

--- a/domains/xenapp.json
+++ b/domains/xenapp.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "techsideofficial",
+        "email": "wienerwolf77@gmail.com"
+    },
+    "record": {
+        "TXT": "e8ervtqg_bno4xnob40f7rgseijrvp72jkhd-siwl0o"
+    }
+}


### PR DESCRIPTION
Added `xenapp.is-a.dev` using the [dashboard](https://manage.is-a.dev).