### PR TITLE
BETA: Register kazuoyk.is-a.dev

### DIFF
--- a/domains/kazuoyk.json
+++ b/domains/kazuoyk.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "KazuoYK",
+        "email": "d4rknewbie@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/kazuoyk/dev"
+    }
+}


### PR DESCRIPTION
Added `kazuoyk.is-a.dev` using the [dashboard](https://manage.is-a.dev).