### PR TITLE
feat(codeowners): assign `.github` to me

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 * @phenax
 
+.github/ @wdhdev
 domains/ @is-a-dev/maintainers
 *.md @is-a-dev/maintainers


### PR DESCRIPTION
This is mainly so I can approve & merge basic workflow updates and stuff when needed without force merging.