### PR TITLE
BETA: Register bit.is-a.dev

### DIFF
--- a/domains/bit.json
+++ b/domains/bit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "apiakuari",
+        "email": "apiakuari@gmail.com"
+    },
+    "record": {
+        "TXT": "_vercel"
+    }
+}


### PR DESCRIPTION
Added `bit.is-a.dev` using the [dashboard](https://manage.is-a.dev).