### PR TITLE
Register lucen.is-a.dev

### DIFF
--- a/domains/lucen.json
+++ b/domains/lucen.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "lucenstuff",
+           "email": "lucentiniagustin@hotmail.com",
+           "discord": "202467820225822720"
+        },
+    
+        "record": {
+            "CNAME": "lucendev.onrender.com"
+        }
+    }
+    


### PR DESCRIPTION
Register lucen.is-a.dev with CNAME record pointing to lucendev.onrender.com.