### PR TITLE
BETA: Register eternalluxury.is-a.dev

### DIFF
--- a/domains/eternalluxury.json
+++ b/domains/eternalluxury.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "EternalLuxury",
+        "email": "luxurydevv@gmail.com"
+    },
+    "record": {
+        "CNAME": "shiny-marzipan-37b154.netlify.app"
+    }
+}

--- a/domains/eternalluxury.json
+++ b/domains/eternalluxury.json
@@ -4,6 +4,6 @@
         "email": "luxurydevv@gmail.com"
     },
     "record": {
-        "CNAME": "shiny-marzipan-37b154.netlify.app"
+        "URL": "https://shiny-marzipan-37b154.netlify.app"
     }
 }


### PR DESCRIPTION
Added `eternalluxury.is-a.dev` using the [dashboard](https://manage.is-a.dev).