### PR TITLE
BETA: Register hongkorium.is-a.dev

### DIFF
--- a/domains/hongkorium.json
+++ b/domains/hongkorium.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HongKorium",
+        "email": "kklau1615@gmail.com"
+    },
+    "record": {
+        "CNAME": "hongkorium.github.io"
+    }
+}


### PR DESCRIPTION
Added `hongkorium.is-a.dev` using the [dashboard](https://manage.is-a.dev).