### PR TITLE
BETA: Register gwt9502.is-a.dev

### DIFF
--- a/domains/gwt9502.json
+++ b/domains/gwt9502.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "gwt9502",
+        "email": "gwt9502@163.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=gwt9502.is-a.dev,bc9bc2513bf30104530b"
+    }
+}


### PR DESCRIPTION
Added `gwt9502.is-a.dev` using the [dashboard](https://manage.is-a.dev).