### PR TITLE
Register Froniz.is-a.dev

### DIFF
--- a/domains/froniz.json
+++ b/domains/froniz.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Froniz",
+           "email": "discordmarc1912@gmail.com",
+           "discord": "1002293564782411787"
+        },
+    
+        "record": {
+            "A": ["144.91.116.153"]
+        }
+    }
+    


### PR DESCRIPTION
Register Froniz.is-a.dev with URL record pointing to https://zerodadev.github.io/Resume/.