### PR TITLE
BETA: Register kirill.adamuk.is-a.dev

### DIFF
--- a/domains/kirill.adamuk.json
+++ b/domains/kirill.adamuk.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "superhorsy",
+        "email": "adamuk.kirill@gmail.com"
+    },
+    "record": {
+        "CNAME": "superhorsy.github.io"
+    }
+}


### PR DESCRIPTION
Added `kirill.adamuk.is-a.dev` using the [dashboard](https://manage.is-a.dev).