### PR TITLE
BETA: Register trungmystic.is-a.dev

### DIFF
--- a/domains/trungmystic.json
+++ b/domains/trungmystic.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "CNAME": "proxy.private.danbot.host"
+    }
+}


### PR DESCRIPTION
Added `trungmystic.is-a.dev` using the [dashboard](https://manage.is-a.dev).