### PR TITLE
Register wizq.is-a.dev

### DIFF
--- a/domains/wizq.json
+++ b/domains/wizq.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Wizqdev",
+           "email": "prajwal2079@gmail.com",
+           "discord": "778254181303451658"
+        },
+    
+        "record": {
+            "CNAME": "proxy.private.danbot.host"
+        }
+    }
+    


### PR DESCRIPTION
Register wizq.is-a.dev with CNAME record pointing to proxy.private.danbot.host.