### PR TITLE
BETA: Register tarifsadman.is-a.dev

### DIFF
--- a/domains/tarifsadman.json
+++ b/domains/tarifsadman.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TarifSadman",
+        "email": "sadmantaha17@gmail.com"
+    },
+    "record": {
+        "CNAME": "tarif"
+    }
+}


### PR DESCRIPTION
Added `tarifsadman.is-a.dev` using the [dashboard](https://manage.is-a.dev).