### PR TITLE
BETA: Register benz.is-a.dev

### DIFF
--- a/domains/benz.json
+++ b/domains/benz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MicroBenz",
+        "email": "microbenz.prob@gmail.com"
+    },
+    "record": {
+        "CNAME": "microbenz.in.th"
+    }
+}


### PR DESCRIPTION
Added `benz.is-a.dev` using the [dashboard](https://manage.is-a.dev).