### PR TITLE
Register abhinav06.is-a.dev

### DIFF
--- a/domains/abhinav06.json
+++ b/domains/abhinav06.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "CodeDreamer06",
+           "email": "codedreamer06@gmail.com",
+           "discord": "763775358565613569"
+        },
+    
+        "record": {
+            "CNAME": "codedreamer06.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register abhinav06.is-a.dev with CNAME record pointing to codedreamer06.github.io.