### PR TITLE
BETA: Register nevo.is-a.dev

### DIFF
--- a/domains/nevo.json
+++ b/domains/nevo.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NevoM4",
+        "email": "nevomordechai@gmail.com"
+    },
+    "record": {
+        "URL": "google.com"
+    }
+}


### PR DESCRIPTION
Added `nevo.is-a.dev` using the [dashboard](https://manage.is-a.dev).