### PR TITLE
BETA: Register buc-aa.is-a.dev

### DIFF
--- a/domains/buc-aa.json
+++ b/domains/buc-aa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AtlasL1",
+        "email": "loxingle1@gmail.com"
+    },
+    "record": {
+        "CNAME": "buc-aa.github.io"
+    }
+}


### PR DESCRIPTION
Added `buc-aa.is-a.dev` using the [dashboard](https://manage.is-a.dev).