### PR TITLE
BETA: Register benlandon.is-a.dev

### DIFF
--- a/domains/benlandon.json
+++ b/domains/benlandon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "https123456789",
+        "email": "benl.landon@proton.me"
+    },
+    "record": {
+        "CNAME": "portfolio-five-vert-95.vercel.app"
+    }
+}


### PR DESCRIPTION
Added `benlandon.is-a.dev` using the [dashboard](https://manage.is-a.dev).