### PR TITLE
BETA: Register dimi.is-a.dev

### DIFF
--- a/domains/dimi.json
+++ b/domains/dimi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dklesev",
+        "email": "dimitrij.klesev@gmail.com"
+    },
+    "record": {
+        "CNAME": "audk.at"
+    }
+}


### PR DESCRIPTION
Added `dimi.is-a.dev` using the [dashboard](https://manage.is-a.dev).