### PR TITLE
BETA: Register adde.is-a.dev

### DIFF
--- a/domains/adde.json
+++ b/domains/adde.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zovl1",
+        "email": "adrianheiktim@gmail.com"
+    },
+    "record": {
+        "CNAME": "www"
+    }
+}


### PR DESCRIPTION
Added `adde.is-a.dev` using the [dashboard](https://manage.is-a.dev).