### PR TITLE
BETA: Register randomalex.is-a.dev

### DIFF
--- a/domains/randomalex.json
+++ b/domains/randomalex.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "randomalex221",
+        "email": "the.bluecrafter122@gmail.com"
+    },
+    "record": {
+        "A": ["84.186.36.153"]
+    }
+}


### PR DESCRIPTION
Added `randomalex.is-a.dev` using the [dashboard](https://manage.is-a.dev).