### PR TITLE
BETA: Register paillat.is-a.dev

### DIFF
--- a/domains/paillat.json
+++ b/domains/paillat.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Paillat-dev",
+        "email": "me@paillat.dev"
+    },
+    "record": {
+        "CNAME": "paill.at"
+    }
+}


### PR DESCRIPTION
Added `paillat.is-a.dev` using the [dashboard](https://manage.is-a.dev).