### PR TITLE
BETA: Register lana.is-a.dev

### DIFF
--- a/domains/lana.json
+++ b/domains/lana.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "xlana16",
+        "email": "maulanasherlock@gmail.com"
+    },
+    "record": {
+        "CNAME": "https://xlana16.github.io/"
+    }
+}


### PR DESCRIPTION
Added `lana.is-a.dev` using the [dashboard](https://manage.is-a.dev).