### PR TITLE
BETA: Register cumcord.is-a.dev

### DIFF
--- a/domains/cumcord.json
+++ b/domains/cumcord.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Caiden-P",
+        "email": "iididhejejdj@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"]
+    }
+}


### PR DESCRIPTION
Added `cumcord.is-a.dev` using the [dashboard](https://manage.is-a.dev).