### PR TITLE
BETA: Register trung.is-a.dev

### DIFF
--- a/domains/trung.json
+++ b/domains/trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "CNAME": "proxy.private.danbot.host"
+    }
+}


### PR DESCRIPTION
Added `trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).