### PR TITLE
BETA: Register ehab.is-a.dev

### DIFF
--- a/domains/ehab.json
+++ b/domains/ehab.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ehabmansour1",
+        "email": "mansehab990@gmail.com"
+    },
+    "record": {
+        "CNAME": "ehabmansour1.github.io"
+    }
+}


### PR DESCRIPTION
Added `ehab.is-a.dev` using the [dashboard](https://manage.is-a.dev).