### PR TITLE
BETA: Register baptiste.is-a.dev

### DIFF
--- a/domains/baptiste.json
+++ b/domains/baptiste.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BapRx",
+        "email": "rouxbaptiste@outlook.com"
+    },
+    "record": {
+        "CNAME": "baprx.github.io"
+    }
+}


### PR DESCRIPTION
Added `baptiste.is-a.dev` using the [dashboard](https://manage.is-a.dev).