### PR TITLE
BETA: Register h1roune.is-a.dev

### DIFF
--- a/domains/h1roune.json
+++ b/domains/h1roune.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zarqizoubir",
+        "email": "zarqi.ezzoubair@etu.uae.ac.ma"
+    },
+    "record": {
+        "CNAME": "zarqi.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `h1roune.is-a.dev` using the [dashboard](https://manage.is-a.dev).