### PR TITLE
BETA: Register zuygui.is-a.dev

### DIFF
--- a/domains/zuygui.json
+++ b/domains/zuygui.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "zuygui",
+        "email": "maxime@halbitte.fr"
+    },
+    "record": {
+        "A": [
+            "217.174.245.249",
+            "51.161.54.161"
+            ],
+        "MX": ["mail.is-a.dev"],
+        "TXT": "v=spf1 mx a:mail.is-a.dev ~all"
+    }
+}


### PR DESCRIPTION
Added `zuygui.is-a.dev` using the [dashboard](https://manage.is-a.dev).