### PR TITLE
Register blc.is-a.dev

### DIFF
--- a/domains/blc.json
+++ b/domains/blc.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "BLCXD",
+           "email": "blctoblc223@gmail.com",
+           "discord": "723837167499083788"
+        },
+    
+        "record": {
+            "CNAME": "blcpage.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register blc.is-a.dev with CNAME record pointing to blcpage.github.io.