### PR TITLE
BETA: Register unnst.is-a.dev

### DIFF
--- a/domains/unnst.json
+++ b/domains/unnst.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "482migs",
+        "email": "amberisamab@gmail.com"
+    },
+    "record": {
+        "CNAME": "unnst.github.io"
+    }
+}


### PR DESCRIPTION
Added `unnst.is-a.dev` using the [dashboard](https://manage.is-a.dev).