### PR TITLE
BETA: Register ak-dev.is-a.dev

### DIFF
--- a/domains/ak-dev.json
+++ b/domains/ak-dev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LRxDarkDevil",
+        "email": "tahaadnanawan@gmail.com"
+    },
+    "record": {
+        "CNAME": "ak-dev.github.io"
+    }
+}


### PR DESCRIPTION
Added `ak-dev.is-a.dev` using the [dashboard](https://manage.is-a.dev).