### PR TITLE
BETA: Register spikegr.is-a.dev

### DIFF
--- a/domains/spikegr.json
+++ b/domains/spikegr.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "SpikeGR",
+        "email": "thedarkgamergr2@gmail.com"
+    },
+    "record": {
+        "TXT": "gdhtdfh"
+    }
+}


### PR DESCRIPTION
Added `spikegr.is-a.dev` using the [dashboard](https://manage.is-a.dev).