### PR TITLE
BETA: Register officialxmuiz.is-a.dev

### DIFF
--- a/domains/officialxmuiz.json
+++ b/domains/officialxmuiz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "muiz12320",
+        "email": "muiz9060786@gmail.com"
+    },
+    "record": {
+        "CNAME": "https://manage.is-a.dev/register/"
+    }
+}


### PR DESCRIPTION
Added `officialxmuiz.is-a.dev` using the [dashboard](https://manage.is-a.dev).