### PR TITLE
BETA: Register cdn.parsewar.is-a.dev

### DIFF
--- a/domains/cdn.parsewar.json
+++ b/domains/cdn.parsewar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AtharvParsewar",
+        "email": "atharvparsewar@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}


### PR DESCRIPTION
Added `cdn.parsewar.is-a.dev` using the [dashboard](https://manage.is-a.dev).