### PR TITLE
BETA: Register drippypop.is-a.dev

### DIFF
--- a/domains/blockbreaker.json
+++ b/domains/blockbreaker.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TheBlockbreaker",
+        "email": "burstsgodly@gmail.com"
+    },
+    "record": {
+        "TXT": "did=did:plc:agavl34uosnej4h54haas6aj"
+    }
+}

--- a/domains/drippypop.json
+++ b/domains/drippypop.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "TheBlockbreaker",
+        "email": "burstsgodly@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `drippypop.is-a.dev` using the [dashboard](https://manage.is-a.dev).