### PR TITLE
BETA: Register hemang.is-a.dev

### DIFF
--- a/domains/hemang.json
+++ b/domains/hemang.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Zemerik",
+        "email": "zemerikY@gmail.com"
+    },
+    "record": {
+        "URL": "https://zemerik.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `hemang.is-a.dev` using the [dashboard](https://manage.is-a.dev).