### PR TITLE
BETA: Register vale.is-a.dev

### DIFF
--- a/domains/vale.json
+++ b/domains/vale.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DeclanChidlow",
+        "email": "git.rh92c@8shield.net"
+    },
+    "record": {
+        "URL": "vale.rocks"
+    }
+}


### PR DESCRIPTION
Added `vale.is-a.dev` using the [dashboard](https://manage.is-a.dev).