### PR TITLE
Register 0x1ar.is-a.dev

### DIFF
--- a/domains/0x1ar.json
+++ b/domains/0x1ar.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "0x1ar",
+           "email": "pschad1926@gmail.com",
+           "discord": "148507267719757825"
+        },
+    
+        "record": {
+            "TXT": "just a professional web page ig"
+        }
+    }
+    


### PR DESCRIPTION
Register 0x1ar.is-a.dev with TXT record pointing to just a professional web page ig.