### PR TITLE
Register jsttan.is-a.dev

### DIFF
--- a/domains/jsttan.json
+++ b/domains/jsttan.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Jst-Tan",
+           "email": "77162018+Jst-Tan@users.noreply.github.com",
+           "discord": "1077450378880233512"
+        },
+    
+        "record": {
+            "CNAME": "jst-tan.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register jsttan.is-a.dev with CNAME record pointing to jst-tan.github.io.