### PR TITLE
BETA: Register fafu.is-a.dev

### DIFF
--- a/domains/fafu.json
+++ b/domains/fafu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "fafu-10",
+        "email": "shimni22@skiff.com"
+    },
+    "record": {
+        "CNAME": "fafu-10.github.io"
+    }
+}


### PR DESCRIPTION
Added `fafu.is-a.dev` using the [dashboard](https://manage.is-a.dev).