### PR TITLE
BETA: Register paulpfeiffer.is-a.dev

### DIFF
--- a/domains/paulpfeiffer.json
+++ b/domains/paulpfeiffer.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "paul-pfeiffer",
+        "email": "ppfeiffer93@gmx.at"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `paulpfeiffer.is-a.dev` using the [dashboard](https://manage.is-a.dev).