### PR TITLE
BETA: Register mongodb.trung.is-a.dev

### DIFF
--- a/domains/mongodb.trung.json
+++ b/domains/mongodb.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}

--- a/domains/newyear.trung.is-a.dev.json
+++ b/domains/newyear.trung.is-a.dev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "CNAME": "lunar-newyr-countdown.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `mongodb.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).