### PR TITLE
BETA: Register durov.is-a.dev

### DIFF
--- a/domains/durov.json
+++ b/domains/durov.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BobleGun",
+        "email": "dobroq1954@gmail.com"
+    },
+    "record": {
+        "CNAME": "durov"
+    }
+}

--- a/domains/telegram.json
+++ b/domains/telegram.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BobleGun",
+        "email": "dobroq1954@gmail.com"
+    },
+    "record": {
+        "TXT": "telegram"
+    }
+}

--- a/domains/tor.json
+++ b/domains/tor.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BobleGun",
+        "email": "dobroq1954@gmail.com"
+    },
+    "record": {
+        "TXT": "tor"
+    }
+}


### PR DESCRIPTION
Added `durov.is-a.dev` using the [dashboard](https://manage.is-a.dev).