### PR TITLE
BETA: Register blog.is-a.dev

### DIFF
--- a/domains/blog.json
+++ b/domains/blog.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "longcy",
+        "email": "a92lcy@163.com"
+    },
+    "record": {
+        "URL": "https://m.mfbtg.com/"
+    }
+}


### PR DESCRIPTION
Added `blog.is-a.dev` using the [dashboard](https://manage.is-a.dev).