### PR TITLE
BETA: Register zero-kurosaki.is-a.dev

### DIFF
--- a/domains/zero-kurosaki.json
+++ b/domains/zero-kurosaki.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Zero-Kurosaki",
+        "email": "zero.sorasaki@gmail.com"
+    },
+    "record": {
+        "CNAME": "1"
+    }
+}


### PR DESCRIPTION
Added `zero-kurosaki.is-a.dev` using the [dashboard](https://manage.is-a.dev).