### PR TITLE
BETA: Register mystic.trung.is-a.dev

### DIFF
--- a/domains/mystic.trung.json
+++ b/domains/mystic.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}


### PR DESCRIPTION
Added `mystic.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).