### PR TITLE
BETA: Register kryptx.is-a.dev

### DIFF
--- a/domains/kryptx.json
+++ b/domains/kryptx.json
@@ -4,6 +4,6 @@
         "email": "k3px@proton.me"
     },
     "record": {
-        "CNAME": "kryptx.github.io"
+        "CNAME": "0kryptx.github.io"
     }
 }

--- a/domains/kryptx.json
+++ b/domains/kryptx.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "0kryptx",
+        "email": "k3px@proton.me"
+    },
+    "record": {
+        "CNAME": "kryptx.github.io"
+    }
+}


### PR DESCRIPTION
Added `kryptx.is-a.dev` using the [dashboard](https://manage.is-a.dev).