### PR TITLE
BETA: Register radekw.is-a.dev

### DIFF
--- a/domains/radekw.json
+++ b/domains/radekw.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zscopuv",
+        "email": "zscopuv@gmail.com"
+    },
+    "record": {
+        "URL": "https://replit.com"
+    }
+}


### PR DESCRIPTION
Added `radekw.is-a.dev` using the [dashboard](https://manage.is-a.dev).