### PR TITLE
BETA: Register silentprogrammer.is-a.dev

### DIFF
--- a/domains/silentprogrammer.json
+++ b/domains/silentprogrammer.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Tanmay-Tiwaricyber",
+        "email": "tanmaytiwaricyber@gmail.com"
+    },
+    "record": {
+        "CNAME": "is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `silentprogrammer.is-a.dev` using the [dashboard](https://manage.silentprogrammer.is-a.dev).