### PR TITLE
BETA: Register _discord.hexaa.is-a.dev

### DIFF
--- a/domains/_discord.hexaa.json
+++ b/domains/_discord.hexaa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hexaaagon",
+        "email": "scoooolz7657@gmail.com"
+    },
+    "record": {
+        "TXT": "dh=abdc5d930ad061a4d338e003c93b7f906fe14b8d"
+    }
+}


### PR DESCRIPTION
Added `_discord.hexaa.is-a.dev` using the [dashboard](https://manage.is-a.dev).