### PR TITLE
Register smartcloud.is-a.dev

### DIFF
--- a/domains/smartcloud.json
+++ b/domains/smartcloud.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Smartlinuxcoder",
+           "email": "123417503+Smartlinuxcoder@users.noreply.github.com",
+           "discord": "987972818341888021"
+        },
+    
+        "record": {
+            "CNAME": "raspberrypi.tail8530e.ts.net"
+        }
+    }
+    

--- a/domains/smartcloud.json
+++ b/domains/smartcloud.json
@@ -1,12 +1,14 @@
 {
         "owner": {
            "username": "Smartlinuxcoder",
-           "email": "123417503+Smartlinuxcoder@users.noreply.github.com",
-           "discord": "987972818341888021"
+           "email": "smartcoder@linuxmail.org",
+           "discord": ".smartcoder"
         },
     
         "record": {
-            "CNAME": "raspberrypi.tail8530e.ts.net"
+            "CNAME": "raspberrypi.tail8530e.ts.net",
+            "MX": ["mail.is-a.dev"],
+            "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
         }
     }
     


### PR DESCRIPTION
Register smartcloud.is-a.dev with CNAME record pointing to raspberrypi.tail8530e.ts.net.