### PR TITLE
Register agn.is-a.dev

### DIFF
--- a/domains/agn.json
+++ b/domains/agn.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "agnesmonret",
+           "email": "agnesmoret@proton.me",
+           "discord": "694917200720429066"
+        },
+    
+        "record": {
+            "CNAME": "agnesmonret.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register agn.is-a.dev with CNAME record pointing to agnesmonret.github.io.