### PR TITLE
BETA: Register zirconiac.is-a.dev

### DIFF
--- a/domains/zirconiac.json
+++ b/domains/zirconiac.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "ZirconiaCubed3v2",
+        "email": "lucian.adzima@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `zirconiac.is-a.dev` using the [dashboard](https://manage.is-a.dev).