### PR TITLE
BETA: Register docs.trung.is-a.dev

### DIFF
--- a/domains/docs.trung.json
+++ b/domains/docs.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "CNAME": "c40e958615-hosting.gitbook.io"
+    }
+}


### PR DESCRIPTION
Added `docs.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).