### PR TITLE
BETA: Register aether.is-a.dev

### DIFF
--- a/domains/aether.json
+++ b/domains/aether.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "penguinencounter",
+        "email": "penguinencounter2+isadev@gmail.com"
+    },
+    "record": {
+        "CNAME": "penguinencounter.github.io"
+    }
+}


### PR DESCRIPTION
Added `aether.is-a.dev` using the [dashboard](https://manage.is-a.dev).