### PR TITLE
Register blatant.is-a.dev

### DIFF
--- a/domains/blatant.json
+++ b/domains/blatant.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "jjjjjjjns",
+           "email": "63760073+jjjjjjjns@users.noreply.github.com",
+           "discord": "749473211594309714"
+        },
+    
+        "record": {
+            "TXT": "shrekmandev"
+        }
+    }
+    


### PR DESCRIPTION
Register blatant.is-a.dev with TXT record pointing to [here](https://jjjjjjjns.github.io/).