### PR TITLE
BETA: Register osint.is-a.dev

### DIFF
--- a/domains/osint.json
+++ b/domains/osint.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "EpicMw",
+        "email": "epiccashmw@protonmail.com"
+    },
+    "record": {
+        "CNAME": "osint.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `osint.is-a.dev` using the [dashboard](https://manage.is-a.dev).