### PR TITLE
BETA: Register smartlinuxcoder.is-a.dev

### DIFF
--- a/domains/smartlinuxcoder.json
+++ b/domains/smartlinuxcoder.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Smartlinuxcoder",
+        "email": "smartcoder@linuxmail.org"
+    },
+    "record": {
+        "CNAME": "smartlinuxcoder.github.io"
+    }
+}


### PR DESCRIPTION
Added `smartlinuxcoder.is-a.dev` using the [dashboard](https://manage.is-a.dev).