### PR TITLE
BETA: Register .minecraft.is-a.dev

### DIFF
--- a/domains/.minecraft.json
+++ b/domains/.minecraft.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hey122112",
+        "email": "dsucks853@gmail.com"
+    },
+    "record": {
+        "URL": "https://hey122112.github.io/eaglerx/"
+    }
+}


### PR DESCRIPTION
Added `.minecraft.is-a.dev` using the [dashboard](https://manage.is-a.dev).