### PR TITLE
BETA: Register quark.is-a.dev

### DIFF
--- a/domains/quark.json
+++ b/domains/quark.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "quarkhadron",
+        "email": "quark1337hadron@gmail.com"
+    },
+    "record": {
+        "URL": "https://www.quarkhadron.dev/"
+    }
+}


### PR DESCRIPTION
Added `quark.is-a.dev` using the [dashboard](https://manage.is-a.dev).