### PR TITLE
BETA: Register prestoncode.is-a.dev

### DIFF
--- a/domains/preston-code.json
+++ b/domains/preston-code.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Preston-Riley",
+        "email": "doooogy7738@gmail.com"
+    },
+    "record": {
+        "CNAME": "77738"
+    }
+}

--- a/domains/prestoncode.json
+++ b/domains/prestoncode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Preston-Riley",
+        "email": "pres1234569@gmail.com"
+    },
+    "record": {
+        "URL": "https://prestoncode.wixsite.com/preston-code"
+    }
+}


### PR DESCRIPTION
Added `prestoncode.is-a.dev` using the [dashboard](https://manage.is-a.dev).