### PR TITLE
BETA: Register jumanji.is-a.dev

### DIFF
--- a/domains/jumanji.json
+++ b/domains/jumanji.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "heyjumanji",
+        "email": "madhuchutiya.unhinge650@silomails.com"
+    },
+    "record": {
+        "CNAME": "heyjumanji.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `jumanji.is-a.dev` using the [dashboard](https://manage.is-a.dev).