### PR TITLE
BETA: Register moncef.is-a.dev

### DIFF
--- a/domains/moncef.json
+++ b/domains/moncef.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "m2ncef",
+        "email": "moncxff@gmail.com"
+    },
+    "record": {
+        "URL": "https://m2ncef.github.io/"
+    }
+}


### PR DESCRIPTION
Added `moncef.is-a.dev` using the [dashboard](https://manage.is-a.dev).