### PR TITLE
BETA: Register rip.is-a.dev

### DIFF
--- a/domains/rip.json
+++ b/domains/rip.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ripples1253",
+        "email": "pearlcodes@outlook.com"
+    },
+    "record": {
+        "A": ["127.0.0.1"]
+    }
+}


### PR DESCRIPTION
Added `rip.is-a.dev` using the [dashboard](https://manage.is-a.dev).