### PR TITLE
Register zer0.is-a.dev

### DIFF
--- a/domains/zer0.json
+++ b/domains/zer0.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Zer0Dev-exe",
+           "email": "igorlizaso16@gmail.com",
+           "discord": "817515739711406140"
+        },
+    
+        "record": {
+            "CNAME": "https://zer0dev-exe.github.io/zer0isadev/"
+        }
+    }
+    


### PR DESCRIPTION
Register zer0.is-a.dev with CNAME record pointing to https://zer0dev-exe.github.io/Zer0isADev/.