### PR TITLE
BETA: Register huzaifa.is-a.dev

### DIFF
--- a/domains/huzaifa.json
+++ b/domains/huzaifa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "SyntaxErrorSolos",
+        "email": "tcs223647@gmail.com"
+    },
+    "record": {
+        "CNAME": "10"
+    }
+}


### PR DESCRIPTION
Added `huzaifa.is-a.dev` using the [dashboard](https://manage.is-a.dev).