### PR TITLE
BETA: Register deko.is-a.dev

### DIFF
--- a/domains/deko.json
+++ b/domains/deko.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ukrioo",
+        "email": "u8k50850@gmail.com"
+    },
+    "record": {
+        "CNAME": "ukrioo.github.io"
+    }
+}


### PR DESCRIPTION
Added `deko.is-a.dev` using the [dashboard](https://manage.is-a.dev).