### PR TITLE
BETA: Register thunderos.is-a.dev

### DIFF
--- a/domains/thunderos.json
+++ b/domains/thunderos.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Shadowolfofficial",
+        "email": "mol.a42360@gmail.com"
+    },
+    "record": {
+        "URL": "google.fr"
+    }
+}


### PR DESCRIPTION
Added `thunderos.is-a.dev` using the [dashboard](https://manage.is-a.dev).