### PR TITLE
BETA: Register ngocnt.is-a.dev

### DIFF
--- a/domains/ngocnt.json
+++ b/domains/ngocnt.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "blackmouse572",
+        "email": "Ngocvlqt1995@gmail.com"
+    },
+    "record": {
+        "TXT": "vc-domain-verify=www.ngocnt.is-a.dev,d33b85c6babc11523aeb"
+    }
+}


### PR DESCRIPTION
Added `ngocnt.is-a.dev` using the [dashboard](https://manage.is-a.dev).