### PR TITLE
BETA: Register ander.is-a.dev

### DIFF
--- a/domains/ander.json
+++ b/domains/ander.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "anderctrl",
+        "email": "anderzrdev@skiff.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `ander.is-a.dev` using the [dashboard](https://manage.is-a.dev).