### PR TITLE
BETA: Register fluor.is-a.dev

### DIFF
--- a/domains/fluor.json
+++ b/domains/fluor.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "PlowDev",
+        "email": "clicpowytb@gmail.com"
+    },
+    "record": {
+        "CNAME": "fluor.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `fluor.is-a.dev` using the [dashboard](https://manage.is-a.dev).