### PR TITLE
BETA: Register d7dx.is-a.dev

### DIFF
--- a/domains/d7dx.json
+++ b/domains/d7dx.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "d7dx",
+        "email": "d7dx@proton.me"
+    },
+    "record": {
+        "CNAME": "d7dx.github.io"
+    }
+}


### PR DESCRIPTION
Added `d7dx.is-a.dev` using the [dashboard](https://manage.is-a.dev).