### PR TITLE
⏪️ Add *cfp domains back yet again

### DIFF
--- a/domains/cfp.json
+++ b/domains/cfp.json
@@ -1,0 +1,10 @@
+{
+	"owner": {
+	  "username": "cfpwastaken",
+	  "email": "",
+	  "discord": "cfp (318394797822050315)"
+	},
+	"record": {
+	  "CNAME": "cfp.gotdns.ch"
+	}
+}

--- a/domains/pic.cfp.json
+++ b/domains/pic.cfp.json
@@ -1,0 +1,11 @@
+{
+	"description": "Private Immich server",
+	"owner": {
+	  "username": "cfpwastaken",
+	  "email": "",
+	  "discord": "cfp (318394797822050315)"
+	},
+	"record": {
+	  "CNAME": "cfp.gotdns.ch"
+	}
+}

--- a/domains/scfp.json
+++ b/domains/scfp.json
@@ -1,0 +1,11 @@
+{
+	"description": "Cfp Short Service",
+	"owner": {
+	  "username": "cfpwastaken",
+	  "email": "",
+	  "discord": "cfp (318394797822050315)"
+	},
+	"record": {
+	  "CNAME": "cfp.gotdns.ch"
+	}
+}

--- a/domains/status.cfp.json
+++ b/domains/status.cfp.json
@@ -1,0 +1,11 @@
+{
+	"description": "Cfp Status",
+	"owner": {
+		"username": "cfpwastaken",
+		"email": "",
+		"discord": "cfp (318394797822050315)"
+	},
+	"record": {
+		"CNAME": "cfp.gotdns.ch"
+	}
+}


### PR DESCRIPTION
<!-- Please complete this template so we can review your pull request faster. -->
My domains have been removed by pull #11598 yet again for returning a 502. I strongly don't believe think that all of my web services started returning 502's at the same time.

This has already happened in #9887 (removal) #9917 (adding back) and I am already getting sick of it, it makes the is-a-dev service seem a little bit unreliable if you remove a domain just for a server slipping and returning a 502 for a bit. I suggest having the script run on 2 days, requesting all the domains twice to see who is responding correctly again to then not remove.

Apologize for the little rant.

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Twitter) so we can contact you. -->

## Website Link/Preview
<!-- Please provide a link or preview of your website below. -->
Requires adding the domains to cfp.gotdns.ch's IP into the hosts file, as nginx auto-redirects back to the .is-a.dev domain.