### PR TITLE
BETA: Register nostallmc.is-a.dev

### DIFF
--- a/domains/nostallmc.json
+++ b/domains/nostallmc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "matejkoo217",
+        "email": "hajekmatej21@gmail.com"
+    },
+    "record": {
+        "URL": "https://e7aad7e3af7e2b68aab9bba68dd3f6af.loophole.site/"
+    }
+}


### PR DESCRIPTION
Added `nostallmc.is-a.dev` using the [dashboard](https://manage.is-a.dev).