### PR TITLE
BETA: Register dogesploit.is-a.dev

### DIFF
--- a/domains/dogesploit.json
+++ b/domains/dogesploit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Zumwaltboi68",
+        "email": "alexander662022@outlook.com"
+    },
+    "record": {
+        "URL": "https://velocity-v2.dogesploit.byethost15.com/"
+    }
+}


### PR DESCRIPTION
Added `dogesploit.is-a.dev` using the [dashboard](https://manage.is-a.dev).