### PR TITLE
BETA: Register status.trung.is-a.dev

### DIFF
--- a/domains/status.trung.json
+++ b/domains/status.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}


### PR DESCRIPTION
Added `status.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).