### PR TITLE
Update astro.is-a.dev

### DIFF
--- a/domains/astro.json
+++ b/domains/astro.json
@@ -4,6 +4,9 @@
         "email": "advait.nsj@gmail.com"
     },
     "record": {
-        "CNAME": "portfolio-b3e91d.webflow.io"
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
     }
 }


### PR DESCRIPTION
Updated `astro.is-a.dev` using the [dashboard](https://manage.is-a.dev).