### PR TITLE
BETA: Register tylerdotnet.is-a.dev

### DIFF
--- a/domains/tylerdotnet.json
+++ b/domains/tylerdotnet.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tylerdotnet",
+        "email": "tylerdotnet@gmail.com"
+    },
+    "record": {
+        "CNAME": "tylerdotnet.github.io"
+    }
+}


### PR DESCRIPTION
Added `tylerdotnet.is-a.dev` using the [dashboard](https://manage.is-a.dev).