### PR TITLE
BETA: Register jatink.is-a.dev

### DIFF
--- a/domains/jatink.json
+++ b/domains/jatink.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "jatindotdev",
+        "email": "main.jatink@gmail.com"
+    },
+    "record": {
+        "CNAME": "jatinkumar.vercel.app"
+    }
+}


### PR DESCRIPTION
Added `jatink.is-a.dev` using the [dashboard](https://manage.is-a.dev).