### PR TITLE
BETA: Register hotsuop.is-a.dev

### DIFF
--- a/domains/hotsuop.json
+++ b/domains/hotsuop.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hotsu0p",
+        "email": "jwstephenson1000@gmail.com"
+    },
+    "record": {
+        "TXT": "test"
+    }
+}


### PR DESCRIPTION
Added `hotsuop.is-a.dev` using the [dashboard](https://manage.is-a.dev).