### PR TITLE
Register cfp.is-a.dev and scfp.is-a.dev back

### DIFF
--- a/domains/cfp.json
+++ b/domains/cfp.json
@@ -2,7 +2,7 @@
     "owner": {
         "username": "cfpwastaken",
         "email": "",
-        "discord": "cfp"
+        "discord": "cfp (318394797822050315)"
     },
     "record": {
         "CNAME": "cfp.gotdns.ch"

--- a/domains/cfp.json
+++ b/domains/cfp.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "cfpwastaken",
+        "email": "chaosflo44plus@gmail.com"
+    },
+    "record": {
+        "CNAME": "cfp.gotdns.ch"
+    }
+}

--- a/domains/scfp.json
+++ b/domains/scfp.json
@@ -3,7 +3,7 @@
     "owner": {
         "username": "cfpwastaken",
         "email": "",
-        "discord": "cfp"
+        "discord": "cfp (318394797822050315)"
     },
     "record": {
         "CNAME": "cfp.gotdns.ch"

--- a/domains/scfp.json
+++ b/domains/scfp.json
@@ -1,4 +1,5 @@
 {
+    "description": "Cfp Short Service",
     "owner": {
         "username": "cfpwastaken",
         "email": "",


### PR DESCRIPTION
Added `cfp.is-a.dev` and `scfp.is-a.dev` using the [dashboard](https://manage.is-a.dev) and manual edits.