### PR TITLE
BETA: Register hexadecimalbyte.is-a.dev

### DIFF
--- a/domains/hexadecimalbyte.json
+++ b/domains/hexadecimalbyte.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HexadecimalByte",
+        "email": "stefan.wulf@t-online.de"
+    },
+    "record": {
+        "URL": "hexadecimalbyte.github.io"
+    }
+}

--- a/domains/hexadecimalbyte.json
+++ b/domains/hexadecimalbyte.json
@@ -4,6 +4,6 @@
         "email": "stefan.wulf@t-online.de"
     },
     "record": {
-        "URL": "hexadecimalbyte.github.io"
+        "URL": "https://hexadecimalbyte.github.io"
     }
 }


### PR DESCRIPTION
Added `hexadecimalbyte.is-a.dev` using the [dashboard](https://manage.is-a.dev).