### PR TITLE
BETA: Register mtt.is-a.dev

### DIFF
--- a/domains/mtt.json
+++ b/domains/mtt.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "itzmtt",
+        "email": "matt.sozzi@gmail.com"
+    },
+    "record": {
+        "CNAME": "serve.obinode.com"
+    }
+}


### PR DESCRIPTION
Added `mtt.is-a.dev` using the [dashboard](https://manage.is-a.dev).