### PR TITLE
BETA: Register naltheduck.is-a.dev

### DIFF
--- a/domains/naltheduck.json
+++ b/domains/naltheduck.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "PewZew",
+        "email": "lanlehoang957@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `naltheduck.is-a.dev` using the [dashboard](https://manage.is-a.dev).