### PR TITLE
BETA: Register twilightshock.is-a.dev

### DIFF
--- a/domains/twilightshock.json
+++ b/domains/twilightshock.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "pherngpy",
+        "email": "apipherng@gmail.com"
+    },
+    "record": {
+        "URL": "https://www.youtube.com/channel/ucocgmtbplb4jdkyqiny5qxq?sub_confirmation=1"
+    }
+}


### PR DESCRIPTION
Added `twilightshock.is-a.dev` using the [dashboard](https://manage.is-a.dev).