### PR TITLE
BETA: Register tawogrant.is-a.dev

### DIFF
--- a/domains/tawogrant.json
+++ b/domains/tawogrant.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "TgkCapture",
+        "email": "tawongakanyenda5@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `tawogrant.is-a.dev` using the [dashboard](https://manage.is-a.dev).