### PR TITLE
BETA: Register apierror.is-a.dev

### DIFF
--- a/domains/apierror.json
+++ b/domains/apierror.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ApiError",
+        "email": "apihacker@proton.me"
+    },
+    "record": {
+        "CNAME": "wbe2.wb-domain.com"
+    }
+}


### PR DESCRIPTION
Added `apierror.is-a.dev` using the [dashboard](https://manage.is-a.dev).