### PR TITLE
BETA: Register letscrypt.is-a.dev

### DIFF
--- a/domains/letscrypt.json
+++ b/domains/letscrypt.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ProxyProviders",
+        "email": "proxyproviders@kekeke.nl"
+    },
+    "record": {
+        "A": ["193.38.55.146"]
+    }
+}


### PR DESCRIPTION
Added `letscrypt.is-a.dev` using the [dashboard](https://manage.is-a.dev).