### PR TITLE
BETA: Register wernerpi.is-a.dev

### DIFF
--- a/domains/wernerpi.json
+++ b/domains/wernerpi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "werner314",
+        "email": "werner.pynappel@gmail.com"
+    },
+    "record": {
+        "A": ["127.0.0.1"]
+    }
+}


### PR DESCRIPTION
Added `wernerpi.is-a.dev` using the [dashboard](https://manage.is-a.dev).