### PR TITLE
Register NineTechnologies.is-a.dev

### DIFF
--- a/domains/ninetechnologies.json
+++ b/domains/ninetechnologies.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Zirmith",
+           "email": "f2v74yt@gmail.com",
+           "discord": "481475041217871882"
+        },
+    
+        "record": {
+            "CNAME": "https://ninetechnologies.is-a.dev"
+        }
+    }
+    


### PR DESCRIPTION
Register NineTechnologies.is-a.dev with CNAME record pointing to https://NineTechnologies.is-a.dev.