### PR TITLE
BETA: Register chatgpt.is-a.dev

### DIFF
--- a/domains/chatgpt.json
+++ b/domains/chatgpt.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Luongzz",
+        "email": "buivanluong0204@gmail.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=chatgpt.is-a.dev,1998eab5eb0e1ae6fe34"
+    }
+}


### PR DESCRIPTION
Added `chatgpt.is-a.dev` using the [dashboard](https://manage.is-a.dev).