### PR TITLE
BETA: Register dblok.is-a.dev

### DIFF
--- a/domains/dblok.json
+++ b/domains/dblok.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Deepx64",
+        "email": "unr3v1@skiff.com"
+    },
+    "record": {
+        "CNAME": "deblok.i-think-i.lol"
+    }
+}


### PR DESCRIPTION
Added `dblok.is-a.dev` using the [dashboard](https://manage.is-a.dev).