### PR TITLE
Update thehuytong.is-a.dev

### DIFF
--- a/domains/thehuytong.json
+++ b/domains/thehuytong.json
@@ -4,6 +4,9 @@
         "email": "tongnguyen.hahuy@gmail.com"
     },
     "record": {
-        "CNAME": "thehuytong.github.io"
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
     }
 }


### PR DESCRIPTION
Updated `thehuytong.is-a.dev` using the [dashboard](https://manage.is-a.dev).