### PR TITLE
BETA: Register hentai.is-a.dev

### DIFF
--- a/domains/hentai.json
+++ b/domains/hentai.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "simswaper",
+        "email": "root@nic3sw2g.xyz"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `hentai.is-a.dev` using the [dashboard](https://manage.is-a.dev).