### PR TITLE
BETA: Register xenside.is-a.dev

### DIFF
--- a/domains/xenside.json
+++ b/domains/xenside.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "XenSideNBTS",
+        "email": "peskoila89@gmail.com"
+    },
+    "record": {
+        "URL": "https://xensidewtf.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `xenside.is-a.dev` using the [dashboard](https://manage.is-a.dev).