### PR TITLE
BETA: Register gen1x.is-a.dev

### DIFF
--- a/domains/gen1x.json
+++ b/domains/gen1x.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Gen1x-ALT",
+        "email": "theg1nx@hotmail.com"
+    },
+    "record": {
+        "CNAME": "gen1x-alt.github.io"
+    }
+}


### PR DESCRIPTION
Added `gen1x.is-a.dev` using the [dashboard](https://manage.is-a.dev).