### PR TITLE
BETA: Register raad.is-a.dev

### DIFF
--- a/domains/raad.json
+++ b/domains/raad.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Raiyaad-Raad",
+        "email": "raiyaadraad132rafan45@gmail.com"
+    },
+    "record": {
+        "URL": "https://raiyaad-raad.github.io/raad.github.io"
+    }
+}


### PR DESCRIPTION
Added `raad.is-a.dev` using the [dashboard](https://manage.is-a.dev).