### PR TITLE
BETA: Register rnv.is-a.dev

### DIFF
--- a/domains/rnv.json
+++ b/domains/rnv.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ZeroDeaths379",
+        "email": "arnavp651@gmail.com"
+    },
+    "record": {
+        "CNAME": "zerodeaths379-github-io.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `rnv.is-a.dev` using the [dashboard](https://manage.is-a.dev).