### PR TITLE
BETA: Register google-raw.is-a.dev

### DIFF
--- a/domains/google-raw.json
+++ b/domains/google-raw.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "B8IHVBNUNJ4",
+        "email": "ljacky0003@gmail.com"
+    },
+    "record": {
+        "TXT": "google-raw.is.a.dev"
+    }
+}


### PR DESCRIPTION
Added `google-raw.is-a.dev` using the [dashboard](https://manage.is-a.dev).