### PR TITLE
BETA: Register abar.is-a.dev

### DIFF
--- a/domains/abar.json
+++ b/domains/abar.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "ABAR5SUB",
+        "email": "pchacker928@gmail.com"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `abar.is-a.dev` using the [dashboard](https://manage.is-a.dev).