### PR TITLE
BETA: Register radiantgroup.is-a.dev

### DIFF
--- a/domains/about.amulyasingh.json
+++ b/domains/about.amulyasingh.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "AMULYASing",
+        "email": "amulyasingh370@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}

--- a/domains/radiantgroup.json
+++ b/domains/radiantgroup.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AMULYASing",
+        "email": "amulyasingh370@gmail.com"
+    },
+    "record": {
+        "CNAME": "amulyasing.github.io"
+    }
+}


### PR DESCRIPTION
Added `radiantgroup.is-a.dev` using the [dashboard](https://manage.is-a.dev).