### PR TITLE
BETA: Register jckli.is-a.dev

### DIFF
--- a/domains/jckli.json
+++ b/domains/jckli.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "jckli",
+        "email": "notjackhli@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/jckli"
+    }
+}


### PR DESCRIPTION
Added `jckli.is-a.dev` using the [dashboard](https://manage.is-a.dev).