### PR TITLE
BETA: Register luigbren.is-a.dev

### DIFF
--- a/domains/luigbren.json
+++ b/domains/luigbren.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "luigbren",
+        "email": "luigibrenelli@Gmail.com"
+    },
+    "record": {
+        "CNAME": "ns1.a2hosting.com"
+    }
+}


### PR DESCRIPTION
Added `luigbren.is-a.dev` using the [dashboard](https://manage.is-a.dev).