### PR TITLE
Update misi.is-a.dev

### DIFF
--- a/domains/misi.json
+++ b/domains/misi.json
@@ -5,6 +5,6 @@
         "twitter": "misi"
     },
     "record": {
-        "CNAME": "misi.is-a.dev.s3-website.eu-central-1.amazonaws.com"
+        "CNAME": "d3dxnxv4oplcb1.cloudfront.net"
     }
 }


### PR DESCRIPTION
Update CNAME record for misi.is-a.dev

The domain links to my [serverless-business-card](https://github.com/suhajda3/serverless-business-card)

Hopefully HTTPS will now work. :)