### PR TITLE
BETA: Register xenside.is-a.dev

### DIFF
--- a/domains/xenside.json
+++ b/domains/xenside.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "XenSideNBTS",
+        "email": "peskoila89@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `xenside.is-a.dev` using the [dashboard](https://manage.is-a.dev).