### PR TITLE
BETA: Register mosa.is-a.dev

### DIFF
--- a/domains/mosa.json
+++ b/domains/mosa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mosageneral",
+        "email": "mosageneral@gmail.com"
+    },
+    "record": {
+        "A": ["130.162.164.99"]
+    }
+}


### PR DESCRIPTION
Added `mosa.is-a.dev` using the [dashboard](https://manage.is-a.dev).