### PR TITLE
BETA: Register salsa.is-a.dev

### DIFF
--- a/domains/salsa.json
+++ b/domains/salsa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "salsabilaananditaputri",
+        "email": "salsabilaananditaputri.5@gmail.com"
+    },
+    "record": {
+        "CNAME": "salsabilaananditaputri.github.io"
+    }
+}


### PR DESCRIPTION
Added `salsa.is-a.dev` using the [dashboard](https://manage.is-a.dev).