### PR TITLE
BETA: Register lengyandong.is-a.dev

### DIFF
--- a/domains/lengyandong.json
+++ b/domains/lengyandong.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lengyandong",
+        "email": "3052868271@qq.com"
+    },
+    "record": {
+        "URL": "http://fence.rf.gd"
+    }
+}


### PR DESCRIPTION
Added `lengyandong.is-a.dev` using the [dashboard](https://manage.is-a.dev).