### PR TITLE
BETA: Register nanonavigate.is-a.dev

### DIFF
--- a/domains/nanonavigate.json
+++ b/domains/nanonavigate.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Kurumi30",
+        "email": "fernandoshengxinzhu@gmail.com"
+    },
+    "record": {
+        "URL": "https://nanonavigate.onrender.com/"
+    }
+}


### PR DESCRIPTION
Added `nanonavigate.is-a.dev` using the [dashboard](https://manage.is-a.dev).