### PR TITLE
BETA: Register lsprgabriel.is-a.dev

### DIFF
--- a/domains/lsprgabriel.json
+++ b/domains/lsprgabriel.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lsprgabriel",
+        "email": "ogabrielpereira@pm.me"
+    },
+    "record": {
+        "CNAME": "www.lsprlab.cloud"
+    }
+}


### PR DESCRIPTION
Added `lsprgabriel.is-a.dev` using the [dashboard](https://manage.is-a.dev).