### PR TITLE
BETA: Register evie.is-a.dev

### DIFF
--- a/domains/evie.json
+++ b/domains/evie.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Socketlike",
+        "email": "evelynxii.xt@gmail.com"
+    },
+    "record": {
+        "CNAME": "socketlike.github.io"
+    }
+}


### PR DESCRIPTION
Added `evie.is-a.dev` using the [dashboard](https://manage.is-a.dev).