### PR TITLE
BETA: Register halil.is-a.dev

### DIFF
--- a/domains/halil.json
+++ b/domains/halil.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "haliiil",
+        "email": "halil.ismail@mercoline.de"
+    },
+    "record": {
+        "A": ["173.249.45.163"]
+    }
+}


### PR DESCRIPTION
Added `halil.is-a.dev` using the [dashboard](https://manage.is-a.dev).