### PR TITLE
BETA: Register notme.is-a.dev

### DIFF
--- a/domains/notme.json
+++ b/domains/notme.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dohphuc",
+        "email": "dpc255779@gmail.com"
+    },
+    "record": {
+        "URL": "notme.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `notme.is-a.dev` using the [dashboard](https://manage.is-a.dev).