### PR TITLE
BETA: Register vinn.is-a.dev

### DIFF
--- a/domains/vinn.json
+++ b/domains/vinn.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vincentma2",
+        "email": "vinnie@mauriello.org"
+    },
+    "record": {
+        "A": ["93.184.216.34"]
+    }
+}


### PR DESCRIPTION
Added `vinn.is-a.dev` using the [dashboard](https://manage.is-a.dev).