### PR TITLE
BETA: Register lightarea.is-a.dev

### DIFF
--- a/domains/lightarea.json
+++ b/domains/lightarea.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "MayankServers",
+        "email": "mayankreal657@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `lightarea.is-a.dev` using the [dashboard](https://manage.is-a.dev).