### PR TITLE
BETA: Register jiawei.is-a.dev

### DIFF
--- a/domains/jiawei.json
+++ b/domains/jiawei.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "Beebeeoii",
+        "email": "b33b33o11@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `jiawei.is-a.dev` using the [dashboard](https://manage.is-a.dev).