### PR TITLE
BETA: Register sotto.is-a.dev

### DIFF
--- a/domains/sotto.json
+++ b/domains/sotto.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RaydanOMGr",
+        "email": "andreykelbler@outlook.de"
+    },
+    "record": {
+        "CNAME": "proxy.private.danbot.host"
+    }
+}


### PR DESCRIPTION
Added `sotto.is-a.dev` using the [dashboard](https://manage.is-a.dev).