### PR TITLE
BETA: Register laman.is-a.dev

### DIFF
--- a/domains/laman.json
+++ b/domains/laman.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Derogater",
+        "email": "thelazybloggers@gmail.com"
+    },
+    "record": {
+        "TXT": "txt"
+    }
+}


### PR DESCRIPTION
Added `laman.is-a.dev` using the [dashboard](https://manage.is-a.dev).