### PR TITLE
Register messagecylcer.is-a.dev

### DIFF
--- a/domains/messagecylcer.json
+++ b/domains/messagecylcer.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "syncstudioxyz",
+           "email": "syncstudioxyz@gmail.com",
+           "discord": "774894992728391710"
+        },
+    
+        "record": {
+            "CNAME": "pnode1.danbot.host:5291"
+        }
+    }
+    


### PR DESCRIPTION
Register messagecylcer.is-a.dev with CNAME record pointing to pnode1.danbot.host:5291.