### PR TITLE
BETA: Register vleov.is-a.dev

### DIFF
--- a/domains/vleov.json
+++ b/domains/vleov.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vLeov",
+        "email": "leo.goetz2008@gmail.com"
+    },
+    "record": {
+        "CNAME": "vleov"
+    }
+}


### PR DESCRIPTION
Added `vleov.is-a.dev` using the [dashboard](https://manage.is-a.dev).