### PR TITLE
BETA: Register digitalleadboard.is-a.dev

### DIFF
--- a/domains/digitalleadboard.json
+++ b/domains/digitalleadboard.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "willhaigh",
+        "email": "willhaigh@hotmail.co.uk"
+    },
+    "record": {
+        "CNAME": "urchin-app-g63h3.ondigitalocean.app"
+    }
+}


### PR DESCRIPTION
Added `digitalleadboard.is-a.dev` using the [dashboard](https://manage.is-a.dev).