### PR TITLE
BETA: Register tomsystems.is-a.dev

### DIFF
--- a/domains/tomsystems.json
+++ b/domains/tomsystems.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "thesillycat",
+        "email": "tomnetwork@duck.com"
+    },
+    "record": {
+        "CNAME": "tomsystems.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `tomsystems.is-a.dev` using the [dashboard](https://manage.is-a.dev).