### PR TITLE
BETA: Register taxen.is-a.dev

### DIFF
--- a/domains/taxen.json
+++ b/domains/taxen.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "taxenlmao",
+        "email": "jayd3ngame@gmail.com"
+    },
+    "record": {
+        "URL": "https://feds.lol/skittles"
+    }
+}


### PR DESCRIPTION
Added `taxen.is-a.dev` using the [dashboard](https://manage.is-a.dev).