### PR TITLE
BETA: Register mathis.is-a.dev

### DIFF
--- a/domains/mathis.json
+++ b/domains/mathis.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "maaaathis",
+        "email": "mathis.fullriede@gmail.com"
+    },
+    "record": {
+        "CNAME": "mathis.software"
+    }
+}


### PR DESCRIPTION
Added `mathis.is-a.dev` using the [dashboard](https://manage.is-a.dev).