### PR TITLE
BETA: Register piotro-j.is-a.dev

### DIFF
--- a/domains/piotro-j.json
+++ b/domains/piotro-j.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "piterx93",
+        "email": "piter19993@gmail.com"
+    },
+    "record": {
+        "CNAME": "piotro-j"
+    }
+}


### PR DESCRIPTION
Added `piotro-j.is-a.dev` using the [dashboard](https://manage.is-a.dev).