### PR TITLE
BETA: Register tolutz.is-a.dev

### DIFF
--- a/domains/tolutz.json
+++ b/domains/tolutz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "to-lutz",
+        "email": "tobias.lutz07@gmail.com"
+    },
+    "record": {
+        "CNAME": "to-lutz.github.io"
+    }
+}


### PR DESCRIPTION
Added `tolutz.is-a.dev` using the [dashboard](https://manage.is-a.dev).