### PR TITLE
BETA: Register chankit.is-a.dev

### DIFF
--- a/domains/chankit.json
+++ b/domains/chankit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ChankitSaini",
+        "email": "chankit@outlook.in"
+    },
+    "record": {
+        "CNAME": "chankit.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `chankit.is-a.dev` using the [dashboard](https://manage.is-a.dev).