### PR TITLE
BETA: Register links.trung.is-a.dev

### DIFF
--- a/domains/links.trung.json
+++ b/domains/links.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}


### PR DESCRIPTION
Added `links.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).