### PR TITLE
BETA: Register moonzdev.is-a.dev

### DIFF
--- a/domains/moonzdev.json
+++ b/domains/moonzdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hymoonz",
+        "email": "bilal190620@gmail.com"
+    },
+    "record": {
+        "CNAME": "8cf3fb31-5df3-4217-b863-7d4088af08ec.id.repl.co"
+    }
+}

--- a/domains/moonzdevelopment.json
+++ b/domains/moonzdevelopment.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hymoonz",
+        "email": "bilal190620@gmail.com"
+    },
+    "record": {
+        "TXT": "replit-verify=8cf3fb31-5df3-4217-b863-7d4088af08ec"
+    }
+}


### PR DESCRIPTION
Added `moonzdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).