### PR TITLE
BETA: Register mage.is-a.dev

### DIFF
--- a/domains/mage.json
+++ b/domains/mage.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mageclienttt",
+        "email": "mageclienttt@gmail.com"
+    },
+    "record": {
+        "MX": ["mx01.mail.icloud.com"]
+    }
+}


### PR DESCRIPTION
Added `mage.is-a.dev` using the [dashboard](https://manage.is-a.dev).