### PR TITLE
BETA: Register bl34ch.is-a.dev

### DIFF
--- a/domains/bl34ch.json
+++ b/domains/bl34ch.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "bl34ched",
+        "email": "bl34ach@gmail.com"
+    },
+    "record": {
+        "CNAME": "c68848fe-7af2-4cb0-9060-006b2ca8a1e4.id.repl.co"
+    }
+}


### PR DESCRIPTION
Added `bl34ch.is-a.dev` using the [dashboard](https://manage.is-a.dev).