### PR TITLE
BETA: Register stan.is-a.dev

### DIFF
--- a/domains/stan.json
+++ b/domains/stan.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "stansters",
+        "email": "stanleygeorgebond@gmail.com"
+    },
+    "record": {
+        "URL": "stn.re"
+    }
+}


### PR DESCRIPTION
Added `stan.is-a.dev` using the [dashboard](https://manage.is-a.dev).