### PR TITLE
BETA: Register gg.is-a.dev

### DIFF
--- a/domains/gg.json
+++ b/domains/gg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "741as",
+        "email": "1@gggf.link"
+    },
+    "record": {
+        "CNAME": "1.1ddns.eu.org"
+    }
+}


### PR DESCRIPTION
Added `gg.is-a.dev` using the [dashboard](https://manage.is-a.dev).