### PR TITLE
BETA: Register mario-ruoff.is-a.dev

### DIFF
--- a/domains/mario-ruoff.json
+++ b/domains/mario-ruoff.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mario-ruoff",
+        "email": "mario.srx99@gmail.com"
+    },
+    "record": {
+        "MX": ["smtp.google.com"]
+    }
+}


### PR DESCRIPTION
Added `mario-ruoff.is-a.dev` using the [dashboard](https://manage.is-a.dev).