### PR TITLE
BETA: Register morfinagg.is-a.dev

### DIFF
--- a/domains/morfinagg.json
+++ b/domains/morfinagg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "valencia-spec",
+        "email": "bartekwyszolmirski@outlook.com"
+    },
+    "record": {
+        "CNAME": "morfinagg"
+    }
+}


### PR DESCRIPTION
Added `morfinagg.is-a.dev` using the [dashboard](https://manage.is-a.dev).