### PR TITLE
BETA: Register shilab.is-a.dev

### DIFF
--- a/domains/shilab.json
+++ b/domains/shilab.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "Shilab66",
+        "email": "aan176972@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `shilab.is-a.dev` using the [dashboard](https://manage.is-a.dev).