### PR TITLE
Register lowteas.is-a.dev

### DIFF
--- a/domains/lowteas.json
+++ b/domains/lowteas.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "gamersbamers",
+           "email": "bamersgamers@gmail.com",
+           "discord": "969389556803715122"
+        },
+    
+        "record": {
+            "A": ["https://lowteasinfo.carrd.co"]
+        }
+    }
+    


### PR DESCRIPTION
Register lowteas.is-a.dev with A record pointing to https://lowteasinfo.carrd.co.