### PR TITLE
BETA: Register programordie.is-a.dev

### DIFF
--- a/domains/programordie.json
+++ b/domains/programordie.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "programORdie2",
+        "email": "cretsnicholas@gmail.com"
+    },
+    "record": {
+        "TXT": "d23d752430f8672b45b0c1bf263488"
+    }
+}


### PR DESCRIPTION
Added `programordie.is-a.dev` using the [dashboard](https://manage.is-a.dev).