### PR TITLE
BETA: Register larp.is-a.dev

### DIFF
--- a/domains/larp.json
+++ b/domains/larp.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lhwe",
+        "email": "arieslovespiggies@gmail.com"
+    },
+    "record": {
+        "A": ["64.23.128.177"]
+    }
+}


### PR DESCRIPTION
Added `larp.is-a.dev` using the [dashboard](https://manage.is-a.dev).