### PR TITLE
BETA: Register ganyu.is-a.dev

### DIFF
--- a/domains/ganyu.json
+++ b/domains/ganyu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "emikohoshi",
+        "email": "hoangyencb1303@gmail.com"
+    },
+    "record": {
+        "CNAME": "emikohoshi.github.io"
+    }
+}


### PR DESCRIPTION
Added `ganyu.is-a.dev` using the [dashboard](https://manage.is-a.dev).