### PR TITLE
BETA: Register lunar.is-a.dev

### DIFF
--- a/domains/lunar.json
+++ b/domains/lunar.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "Lunarate",
+        "email": "veershrivastava1011@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `lunar.is-a.dev` using the [dashboard](https://manage.is-a.dev).