### PR TITLE
BETA: Register gabit.is-a.dev

### DIFF
--- a/domains/gabit.json
+++ b/domains/gabit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Gabituss",
+        "email": "gabit.mail@yandex.ru"
+    },
+    "record": {
+        "A": ["141.8.195.113"]
+    }
+}


### PR DESCRIPTION
Added `gabit.is-a.dev` using the [dashboard](https://manage.is-a.dev).