### PR TITLE
BETA: Register mrepol742.is-a.dev

### DIFF
--- a/domains/mrepol742.json
+++ b/domains/mrepol742.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mrepol742",
+        "email": "mrepol742@gmail.com"
+    },
+    "record": {
+        "CNAME": "mrepol742.github.io"
+    }
+}


### PR DESCRIPTION
Added `mrepol742.is-a.dev` using the [dashboard](https://manage.is-a.dev).