### PR TITLE
BETA: Register chsmusic.is-a.dev

### DIFF
--- a/domains/chsmusic.json
+++ b/domains/chsmusic.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "GeraldTM1",
+        "email": "kodijpayne@gmail.com"
+    },
+    "record": {
+        "CNAME": "chsmusic.is-a-dev"
+    }
+}


### PR DESCRIPTION
Added `chsmusic.is-a.dev` using the [dashboard](https://manage.is-a.dev).