### PR TITLE
BETA: Register dark-pizza.is-a.dev

### DIFF
--- a/domains/dark-pizza.json
+++ b/domains/dark-pizza.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DarkPizza",
+        "email": "arturpizzagames@hotmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/darkpizza/darkpizza"
+    }
+}


### PR DESCRIPTION
Added `dark-pizza.is-a.dev` using the [dashboard](https://manage.is-a.dev).