### PR TITLE
BETA: Register bryce.is-a.dev

### DIFF
--- a/domains/bryce.json
+++ b/domains/bryce.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "addinz",
+        "email": "leachbryce8@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `bryce.is-a.dev` using the [dashboard](https://manage.is-a.dev).