### PR TITLE
BETA: Register hadi.is-a.dev

### DIFF
--- a/domains/hadi.json
+++ b/domains/hadi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zexscode",
+        "email": "zexscode@gmail.com"
+    },
+    "record": {
+        "CNAME": "zexscode.github.io"
+    }
+}


### PR DESCRIPTION
Added `hadi.is-a.dev` using the [dashboard](https://manage.is-a.dev).