### PR TITLE
BETA: Register kavin.is-a.dev (domain name error reapplying)

### DIFF
--- a/domains/kavin81.json
+++ b/domains/kavin81.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "kavin81",
+        "email": "kavin6462@gmail.com"
+    },
+    "record": {
+        "CNAME": "kavin81.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `kavin.is-a.dev` using the [dashboard](https://manage.is-a.dev).