### PR TITLE
BETA: Register vacer.is-a.dev

### DIFF
--- a/domains/vacer.json
+++ b/domains/vacer.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Strongboost",
+        "email": "gigantenjaeger.junior@gmail.com"
+    },
+    "record": {
+        "A": ["5.253.246.227"]
+    }
+}


### PR DESCRIPTION
Added `vacer.is-a.dev` using the [dashboard](https://manage.is-a.dev).