### PR TITLE
BETA: Register zepip.is-a.dev

### DIFF
--- a/domains/zepip.json
+++ b/domains/zepip.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "chickenwing02",
+        "email": "chickenwing02@proton.me"
+    },
+    "record": {
+        "CNAME": "chickenwing02.github.io"
+    }
+}


### PR DESCRIPTION
Added `zepip.is-a.dev` using the [dashboard](https://manage.is-a.dev).