### PR TITLE
BETA: Register discord.deadcode.is-a.dev

### DIFF
--- a/domains/discord.deadcode.json
+++ b/domains/discord.deadcode.json
@@ -4,6 +4,6 @@
         "email": "richard@kanshen.click"
     },
     "record": {
-        "URL": "dsc.gg/deadcodegames"
+        "URL": "https://dsc.gg/deadcodegames"
     }
 }

--- a/domains/discord.deadcode.json
+++ b/domains/discord.deadcode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RichardKanshen",
+        "email": "richard@kanshen.click"
+    },
+    "record": {
+        "URL": "dsc.gg/deadcodegames"
+    }
+}


### PR DESCRIPTION
Added `discord.deadcode.is-a.dev` using the [dashboard](https://manage.is-a.dev).