### PR TITLE
BETA: Register rgb.is-a.dev

### DIFF
--- a/domains/rgb.json
+++ b/domains/rgb.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "rg6b",
+        "email": "ahmedekrem152005@gmail.com"
+    },
+    "record": {
+        "CNAME": "wonderful-flower-042f34710.4.azurestaticapps.net"
+    }
+}


### PR DESCRIPTION
Added `rgb.is-a.dev` using the [dashboard](https://manage.is-a.dev).