### PR TITLE
BETA: Register dtheicydragon.is-a.dev

### DIFF
--- a/domains/dtheicydragon.json
+++ b/domains/dtheicydragon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DTheIcyDragon",
+        "email": "paulnicolai.hennings@gmail.com"
+    },
+    "record": {
+        "TXT": "dtheicydragon"
+    }
+}


### PR DESCRIPTION
Added `dtheicydragon.is-a.dev` using the [dashboard](https://manage.is-a.dev).