### PR TITLE
BETA: Register oogway.is-a.dev

### DIFF
--- a/domains/oogway.json
+++ b/domains/oogway.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ActualMasterOogway",
+        "email": "williasfun@gmail.com"
+    },
+    "record": {
+        "URL": "https://actualmasteroogway.github.io"
+    }
+}


### PR DESCRIPTION
Added `oogway.is-a.dev` using the [dashboard](https://manage.is-a.dev).