### PR TITLE
BETA: Register zeazolf.is-a.dev

### DIFF
--- a/domains/zeazolf.json
+++ b/domains/zeazolf.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "ZeaZolf",
+        "email": "ZeaZolfPc@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `zeazolf.is-a.dev` using the [dashboard](https://manage.is-a.dev).