### PR TITLE
BETA: Register zirc.is-a.dev

### DIFF
--- a/domains/zirc.json
+++ b/domains/zirc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LolzTheDev",
+        "email": "lolzthegreat.0223@gmail.com"
+    },
+    "record": {
+        "URL": "https://lolzthedev.github.io/zirc.is-a.dev/"
+    }
+}


### PR DESCRIPTION
Added `zirc.is-a.dev` using the [dashboard](https://manage.is-a.dev).