### PR TITLE
BETA: Register wizq.is-a.dev

### DIFF
--- a/domains/wizq.json
+++ b/domains/wizq.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Wizqdev",
+        "email": "prajwal2079@gmail.com"
+    },
+    "record": {
+        "A": ["63.141.249.43"]
+    }
+}


### PR DESCRIPTION
Added `wizq.is-a.dev` using the [dashboard](https://manage.is-a.dev).