### PR TITLE
BETA: Register haloethans.is-a.dev

### DIFF
--- a/domains/haloethans.json
+++ b/domains/haloethans.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "haloethanz",
+        "email": "haloethans-twitch@outlook.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `haloethans.is-a.dev` using the [dashboard](https://manage.is-a.dev).