### PR TITLE
BETA: Register lavi.is-a.dev

### DIFF
--- a/domains/lavi.json
+++ b/domains/lavi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LaviArzi",
+        "email": "lavi.arzi@gmail.com"
+    },
+    "record": {
+        "CNAME": "lavirz.com"
+    }
+}


### PR DESCRIPTION
Added `lavi.is-a.dev` using the [dashboard](https://manage.is-a.dev).