### PR TITLE
BETA: Register undercontr.is-a.dev

### DIFF
--- a/domains/undercontr.json
+++ b/domains/undercontr.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "undercontr",
+        "email": "onder.alkan15@gmail.com"
+    },
+    "record": {
+        "A": ["45.81.115.76"]
+    }
+}


### PR DESCRIPTION
Added `undercontr.is-a.dev` using the [dashboard](https://manage.is-a.dev).