### PR TITLE
BETA: Register hookerfun.is-a.dev

### DIFF
--- a/domains/hookerfun.json
+++ b/domains/hookerfun.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Hiallthejetbrains",
+        "email": "bjpythonemails@gmail.com"
+    },
+    "record": {
+        "CNAME": "random"
+    }
+}


### PR DESCRIPTION
Added `hookerfun.is-a.dev` using the [dashboard](https://manage.is-a.dev).