### PR TITLE
BETA: Register grantcards.is-a.dev

### DIFF
--- a/domains/grantcards.json
+++ b/domains/grantcards.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "calvgrant",
+        "email": "alvinnobeltungga@gmail.com"
+    },
+    "record": {
+        "CNAME": "calvgrant.github.io"
+    }
+}


### PR DESCRIPTION
Added `grantcards.is-a.dev` using the [dashboard](https://manage.is-a.dev).