### PR TITLE
BETA: Register varis.is-a.dev

### DIFF
--- a/domains/varis.json
+++ b/domains/varis.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "IfVar",
+        "email": "LZT7@proton.me"
+    },
+    "record": {
+        "TXT": "e443c76ecbbcc3f6baeaf6f80e1dd1"
+    }
+}


### PR DESCRIPTION
Added `varis.is-a.dev` using the [dashboard](https://manage.is-a.dev).