### PR TITLE
BETA: Register zeph.is-a.dev

### DIFF
--- a/domains/zeph.json
+++ b/domains/zeph.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "maanya125",
+        "email": "maanya125@gmail.com"
+    },
+    "record": {
+        "URL": "https://hero154.space"
+    }
+}


### PR DESCRIPTION
Added `zeph.is-a.dev` using the [dashboard](https://manage.is-a.dev).