### PR TITLE
BETA: Register cdn.trung.is-a.dev

### DIFF
--- a/domains/cdn.trung.json
+++ b/domains/cdn.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}


### PR DESCRIPTION
Added `cdn.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).