### PR TITLE
BETA: Register preston-code.is-a.dev

### DIFF
--- a/domains/preston-code.json
+++ b/domains/preston-code.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Preston-Riley",
+        "email": "doooogy7738@gmail.com"
+    },
+    "record": {
+        "CNAME": "77738"
+    }
+}


### PR DESCRIPTION
Added `preston-code.is-a.dev` using the [dashboard](https://manage.is-a.dev).