### PR TITLE
BETA: Register lunareclipsestudio.is-a.dev

### DIFF
--- a/domains/lunareclipsestudio.json
+++ b/domains/lunareclipsestudio.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TBNRDev",
+        "email": "svenramirez28@gmail.com"
+    },
+    "record": {
+        "CNAME": "lunareclipsestudio.github.io"
+    }
+}


### PR DESCRIPTION
Added `lunareclipsestudio.is-a.dev` using the [dashboard](https://manage.is-a.dev).