### PR TITLE
BETA: Register adoqet.is-a.dev

### DIFF
--- a/domains/adoqet.json
+++ b/domains/adoqet.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AdoQeT",
+        "email": "adoqet@gmail.com"
+    },
+    "record": {
+        "CNAME": "adoqet.github.io"
+    }
+}


### PR DESCRIPTION
Added `adoqet.is-a.dev` using the [dashboard](https://manage.is-a.dev).