### PR TITLE
BETA: Register omsandeppatil.is-a.dev

### DIFF
--- a/domains/omsandeppatil.json
+++ b/domains/omsandeppatil.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "omsandippatil",
+        "email": "omsandeeppatil02@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `omsandeppatil.is-a.dev` using the [dashboard](https://manage.is-a.dev).