### PR TITLE
BETA: Register bomboclat.is-a.dev

### DIFF
--- a/domains/bomboclat.json
+++ b/domains/bomboclat.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "nebula45644",
+        "email": "reeseb1660@outlook.com"
+    },
+    "record": {
+        "CNAME": "dns.shuttleproxy.com"
+    }
+}


### PR DESCRIPTION
Added `bomboclat.is-a.dev` using the [dashboard](https://manage.is-a.dev).