### PR TITLE
BETA: Register conycord.is-a.dev

### DIFF
--- a/domains/conycord.json
+++ b/domains/conycord.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "stanasxd",
+        "email": "stanasarts@gmail.com"
+    },
+    "record": {
+        "CNAME": "conycord.github.io"
+    }
+}


### PR DESCRIPTION
Added `conycord.is-a.dev` using the [dashboard](https://manage.is-a.dev).