### PR TITLE
BETA: Register aedotris.is-a.dev

### DIFF
--- a/domains/aedotris.json
+++ b/domains/aedotris.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "levinhkhangzz",
+        "email": "levinhkhang631@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `aedotris.is-a.dev` using the [dashboard](https://manage.is-a.dev).