### PR TITLE
BETA: Register dumo.is-a.dev

### DIFF
--- a/domains/dumo.json
+++ b/domains/dumo.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "thepython555",
+        "email": "k0n52uuu@duck.com"
+    },
+    "record": {
+        "CNAME": "thepython555.github.io"
+    }
+}


### PR DESCRIPTION
Added `dumo.is-a.dev` using the [dashboard](https://manage.is-a.dev).