### PR TITLE
BETA: Register thepersonalsite.is-a.dev

### DIFF
--- a/domains/thepersonalsite.json
+++ b/domains/thepersonalsite.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "JesseHoekema",
+        "email": "jessehoekema@icloud.com"
+    },
+    "record": {
+        "URL": "https://jessehoekema.github.io/tps/"
+    }
+}


### PR DESCRIPTION
Added `thepersonalsite.is-a.dev` using the [dashboard](https://manage.is-a.dev).