### PR TITLE
BETA: Register flappy24.is-a.dev

### DIFF
--- a/domains/flappy24.json
+++ b/domains/flappy24.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Flappy25",
+        "email": "giokleung@outlook.com"
+    },
+    "record": {
+        "A": ["68.4.47.121"]
+    }
+}


### PR DESCRIPTION
Added `flappy24.is-a.dev` using the [dashboard](https://manage.is-a.dev).