### PR TITLE
BETA: Register grafaffel.is-a.dev

### DIFF
--- a/domains/clyde.json
+++ b/domains/clyde.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Grafaffel",
+        "email": "jannisfischer170@gmail.com"
+    },
+    "record": {
+        "URL": "nextsuite.vercel.app"
+    }
+}

--- a/domains/grafaffel.json
+++ b/domains/grafaffel.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Grafaffel",
+        "email": "jannisfischer170@gmail.com"
+    },
+    "record": {
+        "TXT": "dh=4c26ba63fb6abf8c6750481e5fead70cadb12120"
+    }
+}

--- a/domains/wumpus.json
+++ b/domains/wumpus.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Grafaffel",
+        "email": "jannisfischer170@gmail.com"
+    },
+    "record": {
+        "URL": "grafaffel.github.io"
+    }
+}


### PR DESCRIPTION
Added `grafaffel.is-a.dev` using the [dashboard](https://manage.is-a.dev).