### PR TITLE
BETA: Register nc.is-a.dev

### DIFF
--- a/domains/nc.json
+++ b/domains/nc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NCCoder1",
+        "email": "nikhilchhawacharia@gmail.com"
+    },
+    "record": {
+        "CNAME": "celadon-meringue-aba103.netlify.app"
+    }
+}

--- a/domains/nc.json
+++ b/domains/nc.json
@@ -4,6 +4,6 @@
         "email": "nikhilchhawacharia@gmail.com"
     },
     "record": {
-        "CNAME": "celadon-meringue-aba103.netlify.app"
+        "CNAME": "nc-qc9p.onrender.com"
     }
 }


### PR DESCRIPTION
Added `nc.is-a.dev` using the [dashboard](https://manage.is-a.dev).