### PR TITLE
BETA: Register solar.is-a.dev

### DIFF
--- a/domains/solar.json
+++ b/domains/solar.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "solarc3",
+        "email": "ignacio.solar@usach.cl"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `solar.is-a.dev` using the [dashboard](https://manage.is-a.dev).