### PR TITLE
BETA: Register oh64.is-a.dev

### DIFF
--- a/domains/oh64.json
+++ b/domains/oh64.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Oh64-UwU",
+        "email": "Oh64_UwU@pm.me"
+    },
+    "record": {
+        "URL": "https://oh64.42web.io"
+    }
+}


### PR DESCRIPTION
Added `oh64.is-a.dev` using the [dashboard](https://manage.is-a.dev).