### PR TITLE
BETA: Register escape99.is-a.dev

### DIFF
--- a/domains/escape99.json
+++ b/domains/escape99.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mario-ruoff",
+        "email": "mario.srx99@gmail.com"
+    },
+    "record": {
+        "TXT": "google-site-verification=pdrsvu1q5-kmvrfcccst0xijwx-bdevmlke-g8zyzvg"
+    }
+}

--- a/domains/mario-ruoff.json
+++ b/domains/mario-ruoff.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mario-ruoff",
+        "email": "mario.srx99@gmail.com"
+    },
+    "record": {
+        "MX": ["smtp.google.com"]
+    }
+}


### PR DESCRIPTION
Added `escape99.is-a.dev` using the [dashboard](https://manage.is-a.dev).