### PR TITLE
BETA: Register hrdq.is-a.dev

### DIFF
--- a/domains/hrdq.json
+++ b/domains/hrdq.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "h6rd",
+        "email": "crack4ys@gmail.com"
+    },
+    "record": {
+        "CNAME": "hrdq.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `hrdq.is-a.dev` using the [dashboard](https://manage.is-a.dev).