### PR TITLE
BETA: Register spidey.is-a.dev

### DIFF
--- a/domains/spidey.json
+++ b/domains/spidey.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zepip",
+        "email": "zigzaglm13@proton.me"
+    },
+    "record": {
+        "CNAME": "zepip.github.io"
+    }
+}


### PR DESCRIPTION
Added `spidey.is-a.dev` using the [dashboard](https://manage.is-a.dev).