### PR TITLE
BETA: Register devbrainless.is-a.dev

### DIFF
--- a/domains/devbrainless.json
+++ b/domains/devbrainless.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Badless",
+        "email": "karolczeeek@gmail.com"
+    },
+    "record": {
+        "CNAME": "badless.github.io"
+    }
+}


### PR DESCRIPTION
Added `devbrainless.is-a.dev` using the [dashboard](https://manage.is-a.dev).