### PR TITLE
BETA: Register diverlin.is-a.dev

### DIFF
--- a/domains/diverlin.json
+++ b/domains/diverlin.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "D1verlin",
+        "email": "dodobrest006@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `diverlin.is-a.dev` using the [dashboard](https://manage.is-a.dev).