### PR TITLE
BETA: Register doge-v4-proxy.is-a.dev

### DIFF
--- a/domains/doge-v4-proxy.json
+++ b/domains/doge-v4-proxy.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "Zumwaltboi68",
+        "email": "alexander662022@outlook.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `doge-v4-proxy.is-a.dev` using the [dashboard](https://manage.is-a.dev).