### PR TITLE
BETA: Register rscg.is-a.dev

### DIFF
--- a/domains/rscg.json
+++ b/domains/rscg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Krishpkreame",
+        "email": "krishpkreame1405+github@gmail.com"
+    },
+    "record": {
+        "URL": "https://krishpkreame.github.io/"
+    }
+}


### PR DESCRIPTION
Added `rscg.is-a.dev` using the [dashboard](https://manage.is-a.dev).