### PR TITLE
BETA: Register lucendev.is-a.dev

### DIFF
--- a/domains/lucendev.json
+++ b/domains/lucendev.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "lucenstuff",
+        "email": "lucentiniagustin@hotmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `lucendev.is-a.dev` using the [dashboard](https://manage.is-a.dev).