### PR TITLE
BETA: Register tas33n.is-a.dev

### DIFF
--- a/domains/tas33n.json
+++ b/domains/tas33n.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tas33n",
+        "email": "tasu.legend@gmail.com"
+    },
+    "record": {
+        "CNAME": "tas33n.github.io"
+    }
+}


### PR DESCRIPTION
Added `tas33n.is-a.dev` using the [dashboard](https://manage.is-a.dev).