### PR TITLE
BETA: Register lalit.is-a.dev

### DIFF
--- a/domains/lalit.json
+++ b/domains/lalit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lalitm1004",
+        "email": "lalitm1004@gmail.com"
+    },
+    "record": {
+        "TXT": "_vercel"
+    }
+}


### PR DESCRIPTION
Added `lalit.is-a.dev` using the [dashboard](https://manage.is-a.dev).