### PR TITLE
BETA: Register mango.is-a.dev

### DIFF
--- a/domains/mango.json
+++ b/domains/mango.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "JuicyMangoCode",
+        "email": "alicebalicia@gmail.com"
+    },
+    "record": {
+        "TXT": "wonderful"
+    }
+}


### PR DESCRIPTION
Added `mango.is-a.dev` using the [dashboard](https://manage.is-a.dev).