### PR TITLE
BETA: Register utopia.aymo.is-a.dev

### DIFF
--- a/domains/utopia.aymo.json
+++ b/domains/utopia.aymo.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NotAymo",
+        "email": "ninecraftoff@outlook.com"
+    },
+    "record": {
+        "URL": "https://uotpia.helioho.st"
+    }
+}


### PR DESCRIPTION
Added `utopia.aymo.is-a.dev` using the [dashboard](https://manage.is-a.dev).