### PR TITLE
BETA: Register lasse.is-a.dev

### DIFF
--- a/domains/lasse.json
+++ b/domains/lasse.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lassejlv",
+        "email": "vestergaardlasse2@gmail.com"
+    },
+    "record": {
+        "CNAME": "golden-salmiakki-932791.netlify.app"
+    }
+}


### PR DESCRIPTION
Added `lasse.is-a.dev` using the [dashboard](https://manage.is-a.dev).