### PR TITLE
BETA: Register pgh.is-a.dev

### DIFF
--- a/domains/pgh.json
+++ b/domains/pgh.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "thanhnguyen2075",
+        "email": "abc.bingboong@yahoo.com.vn"
+    },
+    "record": {
+        "A": ["103.75.187.18"]
+    }
+}


### PR DESCRIPTION
Added `pgh.is-a.dev` using the [dashboard](https://manage.is-a.dev).