### PR TITLE
BETA: Register wolfdev.is-a.dev

### DIFF
--- a/domains/wolfdev.json
+++ b/domains/wolfdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "wolf1729",
+        "email": "aryanm1729@gmail.com"
+    },
+    "record": {
+        "CNAME": "wolfdev"
+    }
+}


### PR DESCRIPTION
Added `wolfdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).