### PR TITLE
BETA: Register passadissubmari.is-a.dev

### DIFF
--- a/domains/passadissubmari.json
+++ b/domains/passadissubmari.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Cucusise",
+        "email": "cucusise@gmail.com"
+    },
+    "record": {
+        "URL": "https://cucusise.github.io/passadissummari/"
+    }
+}


### PR DESCRIPTION
Added `passadissubmari.is-a.dev` using the [dashboard](https://manage.is-a.dev).