### PR TITLE
BETA: Register noe.is-a.dev

### DIFF
--- a/domains/noe.json
+++ b/domains/noe.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NoeFirst",
+        "email": "noecortinovis@icloud.com"
+    },
+    "record": {
+        "URL": "noefirst.github.io"
+    }
+}


### PR DESCRIPTION
Added `noe.is-a.dev` using the [dashboard](https://manage.is-a.dev).