### PR TITLE
BETA: Register nypd.is-a.dev

### DIFF
--- a/domains/nypd.json
+++ b/domains/nypd.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "a77-dev",
+        "email": "andbro4955@student.ccs.k12.nc.us"
+    },
+    "record": {
+        "URL": "https://feds.lol/nypd"
+    }
+}


### PR DESCRIPTION
Added `nypd.is-a.dev` using the [dashboard](https://manage.is-a.dev).