### PR TITLE
BETA: Register prodefix.is-a.dev

### DIFF
--- a/domains/prodefix.json
+++ b/domains/prodefix.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "PRODEFIX",
+        "email": "prodefix.ytb@gmail.com"
+    },
+    "record": {
+        "CNAME": "prodefix.github.io"
+    }
+}


### PR DESCRIPTION
Added `prodefix.is-a.dev` using the [dashboard](https://manage.is-a.dev).