### PR TITLE
BETA: Register klone.is-a.dev

### DIFF
--- a/domains/klone.json
+++ b/domains/klone.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Vai3soh",
+        "email": "work.rwx.seven@gmail.com"
+    },
+    "record": {
+        "A": ["45.153.69.189"]
+    }
+}


### PR DESCRIPTION
Added `klone.is-a.dev` using the [dashboard](https://manage.is-a.dev).