### PR TITLE
BETA: Register ryobotz.is-a.dev

### DIFF
--- a/domains/ryobotz.json
+++ b/domains/ryobotz.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "FrosGaming",
+        "email": "dgfrosdgfros@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `ryobotz.is-a.dev` using the [dashboard](https://manage.is-a.dev).