### PR TITLE
BETA: Register fae5.is-a.dev

### DIFF
--- a/domains/fae5.json
+++ b/domains/fae5.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "fae5de",
+        "email": "louis.m.ortner@icloud.com"
+    },
+    "record": {
+        "CNAME": "website-6es.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `fae5.is-a.dev` using the [dashboard](https://manage.is-a.dev).