### PR TITLE
BETA: Register ligmatv.is-a.dev

### DIFF
--- a/domains/ligmatv.json
+++ b/domains/ligmatv.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "LIGMATV",
+        "email": "danishnaufal049@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `ligmatv.is-a.dev` using the [dashboard](https://manage.is-a.dev).