### PR TITLE
BETA: Register toonshub.is-a.dev

### DIFF
--- a/domains/toonshub.json
+++ b/domains/toonshub.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "dakshy",
+        "email": "daksh.yadav.2704@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `toonshub.is-a.dev` using the [dashboard](https://manage.is-a.dev).