### PR TITLE
BETA: Register ddos777.is-a.dev

### DIFF
--- a/domains/ddos777.json
+++ b/domains/ddos777.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "ARGHOZALI",
+        "email": "arghozalichannel@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `ddos777.is-a.dev` using the [dashboard](https://manage.is-a.dev).