### PR TITLE
BETA: Register kacper.is-a.dev

### DIFF
--- a/domains/kacper.json
+++ b/domains/kacper.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "flink1337",
+        "email": "haviksior@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `kacper.is-a.dev` using the [dashboard](https://manage.is-a.dev).