### PR TITLE
BETA: Register riann.is-a.dev

### DIFF
--- a/domains/riann.json
+++ b/domains/riann.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "afrianluthfan",
+        "email": "afrian.luthfan@gmail.com"
+    },
+    "record": {
+        "CNAME": "afrianluthfan.github.io"
+    }
+}


### PR DESCRIPTION
Added `riann.is-a.dev` using the [dashboard](https://manage.is-a.dev).