### PR TITLE
BETA: Register norman.is-a.dev

### DIFF
--- a/domains/norman.json
+++ b/domains/norman.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "KNN-07",
+        "email": "trungkiennguyenkhac007@gmail.com"
+    },
+    "record": {
+        "CNAME": "knn-07.github.io"
+    }
+}


### PR DESCRIPTION
Added `norman.is-a.dev` using the [dashboard](https://manage.is-a.dev).