### PR TITLE
BETA: Register kleb.is-a.dev

### DIFF
--- a/domains/kleb.json
+++ b/domains/kleb.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "KrazyKleb",
+        "email": "krazyklebyt@gmail.com"
+    },
+    "record": {
+        "CNAME": "proxy.private.danbot.host"
+    }
+}


### PR DESCRIPTION
Added `kleb.is-a.dev` using the [dashboard](https://manage.is-a.dev).