### PR TITLE
BETA: Register algmapper.is-a.dev

### DIFF
--- a/domains/algmapper.json
+++ b/domains/algmapper.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "Alg-MapPer",
+        "email": "abu7atm9@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `algmapper.is-a.dev` using the [dashboard](https://manage.is-a.dev).