### PR TITLE
BETA: Register mjn.is-a.dev

### DIFF
--- a/domains/mjn.json
+++ b/domains/mjn.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mjnaous",
+        "email": "mj@naous.eu.org"
+    },
+    "record": {
+        "CNAME": "mjnaous.github.io"
+    }
+}


### PR DESCRIPTION
Added `mjn.is-a.dev` using the [dashboard](https://manage.is-a.dev).