### PR TITLE
Update lavafroth.is-a.dev

### DIFF
--- a/domains/lavafroth.json
+++ b/domains/lavafroth.json
@@ -4,6 +4,11 @@
         "email": "lavafroth@protonmail.com"
     },
     "record": {
-        "CNAME": "lavafroth.github.io"
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
     }
 }


### PR DESCRIPTION
Updated `lavafroth.is-a.dev` using the [dashboard](https://manage.is-a.dev).