### PR TITLE
BETA: Register note.is-a.dev

### DIFF
--- a/domains/note.json
+++ b/domains/note.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "imimbert",
+        "email": "2080035494@qq.com"
+    },
+    "record": {
+        "CNAME": "imimbert.github.io"
+    }
+}


### PR DESCRIPTION
Added `note.is-a.dev` using the [dashboard](https://manage.is-a.dev).