### PR TITLE
BETA: Register snip.is-a.dev

### DIFF
--- a/domains/snip.json
+++ b/domains/snip.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "realsnipc",
+        "email": "snipc.mail@proton.me"
+    },
+    "record": {
+        "URL": "https://snipc.me"
+    }
+}


### PR DESCRIPTION
Added `snip.is-a.dev` using the [dashboard](https://manage.is-a.dev).