### PR TITLE
BETA: Register fyphen.is-a.dev

### DIFF
--- a/domains/fyphen.json
+++ b/domains/fyphen.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Fyphen1223",
+        "email": "fyphensub@gmail.com"
+    },
+    "record": {
+        "CNAME": "hacker-bot.ddns.net"
+    }
+}


### PR DESCRIPTION
Added `fyphen.is-a.dev` using the [dashboard](https://manage.is-a.dev).