### PR TITLE
BETA: Register skycloudd.is-a.dev

### DIFF
--- a/domains/skycloudd.json
+++ b/domains/skycloudd.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "skycloudd",
+        "email": "benkrassenburg@gmail.com"
+    },
+    "record": {
+        "CNAME": "skycloudd.github.io"
+    }
+}


### PR DESCRIPTION
Added `skycloudd.is-a.dev` using the [dashboard](https://manage.is-a.dev).