### PR TITLE
BETA: Register boldbydesign.is-a.dev

### DIFF
--- a/domains/boldbydesign.json
+++ b/domains/boldbydesign.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Boldbydesign",
+        "email": "jeremiah.helfer@protonmail.com"
+    },
+    "record": {
+        "URL": "boldbydesign.is-a-.dev"
+    }
+}


### PR DESCRIPTION
Added `boldbydesign.is-a.dev` using the [dashboard](https://manage.is-a.dev).