### PR TITLE
BETA: Register ardox.is-a.dev

### DIFF
--- a/domains/ardox.json
+++ b/domains/ardox.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LeVraiArdox",
+        "email": "adrian.arjoca18@gmail.com"
+    },
+    "record": {
+        "CNAME": "ardox.is-a.dev"
+    }
+}

--- a/domains/levraiardox.json
+++ b/domains/levraiardox.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LeVraiArdox",
+        "email": "adrian.arjoca18@gmail.com"
+    },
+    "record": {
+        "CNAME": "ardox.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `ardox.is-a.dev` using the [dashboard](https://manage.is-a.dev).