### PR TITLE
BETA: Register durov.is-a.dev

### DIFF
--- a/domains/durov.json
+++ b/domains/durov.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BobleGun",
+        "email": "dobroq1954@gmail.com"
+    },
+    "record": {
+        "CNAME": "a0913910.xsph.ru"
+    }
+}


### PR DESCRIPTION
Added `durov.is-a.dev` using the [dashboard](https://manage.is-a.dev).