### PR TITLE
BETA: Register masterle.is-a.dev

### DIFF
--- a/domains/masterle.json
+++ b/domains/masterle.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mast3rle",
+        "email": "iam@mast3rle.xyz"
+    },
+    "record": {
+        "URL": "https://dev.mast3rle.xyz"
+    }
+}


### PR DESCRIPTION
Added `masterle.is-a.dev` using the [dashboard](https://manage.is-a.dev).