### PR TITLE
BETA: Register ben-landon.is-a.dev

### DIFF
--- a/domains/ben-landon.json
+++ b/domains/ben-landon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "https123456789",
+        "email": "benl.landon@proton.me"
+    },
+    "record": {
+        "URL": "https://ben-landon.shuttleapp.rs"
+    }
+}


### PR DESCRIPTION
Added `ben-landon.is-a.dev` using the [dashboard](https://manage.is-a.dev).