### PR TITLE
Update sotto.is-a.dev

### DIFF
--- a/domains/sotto.json
+++ b/domains/sotto.json
@@ -4,6 +4,11 @@
         "email": "andreykelbler@outlook.de"
     },
     "record": {
-        "CNAME": "proxy.private.danbot.host"
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
     }
 }


### PR DESCRIPTION
Updated `sotto.is-a.dev` using the [dashboard](https://manage.is-a.dev).