### PR TITLE
BETA: Register whiff.is-a.dev

### DIFF
--- a/domains/whiff.json
+++ b/domains/whiff.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "WhiffedKnight",
+        "email": "abalabalscratch@gmail.com"
+    },
+    "record": {
+        "CNAME": "whiffedknight.github.io"
+    }
+}


### PR DESCRIPTION
Added `whiff.is-a.dev` using the [dashboard](https://manage.is-a.dev).