### PR TITLE
BETA: Register boseong.is-a.dev

### DIFF
--- a/domains/boseong.json
+++ b/domains/boseong.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "2paperstar",
+        "email": "lee@paperst.ar"
+    },
+    "record": {
+        "CNAME": "paperst.ar"
+    }
+}

--- a/domains/paperstar.json
+++ b/domains/paperstar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "2paperstar",
+        "email": "lee@paperst.ar"
+    },
+    "record": {
+        "CNAME": "paperst.ar"
+    }
+}


### PR DESCRIPTION
Added `boseong.is-a.dev` using the [dashboard](https://manage.is-a.dev).