### PR TITLE
BETA: Register efbotlink.is-a.dev

### DIFF
--- a/domains/efbotlink.json
+++ b/domains/efbotlink.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Heroku403",
+        "email": "juhisharma0757@gmail.com"
+    },
+    "record": {
+        "CNAME": "amorphous-tiger-uqyq9wgl8mh7keh8qonqzxst.herokudns.com"
+    }
+}


### PR DESCRIPTION
Added `efbotlink.is-a.dev` using the [dashboard](https://manage.is-a.dev).