### PR TITLE
BETA: Register nightdoom.is-a.dev

### DIFF
--- a/domains/nightdoom.json
+++ b/domains/nightdoom.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zororishi",
+        "email": "fgvikingyt0956@gmail.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=nightdoom.is-a.dev,5711e6a41f95623e7dda"
+    }
+}


### PR DESCRIPTION
Added `nightdoom.is-a.dev` using the [dashboard](https://manage.is-a.dev).