### PR TITLE
BETA: Register kaist-server.is-a.dev

### DIFF
--- a/domains/kaist-server.json
+++ b/domains/kaist-server.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "predict-woo",
+        "email": "andyye.jongcye@gmail.com"
+    },
+    "record": {
+        "A": ["130.162.135.186"]
+    }
+}


### PR DESCRIPTION
Added `kaist-server.is-a.dev` using the [dashboard](https://manage.is-a.dev).