### PR TITLE
BETA: Register zelriano36.is-a.dev

### DIFF
--- a/domains/zelriano36.json
+++ b/domains/zelriano36.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zelriano36",
+        "email": "bastien.salvetat@gmail.com"
+    },
+    "record": {
+        "CNAME": "zelriano36.github.io"
+    }
+}


### PR DESCRIPTION
Added `zelriano36.is-a.dev` using the [dashboard](https://manage.is-a.dev).