### PR TITLE
BETA: Register gratatouille.is-a.dev

### DIFF
--- a/domains/gratatouille.json
+++ b/domains/gratatouille.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "itsagra",
+        "email": "ftrahl@gmail.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=gratatouille.is-a.dev,bc9954ee983af0375eef"
+    }
+}


### PR DESCRIPTION
Added `gratatouille.is-a.dev` using the [dashboard](https://manage.is-a.dev).