### PR TITLE
Update 37cut.is-a.dev

### DIFF
--- a/domains/37cut.json
+++ b/domains/37cut.json
@@ -1,11 +1,11 @@
 {
-    "description": "Personal Website",
-    "repo": "https://github.com/37cut/37cut.github.io",
     "owner": {
         "username": "37cut",
         "email": "cutt37@outlook.com"
     },
     "record": {
-        "CNAME": "37cut.github.io"
+        "A": ["217.174.245.249"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
     }
 }


### PR DESCRIPTION
Updated `37cut.is-a.dev` using the [dashboard](https://manage.is-a.dev).