### PR TITLE
BETA: Register gachugu.is-a.dev

### DIFF
--- a/domains/gachugu.json
+++ b/domains/gachugu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BryanGachugu",
+        "email": "gachugusville@gmail.com"
+    },
+    "record": {
+        "CNAME": "bryangachugu.github.io"
+    }
+}


### PR DESCRIPTION
Added `gachugu.is-a.dev` using the [dashboard](https://manage.is-a.dev).