### PR TITLE
BETA: Register mediocreballs.is-a.dev

### DIFF
--- a/domains/mediocreballs.json
+++ b/domains/mediocreballs.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "OWER396",
+        "email": "julbera89@gmail.com"
+    },
+    "record": {
+        "A": ["192.168.0.68"]
+    }
+}


### PR DESCRIPTION
Added `mediocreballs.is-a.dev` using the [dashboard](https://manage.is-a.dev).