### PR TITLE
BETA: Register bongopentester.is-a.dev

### DIFF
--- a/domains/bongopentester.json
+++ b/domains/bongopentester.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "iamunixtz",
+        "email": "unixtz@protonmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `bongopentester.is-a.dev` using the [dashboard](https://manage.is-a.dev).