### PR TITLE
BETA: Register kokofixcomputers.is-a.dev

### DIFF
--- a/domains/kokofixcomputers.json
+++ b/domains/kokofixcomputers.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "kokofixcomputers",
+        "email": "github@kokofixcomputers.serv00.net"
+    },
+    "record": {
+        "TXT": "013e49fe981141dd118a0148d40980"
+    }
+}


### PR DESCRIPTION
Added `kokofixcomputers.is-a.dev` using the [dashboard](https://manage.is-a.dev).