### PR TITLE
BETA: Register cloudron.is-a.dev

### DIFF
--- a/domains/cloudron.json
+++ b/domains/cloudron.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Krishan19",
+        "email": "krishan.nalinda19@gmail.com"
+    },
+    "record": {
+        "A": ["10.139.0.2"]
+    }
+}


### PR DESCRIPTION
Added `cloudron.is-a.dev` using the [dashboard](https://manage.is-a.dev).