### PR TITLE
BETA: Register montana.is-a.dev

### DIFF
--- a/domains/montana.json
+++ b/domains/montana.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "dnscat",
+        "email": "thilo.x.kaufmann@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `montana.is-a.dev` using the [dashboard](https://manage.is-a.dev).