### PR TITLE
BETA: Register evie.is-a.dev

### DIFF
--- a/domains/evie.json
+++ b/domains/evie.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Socketlike",
+        "email": "evelynxii.xt@gmail.com"
+    },
+    "record": {
+        "TXT": "dh=2ffdb09f9be5f3f51fe2089c4cced6ec296d490e"
+    }
+}


### PR DESCRIPTION
Added `evie.is-a.dev` using the [dashboard](https://manage.is-a.dev).