### PR TITLE
BETA: Register hobonatius.is-a.dev

### DIFF
--- a/domains/hobonatius.json
+++ b/domains/hobonatius.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HobonatiusVS",
+        "email": "hobonatius.vs@gmail.com"
+    },
+    "record": {
+        "CNAME": "hobonatius.is.a.dev"
+    }
+}


### PR DESCRIPTION
Added `hobonatius.is-a.dev` using the [dashboard](https://manage.is-a.dev).