### PR TITLE
BETA: Register m.avila.is-a.dev

### DIFF
--- a/domains/m.avila.json
+++ b/domains/m.avila.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DxRavage",
+        "email": "marianoavilaj4@gmail.com"
+    },
+    "record": {
+        "CNAME": "www.m.avila.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `m.avila.is-a.dev` using the [dashboard](https://manage.is-a.dev).