### PR TITLE
BETA: Register mario-ruoff.is-a.dev

### DIFF
--- a/domains/escape99.json
+++ b/domains/escape99.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mario-ruoff",
+        "email": "mario.srx99@gmail.com"
+    },
+    "record": {
+        "TXT": "google-site-verification=pdrsvu1q5-kmvrfcccst0xijwx-bdevmlke-g8zyzvg"
+    }
+}


### PR DESCRIPTION
Added `mario-ruoff.is-a.dev` using the [dashboard](https://manage.is-a.dev).