### PR TITLE
BETA: Register onlytris.is-a.dev

### DIFF
--- a/domains/onlytris.json
+++ b/domains/onlytris.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tq56968",
+        "email": "tq56968@gmail.com"
+    },
+    "record": {
+        "A": ["103.252.137.101"]
+    }
+}


### PR DESCRIPTION
Added `onlytris.is-a.dev` using the [dashboard](https://manage.is-a.dev).