### PR TITLE
Register pastebins.is-a.dev

### DIFF
--- a/domains/pastebins.json
+++ b/domains/pastebins.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "alex1028199",
+           "email": "yu1234u73f.com@gmail.com",
+           "discord": "834867471885271053"
+        },
+    
+        "record": {
+            "CNAME": "proxy.private.danbot.host"
+        }
+    }
+    


### PR DESCRIPTION
Register pastebins.is-a.dev with CNAME record pointing to proxy.private.danbot.host.