### PR TITLE
BETA: Register painfuego.is-a.dev

### DIFF
--- a/domains/painfuego.json
+++ b/domains/painfuego.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "flame3301",
+        "email": "neongamerflame@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `painfuego.is-a.dev` using the [dashboard](https://manage.is-a.dev).