### PR TITLE
BETA: Register heromax.is-a.dev

### DIFF
--- a/domains/heromax.json
+++ b/domains/heromax.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tileicklest",
+        "email": "deshaunmcceay374@gmail.com"
+    },
+    "record": {
+        "CNAME": "heromax.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `heromax.is-a.dev` using the [dashboard](https://manage.is-a.dev).