### PR TITLE
BETA: Register thehuytong.is-a.dev

### DIFF
--- a/domains/thehuytong.json
+++ b/domains/thehuytong.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "thehuytong",
+        "email": "tongnguyen.hahuy@gmail.com"
+    },
+    "record": {
+        "CNAME": "thehuytong.github.io"
+    }
+}


### PR DESCRIPTION
Added `thehuytong.is-a.dev` using the [dashboard](https://manage.is-a.dev).