### PR TITLE
BETA: Register abv.is-a.dev

### DIFF
--- a/domains/abv.json
+++ b/domains/abv.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "leburgue",
+        "email": "albertonazijew@gmail.com"
+    },
+    "record": {
+        "A": ["159.54.140.185"]
+    }
+}


### PR DESCRIPTION
Added `abv.is-a.dev` using the [dashboard](https://manage.is-a.dev).