### PR TITLE
BETA: Register zb92427382.deadcode.is-a.dev

### DIFF
--- a/domains/zb92427382.deadcode.json
+++ b/domains/zb92427382.deadcode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RichardKanshen",
+        "email": "richard@kanshen.click"
+    },
+    "record": {
+        "CNAME": "zmverify.zoho.eu"
+    }
+}


### PR DESCRIPTION
Added `zb92427382.deadcode.is-a.dev` using the [dashboard](https://manage.is-a.dev).
As a side note, this is a record request regarding Zoho Mail Domain Verification - MX records are allowed, so I assume emails are okay on here.