### PR TITLE
BETA: Register keyzz-xvi.is-a.dev

### DIFF
--- a/domains/keyzz-xvi.json
+++ b/domains/keyzz-xvi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "keyzz-xvi",
+        "email": "alexenea08@gmail.com"
+    },
+    "record": {
+        "CNAME": "keyzz-xvi.github.io"
+    }
+}


### PR DESCRIPTION
Added `keyzz-xvi.is-a.dev` using the [dashboard](https://manage.is-a.dev).