### PR TITLE
feat(validation): acme challenge support

### DIFF
--- a/tests/validations.test.js
+++ b/tests/validations.test.js
@@ -65,6 +65,7 @@ describe('validateDomainData', () => {
     { ...defaultDomain, record: { A: '::1' } },
     { ...defaultDomain, name: '_discord' },
     { ...defaultDomain, name: '_gitlab-pages-verification-code' },
+    { ...defaultDomain, name: '_acme-challenge' },
   ];
 
   const validCases = [
@@ -96,6 +97,7 @@ describe('validateDomainData', () => {
     { ...defaultDomain, record: { A: ['122.222.222.222'] } },
     { ...defaultDomain, name: '_discord.subdomain' },
     { ...defaultDomain, name: '_gitlab-pages-verification-code.subdomain' },
+    { ...defaultDomain, name: '_acme-challenge.subdomain' },
   ];
 
   it('should return false for invalid data', () => {

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -40,6 +40,7 @@ const extraSupportedNames = [
   testRegex(/^_github(-pages)?-challenge-[a-z0-9-_]+$/i), // Exception for github verification records
   R.equals('_discord'),
   R.equals('_gitlab-pages-verification-code'),
+  R.equals('_acme-challenge'),
 ]
 
 const validateDomainData = validate({


### PR DESCRIPTION
This PR will allow users to add `_acme-challenge` records to their subdomains to be able to generate SSL certificates using DNS verification.

In future, we should add a cleanup workflow which runs every week or so, so old challenge records are deleted.

I am waiting for at least 5 approvals by our staff team (at least 3 maintainers and 2 helpers) to approve this PR as I would like to get their thoughts on the change.