### PR TITLE
BETA: Register m483g.is-a.dev

### DIFF
--- a/domains/m483g.json
+++ b/domains/m483g.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "max483g",
+        "email": "max483g@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `m483g.is-a.dev` using the [dashboard](https://manage.is-a.dev).