### PR TITLE
BETA: Register peme969.is-a.dev

### DIFF
--- a/domains/peme969.json
+++ b/domains/peme969.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "peme969",
+        "email": "mrcoderpeme@gmail.com"
+    },
+    "record": {
+        "CNAME": "peme969.github.io"
+    }
+}


### PR DESCRIPTION
Added `peme969.is-a.dev` using the [dashboard](https://manage.is-a.dev).