### PR TITLE
BETA: Register carsonday.is-a.dev

### DIFF
--- a/domains/carsonday.json
+++ b/domains/carsonday.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "CarsonDay11",
+        "email": "carson@carsonday.pro"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `carsonday.is-a.dev` using the [dashboard](https://manage.is-a.dev).