### PR TITLE
BETA: Register oceannetwork.is-a.dev

### DIFF
--- a/domains/oceannetwork.json
+++ b/domains/oceannetwork.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ikcaaft",
+        "email": "mitchelblokker@hotmail.com"
+    },
+    "record": {
+        "URL": "https://7b5d5049-e5ab-47a5-93c2-14b263d69fce-00-2y8olb6cg2med.janeway.replit.dev/index.html"
+    }
+}


### PR DESCRIPTION
Added `oceannetwork.is-a.dev` using the [dashboard](https://manage.is-a.dev).