### PR TITLE
BETA: Register darkxx.is-a.dev

### DIFF
--- a/domains/darkxx.json
+++ b/domains/darkxx.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Darkxx14",
+        "email": "packs.gg1@gmail.com"
+    },
+    "record": {
+        "A": ["8.8.8.8"]
+    }
+}


### PR DESCRIPTION
Added `darkxx.is-a.dev` using the [dashboard](https://manage.is-a.dev).