### PR TITLE
BETA: Register haruharu.is-a.dev

### DIFF
--- a/domains/haruharu.json
+++ b/domains/haruharu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "haruharutv",
+        "email": "gma.denshikogakugroup@gmail.com"
+    },
+    "record": {
+        "CNAME": "haruharutv-admin.netlify.app"
+    }
+}


### PR DESCRIPTION
Added `haruharu.is-a.dev` using the [dashboard](https://manage.is-a.dev).