### PR TITLE
BETA: Register dark-py.is-a.dev

### DIFF
--- a/domains/dark-py.json
+++ b/domains/dark-py.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Vishal-1756",
+        "email": "vishalborse2885@gmail.com"
+    },
+    "record": {
+        "URL": "dark.py"
+    }
+}


### PR DESCRIPTION
Added `dark-py.is-a.dev` using the [dashboard](https://manage.is-a.dev).