### PR TITLE
BETA: Register iq.is-a.dev

### DIFF
--- a/domains/iq.json
+++ b/domains/iq.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "deploy-enjoy",
+        "email": "psaputskyi2023@itcollege.lviv.ua"
+    },
+    "record": {
+        "A": ["76.76.21.21"]
+    }
+}


### PR DESCRIPTION
Added `iq.is-a.dev` using the [dashboard](https://manage.is-a.dev).