### PR TITLE
BETA: Register brandgrandreal.is-a.dev

### DIFF
--- a/domains/brandgrandreal.json
+++ b/domains/brandgrandreal.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BrandgrandRealMe",
+        "email": "brandon.lambe@skiff.com"
+    },
+    "record": {
+        "CNAME": "brandgrandrealme.github.io"
+    }
+}


### PR DESCRIPTION
Added `brandgrandreal.is-a.dev` using the [dashboard](https://manage.is-a.dev).