### PR TITLE
Register ryder.is-a.dev

### DIFF
--- a/domains/ryder.json
+++ b/domains/ryder.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "RyderCragie",
+           "email": "69316364+RyderCragie@users.noreply.github.com",
+           "discord": "713201205488254976"
+        },
+    
+        "record": {
+            "CNAME": "ghs.googlehosted.com"
+        }
+    }
+    


### PR DESCRIPTION
Register ryder.is-a.dev with CNAME record pointing to ghs.googlehosted.com.