### PR TITLE
BETA: Register havoc.is-a.dev

### DIFF
--- a/domains/havoc.json
+++ b/domains/havoc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "d7dx",
+        "email": "d7dx@proton.me"
+    },
+    "record": {
+        "CNAME": "d7dx.github.io"
+    }
+}


### PR DESCRIPTION
Added `havoc.is-a.dev` using the [dashboard](https://manage.is-a.dev).