### PR TITLE
BETA: Register lucen.is-a.dev

### DIFF
--- a/domains/lucen.json
+++ b/domains/lucen.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "lucenstuff",
+        "email": "lucentiniagustin@hotmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"],
+        "AAAA": ["2a00:da00:1800:83a4::1"],
+        "MX": ["hosts.is-a.dev"],
+        "TXT": "v=spf1 a mx ip4:217.174.245.249 ~all"
+    }
+}


### PR DESCRIPTION
Added `lucen.is-a.dev` using the [dashboard](https://manage.is-a.dev).