### PR TITLE
BETA: Register acevatex.is-a.dev

### DIFF
--- a/domains/acevatex.json
+++ b/domains/acevatex.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Acevatex",
+        "email": "superboss12309playz@gmail.com"
+    },
+    "record": {
+        "CNAME": "1"
+    }
+}


### PR DESCRIPTION
Added `acevatex.is-a.dev` using the [dashboard](https://manage.is-a.dev).