### PR TITLE
Update adityajyoti.json To point to new URL

### DIFF
--- a/domains/adityajyoti.json
+++ b/domains/adityajyoti.json
@@ -4,6 +4,6 @@
         "email": "aj.adityajyoti@gmail.com"
     },
     "record": {
-        "URL": "https://github.com/aditya-jyoti/aditya-jyoti.github.io"
+        "URL": "https://aditya-jyoti.github.io"
     }
 }


### PR DESCRIPTION
I accidentally set the previous record URL to point towards the github repo and not the github pages url

similar #9775 

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [ ] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Discord or Twitter) so we can contact you. -->


## Website Link/Preview

https://aditya-jyoti.github.io
