### PR TITLE
BETA: Register astro.is-a.dev

### DIFF
--- a/domains/astro.json
+++ b/domains/astro.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "777advait",
+        "email": "advait.nsj@gmail.com"
+    },
+    "record": {
+        "CNAME": "portfolio-b3e91d.webflow.io"
+    }
+}


### PR DESCRIPTION
Added `astro.is-a.dev` using the [dashboard](https://manage.is-a.dev).