### PR TITLE
BETA: Register rinat.is-a.dev

### DIFF
--- a/domains/rinat.json
+++ b/domains/rinat.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "notrinat",
+        "email": "rinatbogdanovthebest@gmail.com"
+    },
+    "record": {
+        "CNAME": "notrinat.github.io"
+    }
+}


### PR DESCRIPTION
Added `rinat.is-a.dev` using the [dashboard](https://manage.is-a.dev).