### PR TITLE
BETA: Register uptime.trung.is-a.dev

### DIFF
--- a/domains/uptime.trung.json
+++ b/domains/uptime.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "CNAME": "proxy.private.danbot.host"
+    }
+}


### PR DESCRIPTION
Added `uptime.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).