### PR TITLE
BETA: Register newyear.trung.is-a.dev.is-a.dev

### DIFF
--- a/domains/newyear.trung.is-a.dev.json
+++ b/domains/newyear.trung.is-a.dev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "CNAME": "lunar-newyr-countdown.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `newyear.trung.is-a.dev.is-a.dev` using the [dashboard](https://manage.is-a.dev).