### PR TITLE
BETA: Register r1p.is-a.dev

### DIFF
--- a/domains/r1p.json
+++ b/domains/r1p.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "0kryptx",
+        "email": "k3px@proton.me"
+    },
+    "record": {
+        "CNAME": "0kryptx.github.io"
+    }
+}


### PR DESCRIPTION
Added `r1p.is-a.dev` using the [dashboard](https://manage.is-a.dev).