### PR TITLE
BETA: Register wtfoffside.is-a.dev

### DIFF
--- a/domains/wtfoffside.json
+++ b/domains/wtfoffside.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "devembrace",
+        "email": "rollxhowns@outlook.com"
+    },
+    "record": {
+        "TXT": "a61cbd7bb32cb2e5bf7c74e98f1509"
+    }
+}


### PR DESCRIPTION
Added `wtfoffside.is-a.dev` using the [dashboard](https://manage.is-a.dev).