### PR TITLE
BETA: Register yieldray.is-a.dev

### DIFF
--- a/domains/yieldray.json
+++ b/domains/yieldray.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "YieldRay",
+        "email": "yieldray@outlook.com"
+    },
+    "record": {
+        "URL": "https://ray.deno.dev/"
+    }
+}


### PR DESCRIPTION
Added `yieldray.is-a.dev` using the [dashboard](https://manage.is-a.dev).