### PR TITLE
BETA: Register dallonlahoda.is-a.dev

### DIFF
--- a/domains/dallonlahoda.json
+++ b/domains/dallonlahoda.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "boomshakazulu",
+        "email": "dallonlahoda@hotmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `dallonlahoda.is-a.dev` using the [dashboard](https://manage.is-a.dev).