### PR TITLE
Register oh64.is-a.dev

### DIFF
--- a/domains/oh64.json
+++ b/domains/oh64.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Oh64-UwU",
+           "email": "Oh64_UwU@pm.me",
+           "discord": "1167437133481508867"
+        },
+    
+        "record": {
+            "CNAME": "oh64.42web.io"
+        }
+    }
+    


### PR DESCRIPTION
Register oh64.is-a.dev with CNAME record pointing to Oh64.42web.io.