### PR TITLE
BETA: Register dunkiegaming.is-a.dev

### DIFF
--- a/domains/dunkiegaming.json
+++ b/domains/dunkiegaming.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DunkieGaming",
+        "email": "duncangabrielse9@gmail.com"
+    },
+    "record": {
+        "CNAME": "dunkiegamings.nohost.me"
+    }
+}


### PR DESCRIPTION
Added `dunkiegaming.is-a.dev` using the [dashboard](https://manage.is-a.dev).