### PR TITLE
BETA: Register blockbreaker.is-a.dev

### DIFF
--- a/domains/blockbreaker.json
+++ b/domains/blockbreaker.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "tootypatrooty6",
+        "email": "jmekhi32@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `blockbreaker.is-a.dev` using the [dashboard](https://manage.is-a.dev).