### PR TITLE
BETA: Register amol3.is-a.dev

### DIFF
--- a/domains/amol3.json
+++ b/domains/amol3.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "amol234545",
+        "email": "amolmilton@gmail.com"
+    },
+    "record": {
+        "CNAME": "amol234545.github.io"
+    }
+}


### PR DESCRIPTION
Added `amol3.is-a.dev` using the [dashboard](https://manage.is-a.dev).