### PR TITLE
BETA: Register teknoday.is-a.dev

### DIFF
--- a/domains/teknoday.json
+++ b/domains/teknoday.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "teknoku32",
+        "email": "tajam24news@gmail.com"
+    },
+    "record": {
+        "URL": "https://bidayy.com"
+    }
+}


### PR DESCRIPTION
Added `teknoday.is-a.dev` using the [dashboard](https://manage.is-a.dev).