### PR TITLE
BETA: Register chutte.is-a.dev

### DIFF
--- a/domains/chutte.json
+++ b/domains/chutte.json
@@ -4,6 +4,6 @@
         "email": "savindusupunsathsara@gmail.com"
     },
     "record": {
-        "TXT": "_vercel"
+        "CNAME": "supunsathsara.pages.dev"
     }
 }

--- a/domains/chutte.json
+++ b/domains/chutte.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "supunsathsara",
+        "email": "savindusupunsathsara@gmail.com"
+    },
+    "record": {
+        "TXT": "_vercel"
+    }
+}


### PR DESCRIPTION
Added `chutte.is-a.dev` using the [dashboard](https://manage.is-a.dev).