### PR TITLE
BETA: Register lemon.is-a.dev

### DIFF
--- a/domains/lemon.json
+++ b/domains/lemon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "PassiveLemon",
+        "email": "lemonl3mn@protonmail.com"
+    },
+    "record": {
+        "A": ["64.217.148.69"]
+    }
+}


### PR DESCRIPTION
Added `lemon.is-a.dev` using the [dashboard](https://manage.is-a.dev).

My domain was removed in the cleanup a week ago but I still use it so I'm just requesting it back.
BTW, how is the removal determined?