### PR TITLE
BETA: Register whsprr.is-a.dev

### DIFF
--- a/domains/whsprr.json
+++ b/domains/whsprr.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "whos-whsprr",
+        "email": "cheneycam09@gmail.com"
+    },
+    "record": {
+        "CNAME": "whsprr.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `whsprr.is-a.dev` using the [dashboard](https://manage.is-a.dev).