### PR TITLE
fix(domain): _github-pages-challenge-mackrz.mackrz.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-mackrz.mackrz.json
+++ b/domains/_github-pages-challenge-mackrz.mackrz.json
@@ -5,6 +5,7 @@
         "email": "macio181@gmail.com"
     },
     "record": {
-        "TXT": "5a7205dd21c68bf953f930899845d9"
+        "TXT": "5a7205dd21c68bf953f930899845d9",
+        "CNAME": "mackrz.github.io"
     }
 }


### PR DESCRIPTION
Changes due to issues from Github pages:

mackrz.is-a.dev is improperly configured
Your site's DNS settings are using a custom subdomain, mackrz.is-a.dev, that is set up as an A record. We recommend you change this to a CNAME record pointing to mackrz.github.io. For more information, see [documentation](https://docs.github.com/articles/setting-up-a-custom-domain-with-github-pages/) (InvalidARecordError).