### PR TITLE
BETA: Register mourad.is-a.dev

### DIFF
--- a/domains/mourad.json
+++ b/domains/mourad.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "mourai",
+        "email": "m@mourai.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `mourad.is-a.dev` using the [dashboard](https://manage.is-a.dev).