### PR TITLE
BETA: Register ruhs.is-a.dev

### DIFF
--- a/domains/ruhs.json
+++ b/domains/ruhs.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ruhsBB",
+        "email": "sami@fedora.email"
+    },
+    "record": {
+        "A": ["185.27.134.59"]
+    }
+}


### PR DESCRIPTION
Added `ruhs.is-a.dev` using the [dashboard](https://manage.is-a.dev).