### PR TITLE
BETA: Register zb92427382.deadcode.is-a.dev

### DIFF
--- a/discord.deadcode.json
+++ b/discord.deadcode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RichardKanshen",
+        "email": "richard@kanshen.click"
+    },
+    "record": {
+        "URL": "https://dsc.gg/deadcodegames"
+    }
+}

--- a/domains/discord.deadcode.json
+++ b/domains/discord.deadcode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RichardKanshen",
+        "email": "richard@kanshen.click"
+    },
+    "record": {
+        "URL": "dsc.gg/deadcodegames"
+    }
+}

--- a/domains/discord.deadcode.json
+++ b/domains/discord.deadcode.json
@@ -1,9 +1,0 @@
-{
-    "owner": {
-        "username": "RichardKanshen",
-        "email": "richard@kanshen.click"
-    },
-    "record": {
-        "URL": "dsc.gg/deadcodegames"
-    }
-}

--- a/domains/zb92427382.deadcode.json
+++ b/domains/zb92427382.deadcode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RichardKanshen",
+        "email": "richard@kanshen.click"
+    },
+    "record": {
+        "CNAME": "zmverify.zoho.eu"
+    }
+}


### PR DESCRIPTION
Added `zb92427382.deadcode.is-a.dev` using the [dashboard](https://manage.is-a.dev).
As a side note, this is a request for domain verification for an email address connected to [an already approved subdomain `deadcode`](https://github.com/is-a-dev/register/pull/8687). I believe email addresses are allowed here, since MX records can be requested here too, so I hope I did not do anything wrong :P