### PR TITLE
Register tekaje.is-a.dev

### DIFF
--- a/domains/tekaje.json
+++ b/domains/tekaje.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "CNAME": "zarxd.github.io/tkj-one-gallery"
+            "CNAME": "zarxd.github.io"
         }
     }
     

--- a/domains/tekaje.json
+++ b/domains/tekaje.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "ZarXD",
+           "email": "banghads09@gmail.com",
+           "discord": "835526814088298526"
+        },
+    
+        "record": {
+            "CNAME": "zarxd.github.io/tkj-one-gallery"
+        }
+    }
+    


### PR DESCRIPTION
Register tekaje.is-a.dev with CNAME record pointing to zarxd.github.io/tkj-one-gallery.