### PR TITLE
BETA: Register madaha.is-a.dev

### DIFF
--- a/domains/madaha.json
+++ b/domains/madaha.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "catmaple",
+        "email": "szhaimei@hotmail.com"
+    },
+    "record": {
+        "CNAME": "www"
+    }
+}


### PR DESCRIPTION
Added `madaha.is-a.dev` using the [dashboard](https://manage.is-a.dev).