### PR TITLE
BETA: Register carpodi.is-a.dev

### DIFF
--- a/domains/carpodi.json
+++ b/domains/carpodi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Carpodi",
+        "email": "itsjahzielgarcia07@gmail.com"
+    },
+    "record": {
+        "CNAME": "carpodi.github.io"
+    }
+}


### PR DESCRIPTION
Added `carpodi.is-a.dev` using the [dashboard](https://manage.is-a.dev).