### PR TITLE
BETA: Register queaxtra.is-a.dev

### DIFF
--- a/domains/queaxtra.json
+++ b/domains/queaxtra.json
@@ -4,6 +4,6 @@
         "email": "fatihbgr@duck.com"
     },
     "record": {
-        "TXT": "vc-domain-verify=queaxtra.is-a.dev,99c8c889ab11cf641590"
+        "CNAME": "queaxtra-me.pages.dev"
     }
 }

--- a/domains/queaxtra.json
+++ b/domains/queaxtra.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Queaxtra",
+        "email": "fatihbgr@duck.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=queaxtra.is-a.dev,99c8c889ab11cf641590"
+    }
+}


### PR DESCRIPTION
Added `queaxtra.is-a.dev` using the [dashboard](https://manage.is-a.dev).