### PR TITLE
BETA: Register drively.is-a.dev

### DIFF
--- a/domains/drively.json
+++ b/domains/drively.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Gawnul",
+        "email": "rootnull@outlook.es"
+    },
+    "record": {
+        "URL": "https://bento.me/drively"
+    }
+}


### PR DESCRIPTION
Added `drively.is-a.dev` using the [dashboard](https://manage.is-a.dev).