### PR TITLE
Update magniquick.is-a.dev

### DIFF
--- a/domains/magniquick.json
+++ b/domains/magniquick.json
@@ -1,19 +1,12 @@
 {
-    "description": "magniquick's personal site",
-    "repo": "https://github.com/Magniquick/magniquick.github.io",
     "owner": {
-        "username": "magniquick",
-        "email": "",
-        "discord": "Magniquick#5003"
+        "username": "Magniquick",
+        "email": "navonjohnlukose@gmail.com"
     },
     "record": {
-        "A": [
-            "185.199.108.153",
-            "185.199.109.153",
-            "185.199.110.153",
-            "185.199.111.153"
-        ],
-        "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
-        "TXT": "v=spf1 include:spf.improvmx.com ~all"
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
     }
 }


### PR DESCRIPTION
Updated `magniquick.is-a.dev` using the [dashboard](https://manage.is-a.dev).