### PR TITLE
BETA: Register daku.is-a.dev

### DIFF
--- a/domains/daku.json
+++ b/domains/daku.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "DakUOfficial",
+        "email": "dominiku718@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `daku.is-a.dev` using the [dashboard](https://manage.is-a.dev).