### PR TITLE
BETA: Register kodex.is-a.dev

### DIFF
--- a/domains/kodex.json
+++ b/domains/kodex.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "codex009",
+        "email": "3gareb@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `kodex.is-a.dev` using the [dashboard](https://manage.is-a.dev).