### PR TITLE
BETA: Register hcs777.is-a.dev

### DIFF
--- a/domains/hcs777.json
+++ b/domains/hcs777.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "emelbaru88",
+        "email": "emelbaruh@gmail.com"
+    },
+    "record": {
+        "CNAME": "hcs777.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `hcs777.is-a.dev` using the [dashboard](https://manage.is-a.dev).