### PR TITLE
BETA: Register daudix.is-a.dev

### DIFF
--- a/domains/daudix.json
+++ b/domains/daudix.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "daudix",
+        "email": "ddaudix@gmail.com"
+    },
+    "record": {
+        "URL": "https://daudix.codeberg.page"
+    }
+}


### PR DESCRIPTION
Added `daudix.is-a.dev` using the [dashboard](https://manage.is-a.dev).