### PR TITLE
BETA: Register oli.is-a.dev

### DIFF
--- a/domains/oli.json
+++ b/domains/oli.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hxntaish",
+        "email": "juliettepoisson3@gmail.com"
+    },
+    "record": {
+        "A": ["185.171.202.187"]
+    }
+}


### PR DESCRIPTION
Added `oli.is-a.dev` using the [dashboard](https://manage.is-a.dev).