### PR TITLE
BETA: Register xeno9118.is-a.dev

### DIFF
--- a/domains/xeno9118.json
+++ b/domains/xeno9118.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Aether1777",
+        "email": "bkevin39415@gmail.com"
+    },
+    "record": {
+        "CNAME": "border.hop.io"
+    }
+}


### PR DESCRIPTION
Added `xeno9118.is-a.dev` using the [dashboard](https://manage.is-a.dev).