### PR TITLE
BETA: Register titan.is-a.dev

### DIFF
--- a/domains/titan.json
+++ b/domains/titan.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "bhoopesh369",
+        "email": "bhoopesh459@gmail.com"
+    },
+    "record": {
+        "A": ["217.174.245.249"]
+    }
+}


### PR DESCRIPTION
Added `titan.is-a.dev` using the [dashboard](https://manage.is-a.dev).