### PR TITLE
BETA: Register haruki.py.is-a.dev

### DIFF
--- a/domains/haruki.py.json
+++ b/domains/haruki.py.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Anandkrishna34",
+        "email": "aanandkrishna344@gmail.com"
+    },
+    "record": {
+        "CNAME": "proxy.private.danbot.host"
+    }
+}


### PR DESCRIPTION
Added `haruki.py.is-a.dev` using the [dashboard](https://manage.is-a.dev).