### PR TITLE
BETA: Register markblum.is-a.dev

### DIFF
--- a/domains/markblum.json
+++ b/domains/markblum.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mblumdumes",
+        "email": "mark@el-blum.de"
+    },
+    "record": {
+        "CNAME": "el-blum.selfhost.co"
+    }
+}


### PR DESCRIPTION
Added `markblum.is-a.dev` using the [dashboard](https://manage.is-a.dev).