### PR TITLE
BETA: Register c22.is-a.dev

### DIFF
--- a/domains/c22.json
+++ b/domains/c22.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "c22dev",
+        "email": "constclerc@gmail.com"
+    },
+    "record": {
+        "CNAME": "964dab70-f6cd-45f1-a896-af0276fa4d15.id.repl.co"
+    }
+}


### PR DESCRIPTION
Added `c22.is-a.dev` using the [dashboard](https://manage.is-a.dev).