### PR TITLE
Update mosssdark.is-a.dev

### DIFF
--- a/domains/mosssdark.json
+++ b/domains/mosssdark.json
@@ -4,6 +4,9 @@
         "email": "maillegendop@gmail.com"
     },
     "record": {
-        "CNAME": "proxy.private.danbot.host"
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
     }
 }


### PR DESCRIPTION
Updated `mosssdark.is-a.dev` using the [dashboard](https://manage.is-a.dev).