### PR TITLE
BETA: Register nonam4lol.is-a.dev

### DIFF
--- a/domains/nonam4lol.json
+++ b/domains/nonam4lol.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Nonam4lol",
+        "email": "literallynoname13@gmail.com"
+    },
+    "record": {
+        "A": ["45.11.229.211"]
+    }
+}


### PR DESCRIPTION
Added `nonam4lol.is-a.dev` using the [dashboard](https://manage.is-a.dev).