### PR TITLE
Register zephyr.is-a.dev

### DIFF
--- a/domains/zephyr.json
+++ b/domains/zephyr.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "ALVINTAN159",
+           "email": "alvintan159@gmail.com",
+           "discord": "985731141640286258"
+        },
+    
+        "record": {
+            "CNAME": "autocontent.ninefortwo.be"
+        }
+    }
+    


### PR DESCRIPTION
Register zephyr.is-a.dev with CNAME record pointing to autocontent.ninefortwo.be.