### PR TITLE
BETA: Register bypixeltv.is-a.dev

### DIFF
--- a/domains/bypixeltv.json
+++ b/domains/bypixeltv.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "byPixelTV",
+        "email": "lukasfurich@gmail.com"
+    },
+    "record": {
+        "CNAME": "elaborate-faloodeh-c1d64a.netlify.app"
+    }
+}


### PR DESCRIPTION
Added `bypixeltv.is-a.dev` using the [dashboard](https://manage.is-a.dev).