### PR TITLE
BETA: Register darkpizza.is-a.dev

### DIFF
--- a/domains/darkpizza.json
+++ b/domains/darkpizza.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DarkPizza",
+        "email": "arturpizzagames@hotmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/darkpizza/darkpizza/blob/main/readme.md"
+    }
+}


### PR DESCRIPTION
Added `darkpizza.is-a.dev` using the [dashboard](https://manage.is-a.dev).