### PR TITLE
BETA: Register medmh.is-a.dev

### DIFF
--- a/domains/medmh.json
+++ b/domains/medmh.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "medragneel",
+        "email": "medmystgon@gmail.com"
+    },
+    "record": {
+        "CNAME": "netlify.app"
+    }
+}


### PR DESCRIPTION
Added `medmh.is-a.dev` using the [dashboard](https://manage.is-a.dev).