### PR TITLE
BETA: Register einzi.is-a.dev

### DIFF
--- a/domains/einzi.json
+++ b/domains/einzi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "asnlg",
+        "email": "tsgdevil63@yahoo.com"
+    },
+    "record": {
+        "TXT": "something"
+    }
+}


### PR DESCRIPTION
Added `einzi.is-a.dev` using the [dashboard](https://manage.is-a.dev).