### PR TITLE
BETA: Register hoscraft.is-a.dev

### DIFF
--- a/domains/hoscraft.json
+++ b/domains/hoscraft.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HossamMohsen7",
+        "email": "hosam.mohsen13@gmail.com"
+    },
+    "record": {
+        "CNAME": "hossamohsen.me"
+    }
+}


### PR DESCRIPTION
Added `hoscraft.is-a.dev` using the [dashboard](https://manage.is-a.dev).