### PR TITLE
BETA: Register as.is-a.dev

### DIFF
--- a/domains/as.json
+++ b/domains/as.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "red78massive1573",
+        "email": "owenhendrawanismyname@gmail.com"
+    },
+    "record": {
+        "URL": "https://red78massive1573.github.io"
+    }
+}


### PR DESCRIPTION
Added `as.is-a.dev` using the [dashboard](https://manage.is-a.dev).