### PR TITLE
Register cdn.artix.is-a.dev

### DIFF
--- a/domains/cdn.artix.json
+++ b/domains/cdn.artix.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "alex1028199",
+           "email": "yu1234u73f.com@gmail.com",
+           "discord": "834867471885271053"
+        },
+    
+        "record": {
+            "A": ["69.30.249.53"]
+        }
+    }
+    


### PR DESCRIPTION
Register cdn.artix.is-a.dev with A record pointing to 69.30.249.53.