### PR TITLE
BETA: Register _discord.dave9123.is-a.dev

### DIFF
--- a/domains/_discord.dave9123.json
+++ b/domains/_discord.dave9123.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dave9123",
+        "email": "dave.turmawan@outlook.com"
+    },
+    "record": {
+        "TXT": "dh=c722517186a5638488426a7e82c84a7ade5b01e0"
+    }
+}


### PR DESCRIPTION
Added `_discord.dave9123.is-a.dev` using the [dashboard](https://manage.is-a.dev).