### PR TITLE
BETA: Register code.trung.is-a.dev

### DIFF
--- a/domains/code.trung.json
+++ b/domains/code.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "CNAME": "proxy.private.danbot.host"
+    }
+}


### PR DESCRIPTION
Added `code.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).