### PR TITLE
BETA: Register gassayping.is-a.dev

### DIFF
--- a/domains/gassayping.json
+++ b/domains/gassayping.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "gassayping",
+        "email": "Dev_Gassayping@proton.me"
+    },
+    "record": {
+        "CNAME": "gassayping.github.io"
+    }
+}


### PR DESCRIPTION
Added `gassayping.is-a.dev` using the [dashboard](https://manage.is-a.dev).