### PR TITLE
BETA: Register lain.is-a.dev

### DIFF
--- a/domains/lain.json
+++ b/domains/lain.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "LainUnchained",
+        "email": "lain.un@protonmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `lain.is-a.dev` using the [dashboard](https://manage.is-a.dev).