### PR TITLE
BETA: Register xtoast.is-a.dev

### DIFF
--- a/domains/xtoast.json
+++ b/domains/xtoast.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Toast0012",
+        "email": "aahansiwakoti1@gmail.com"
+    },
+    "record": {
+        "CNAME": "toastdev.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `xtoast.is-a.dev` using the [dashboard](https://manage.is-a.dev).