### PR TITLE
BETA: Register albanna.is-a.dev

### DIFF
--- a/domains/albanna.json
+++ b/domains/albanna.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Abdullah-Albanna",
+        "email": "albannaa78@gmail.com"
+    },
+    "record": {
+        "CNAME": "abdullah-albanna.github.io"
+    }
+}


### PR DESCRIPTION
Added `albanna.is-a.dev` using the [dashboard](https://manage.is-a.dev).