### PR TITLE
Register lighty.is-a.dev

### DIFF
--- a/domains/lighty.json
+++ b/domains/lighty.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "ssynical",
+           "email": "trapizoids543@gmail.com",
+           "discord": "1108616541739700284"
+        },
+    
+        "record": {
+            "CNAME": "ssynical.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register lighty.is-a.dev with CNAME record pointing to ssynical.github.io.