### PR TITLE
BETA: Register magdi.is-a.dev

### DIFF
--- a/domains/magdi.json
+++ b/domains/magdi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "coeur85",
+        "email": "ahmed.magdi@msn.com"
+    },
+    "record": {
+        "MX": ["mx01.mail.icloud.com"]
+    }
+}


### PR DESCRIPTION
Added `magdi.is-a.dev` using the [dashboard](https://manage.is-a.dev).