### PR TITLE
BETA: Register nauriculus.is-a.dev

### DIFF
--- a/domains/nauriculus.json
+++ b/domains/nauriculus.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "nauriculus",
+        "email": "nauriculus@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `nauriculus.is-a.dev` using the [dashboard](https://manage.is-a.dev).