### PR TITLE
BETA: Register lunarleaf.is-a.dev

### DIFF
--- a/domains/lunarleaf.json
+++ b/domains/lunarleaf.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LunarLeaf",
+        "email": "laptopaleksa45@gmail.com"
+    },
+    "record": {
+        "CNAME": "lunarleaf.github.io"
+    }
+}


### PR DESCRIPTION
Added `lunarleaf.is-a.dev` using the [dashboard](https://manage.is-a.dev).