### PR TITLE
BETA: Register hazelnut.is-a.dev

### DIFF
--- a/domains/hazelnut.json
+++ b/domains/hazelnut.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HazelNutHoney",
+        "email": "hazelnutzhoney@gmail.com"
+    },
+    "record": {
+        "CNAME": "hazelnuthoney.github.io"
+    }
+}


### PR DESCRIPTION
Added `hazelnut.is-a.dev` using the [dashboard](https://manage.is-a.dev).