### PR TITLE
BETA: Register nyf.is-a.dev

### DIFF
--- a/domains/nyf.json
+++ b/domains/nyf.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "user142642",
+        "email": "nayef.alkhateb2022@gmail.com"
+    },
+    "record": {
+        "CNAME": "www"
+    }
+}


### PR DESCRIPTION
Added `nyf.is-a.dev` using the [dashboard](https://manage.is-a.dev).