### PR TITLE
BETA: Register levhoppenbrouwers.is-a.dev

### DIFF
--- a/domains/levhoppenbrouwers.json
+++ b/domains/levhoppenbrouwers.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "gayskateboardwizard",
+        "email": "signallost1234@gmail.com"
+    },
+    "record": {
+        "CNAME": "www"
+    }
+}


### PR DESCRIPTION
Added `levhoppenbrouwers.is-a.dev` using the [dashboard](https://manage.is-a.dev).