### PR TITLE
BETA: Register johnroylapida.is-a.dev

### DIFF
--- a/domains/johnroylapida.json
+++ b/domains/johnroylapida.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "SnoopyCodeX",
+        "email": "johnroy062102calimlim@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `johnroylapida.is-a.dev` using the [dashboard](https://manage.is-a.dev).