### PR TITLE
BETA: Register parasyte.is-a.dev

### DIFF
--- a/domains/parasyte.json
+++ b/domains/parasyte.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ParasyteUnknown",
+        "email": "parasyte@duck.com"
+    },
+    "record": {
+        "URL": "http://0ddsec.xyz"
+    }
+}


### PR DESCRIPTION
Added `parasyte.is-a.dev` using the [dashboard](https://manage.is-a.dev).