### PR TITLE
BETA: Register rishub.is-a.dev

### DIFF
--- a/domains/rishub.json
+++ b/domains/rishub.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "itsrishub",
+        "email": "itsrishub@gmail.com"
+    },
+    "record": {
+        "URL": "https://rishub.cc"
+    }
+}


### PR DESCRIPTION
Added `rishub.is-a.dev` using the [dashboard](https://manage.is-a.dev).