### PR TITLE
BETA: Register caesar.is-a.dev

### DIFF
--- a/domains/caesar.json
+++ b/domains/caesar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Illupiter",
+        "email": "lollelxkfo@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}


### PR DESCRIPTION
Added `caesar.is-a.dev` using the [dashboard](https://manage.is-a.dev).