### PR TITLE
BETA: Register technofusiontech.is-a.dev

### DIFF
--- a/domains/technofusiontech.json
+++ b/domains/technofusiontech.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TechnoFusionTech",
+        "email": "technofusiontech@techie.com"
+    },
+    "record": {
+        "CNAME": "technofusiontech.github.io"
+    }
+}


### PR DESCRIPTION
Added `technofusiontech.is-a.dev` using the [dashboard](https://manage.is-a.dev).