### PR TITLE
BETA: Register vixcord.is-a.dev

### DIFF
--- a/domains/vixcord.json
+++ b/domains/vixcord.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AbsolutelyNothingAndNoOne",
+        "email": "tinakiss2234@gmail.com"
+    },
+    "record": {
+        "URL": "https://defensiveunluckystate.mkds.repl.co/"
+    }
+}


### PR DESCRIPTION
Added `vixcord.is-a.dev` using the [dashboard](https://manage.is-a.dev).