### PR TITLE
BETA: Register cloudirector.is-a.dev

### DIFF
--- a/domains/cloudirector.json
+++ b/domains/cloudirector.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "cloudirector",
+        "email": "cantcloud@gmail.com"
+    },
+    "record": {
+        "TXT": "123456"
+    }
+}


### PR DESCRIPTION
Added `cloudirector.is-a.dev` using the [dashboard](https://manage.is-a.dev).