### PR TITLE
BETA: Register alfari.is-a.dev

### DIFF
--- a/domains/alfari.json
+++ b/domains/alfari.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "alfari24",
+        "email": "ari@alfari.id"
+    },
+    "record": {
+        "A": ["194.15.36.220"]
+    }
+}


### PR DESCRIPTION
Added `alfari.is-a.dev` using the [dashboard](https://manage.is-a.dev).