### PR TITLE
BETA: Register nicoladen.is-a.dev

### DIFF
--- a/domains/nicoladen.json
+++ b/domains/nicoladen.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "nicoladen05",
+        "email": "nicolashartmanntaba@gmail.com"
+    },
+    "record": {
+        "CNAME": "nicoladen05.github.io"
+    }
+}


### PR DESCRIPTION
Added `nicoladen.is-a.dev` using the [dashboard](https://manage.is-a.dev).