### PR TITLE
BETA: Register ash.is-a.dev

### DIFF
--- a/domains/ash.json
+++ b/domains/ash.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LavishSphere",
+        "email": "ash@ashbot.work"
+    },
+    "record": {
+        "CNAME": "ashpro.netlify.app"
+    }
+}


### PR DESCRIPTION
Added `ash.is-a.dev` using the [dashboard](https://manage.is-a.dev).