### PR TITLE
BETA: Register vrxxdev.is-a.dev

### DIFF
--- a/domains/vrxxdev.json
+++ b/domains/vrxxdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Its-VrxxDev",
+        "email": "vrxxdev@gmail.com"
+    },
+    "record": {
+        "CNAME": "5c89de66-4d03-4838-842d-4745a6da887d-00-mv6wfn8khxkg.pike.replit.dev"
+    }
+}


### PR DESCRIPTION
Added `vrxxdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).