### PR TITLE
BETA: Register markgurney.is-a.dev

### DIFF
--- a/domains/markgurney.json
+++ b/domains/markgurney.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Superchicken962",
+        "email": "superchicken9962@gmail.com"
+    },
+    "record": {
+        "CNAME": "superchicken962.github.io"
+    }
+}


### PR DESCRIPTION
Added `markgurney.is-a.dev` using the [dashboard](https://manage.is-a.dev).