### PR TITLE
BETA: Register sky-bridge.is-a.dev

### DIFF
--- a/domains/sky-bridge.json
+++ b/domains/sky-bridge.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "levisurely",
+        "email": "jr1264464@gmail.com"
+    },
+    "record": {
+        "CNAME": "levisurely.github.io"
+    }
+}


### PR DESCRIPTION
Added `sky-bridge.is-a.dev` using the [dashboard](https://manage.is-a.dev).