### PR TITLE
Register shapesdocs.is-a.dev

### DIFF
--- a/domains/shapesdocs.json
+++ b/domains/shapesdocs.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Syst69",
+           "email": "xcrosssaroj@gmail.com",
+           "discord": "750339984598368287"
+        },
+    
+        "record": {
+            "AAAA": "fanmade docs for creating shapes"
+        }
+    }
+    


### PR DESCRIPTION
Register shapesdocs.is-a.dev with AAAA record pointing to Fanmade docs for creating shapes.