### PR TITLE
BETA: Register gerzhahp.is-a.dev

### DIFF
--- a/domains/gerzhahp.json
+++ b/domains/gerzhahp.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "zh4dev",
+        "email": "safeusdev@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `gerzhahp.is-a.dev` using the [dashboard](https://manage.is-a.dev).