### PR TITLE
BETA: Register college-front.is-a.dev

### DIFF
--- a/domains/college-front.json
+++ b/domains/college-front.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "amir-mohammad-HP",
+        "email": "hamidipour97@gmail.com"
+    },
+    "record": {
+        "CNAME": "front.collegesaz.ir"
+    }
+}


### PR DESCRIPTION
Added `college-front.is-a.dev` using the [dashboard](https://manage.is-a.dev).