### PR TITLE
BETA: Register bulkypanda.is-a.dev

### DIFF
--- a/domains/bulkypanda.json
+++ b/domains/bulkypanda.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "bulkypanda",
+        "email": "arya@gummadi.net"
+    },
+    "record": {
+        "CNAME": "bulkypanda.github.io"
+    }
+}


### PR DESCRIPTION
Added `bulkypanda.is-a.dev` using the [dashboard](https://manage.is-a.dev).