### PR TITLE
BETA: Register effex.is-a.dev

### DIFF
--- a/domains/effex.json
+++ b/domains/effex.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "noteffex",
+        "email": "effex.wtf@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/noteffex"
+    }
+}


### PR DESCRIPTION
Added `effex.is-a.dev` using the [dashboard](https://manage.is-a.dev).