### PR TITLE
BETA: Register valowolf.is-a.dev

### DIFF
--- a/domains/valowolf.json
+++ b/domains/valowolf.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ValoWolf",
+        "email": "starfleet.valowolf@gmail.com"
+    },
+    "record": {
+        "CNAME": "hosts.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `valowolf.is-a.dev` using the [dashboard](https://manage.is-a.dev).