### PR TITLE
BETA: Register enzocoquelle.is-a.dev

### DIFF
--- a/domains/enzocoquelle.json
+++ b/domains/enzocoquelle.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Zoliex",
+        "email": "enzo.coquelle06@gmail.com"
+    },
+    "record": {
+        "URL": "https://enzo-coquelle.webflow.io/"
+    }
+}


### PR DESCRIPTION
Added `enzocoquelle.is-a.dev` using the [dashboard](https://manage.is-a.dev).