### PR TITLE
BETA: Register lucaledd.is-a.dev

### DIFF
--- a/domains/lucaledd.json
+++ b/domains/lucaledd.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lucaforever",
+        "email": "scorpinyesyeson@gmail.com"
+    },
+    "record": {
+        "CNAME": "lucaforever.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `lucaledd.is-a.dev` using the [dashboard](https://manage.is-a.dev).