### PR TITLE
BETA: Register ngt.is-a.dev

### DIFF
--- a/domains/ngt.json
+++ b/domains/ngt.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "7ngt",
+        "email": "contatofthales@gmail.com"
+    },
+    "record": {
+        "URL": "https://discord.com/users/906639702558375986"
+    }
+}


### PR DESCRIPTION
Added `ngt.is-a.dev` using the [dashboard](https://manage.is-a.dev).