### PR TITLE
BETA: Register smartlinuxcoder.is-a.dev

### DIFF
--- a/domains/archlinux.json
+++ b/domains/archlinux.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "Smartlinuxcoder",
+        "email": "smartcoder@linuxmail.org"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}

--- a/domains/smartcoder.json
+++ b/domains/smartcoder.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "Smartlinuxcoder",
+        "email": "smartcoder@linuxmail.org"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}

--- a/domains/smartlinuxcoder.json
+++ b/domains/smartlinuxcoder.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "Smartlinuxcoder",
+        "email": "randazzogiulio7@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `smartlinuxcoder.is-a.dev` using the [dashboard](https://manage.is-a.dev).