### PR TITLE
BETA: Register eletrixtime.is-a.dev

### DIFF
--- a/domains/eletrixtime.json
+++ b/domains/eletrixtime.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "EletrixtimeYT",
+        "email": "lisandro.b@outlook.com"
+    },
+    "record": {
+        "CNAME": "eletrixtimeyt.github.io"
+    }
+}


### PR DESCRIPTION
Added `eletrixtime.is-a.dev` using the [dashboard](https://manage.is-a.dev).