### PR TITLE
BETA: Register d4rabi.is-a.dev

### DIFF
--- a/domains/d4rabi.json
+++ b/domains/d4rabi.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "d4rabi",
+        "email": "fauzan.idalfithri@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `d4rabi.is-a.dev` using the [dashboard](https://manage.is-a.dev).