### PR TITLE
BETA: Register xyront.is-a.dev

### DIFF
--- a/domains/xyront.json
+++ b/domains/xyront.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Xyront",
+        "email": "abalabalscratch@gmail.com"
+    },
+    "record": {
+        "CNAME": "xyront.github.io"
+    }
+}


### PR DESCRIPTION
Added `xyront.is-a.dev` using the [dashboard](https://manage.is-a.dev).