### PR TITLE
BETA: Register whiffedk.is-a.dev

### DIFF
--- a/domains/whiffedk.json
+++ b/domains/whiffedk.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "WhiffedKnight",
+        "email": "abalabalscratch@gmail.com"
+    },
+    "record": {
+        "CNAME": "whiffedknight.github.io"
+    }
+}


### PR DESCRIPTION
Added `whiffedk.is-a.dev` using the [dashboard](https://manage.is-a.dev).