### PR TITLE
BETA: Register galaxymusicbot.is-a.dev

### DIFF
--- a/domains/galaxymusicbot.json
+++ b/domains/galaxymusicbot.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NICK-FURY-6023",
+        "email": "partham302@gmail.com"
+    },
+    "record": {
+        "CNAME": "ooo3"
+    }
+}


### PR DESCRIPTION
Added `galaxymusicbot.is-a.dev` using the [dashboard](https://manage.is-a.dev).