### PR TITLE
BETA: Register rice.is-a.dev

### DIFF
--- a/domains/rice.json
+++ b/domains/rice.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "JoaquinDaBest",
+        "email": "theonlyhehehehaw@gmail.com"
+    },
+    "record": {
+        "CNAME": "keenwa.x10.mx"
+    }
+}


### PR DESCRIPTION
Added `rice.is-a.dev` using the [dashboard](https://manage.is-a.dev).