### PR TITLE
BETA: Register axe.is-a.dev

### DIFF
--- a/domains/axe.json
+++ b/domains/axe.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "axelawh",
+        "email": "lewisbrown171@gmail.com"
+    },
+    "record": {
+        "A": ["195.20.254.54"]
+    }
+}


### PR DESCRIPTION
Added `axe.is-a.dev` using the [dashboard](https://manage.is-a.dev).