### PR TITLE
BETA: Register lyn.is-a.dev

### DIFF
--- a/domains/lyn.json
+++ b/domains/lyn.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "cosmosc0des",
+        "email": "lyncodes@proton.me"
+    },
+    "record": {
+        "URL": "https://lyncodes.neocities.org"
+    }
+}


### PR DESCRIPTION
Added `lyn.is-a.dev` using the [dashboard](https://manage.is-a.dev).