### PR TITLE
BETA: Register zenoxcloud.is-a.dev

### DIFF
--- a/domains/zenoxcloud.json
+++ b/domains/zenoxcloud.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "coolhighzzz",
+        "email": "neuralbyteshost@gmail.com"
+    },
+    "record": {
+        "A": ["188.241.54.112"]
+    }
+}


### PR DESCRIPTION
Added `zenoxcloud.is-a.dev` using the [dashboard](https://manage.is-a.dev).