### PR TITLE
Register kartikey.is-a.dev

### DIFF
--- a/domains/kartikey.json
+++ b/domains/kartikey.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "kartikey-mittal",
+           "email": "g6.kartikey@gmail.com",
+           "discord": "1044296816071548961"
+        },
+    
+        "record": {
+            "MX": ["kartikey-mittal.github.io"]
+        }
+    }
+    

--- a/domains/kartikey.json
+++ b/domains/kartikey.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "MX": ["kartikey-mittal.github.io"]
+            "CNAME": ["kartikey-mittal.github.io"]
         }
     }
     

--- a/domains/kartikey.json
+++ b/domains/kartikey.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "CNAME": ["kartikey-mittal.github.io"]
+            "CNAME": ["kartikey-mittal.github.io/profile"]
         }
     }
     


### PR DESCRIPTION
Register kartikey.is-a.dev with MX record pointing to kartikey-mittal.github.io/profile/