### PR TITLE
BETA: Register blazyflash.is-a.dev

### DIFF
--- a/domains/blazyflash.json
+++ b/domains/blazyflash.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Thanatoslayer6",
+        "email": "thanatoslayer6@gmail.com"
+    },
+    "record": {
+        "URL": "https://ballzy.vercel.app/"
+    }
+}


### PR DESCRIPTION
Added `blazyflash.is-a.dev` using the [dashboard](https://manage.is-a.dev).