### PR TITLE
BETA: Register xuancuong.is-a.dev

### DIFF
--- a/domains/xuancuong.json
+++ b/domains/xuancuong.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CuongChab",
+        "email": "tkncuong06@gmail.com"
+    },
+    "record": {
+        "A": ["192.168.0.1"]
+    }
+}


### PR DESCRIPTION
Added `xuancuong.is-a.dev` using the [dashboard](https://manage.is-a.dev).