### PR TITLE
BETA: Register undercurve.is-a.dev

### DIFF
--- a/domains/undercurve.json
+++ b/domains/undercurve.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "UnderCurve",
+        "email": "partypenguin.today@gmail.com"
+    },
+    "record": {
+        "URL": "undercurve.wdym.info"
+    }
+}


### PR DESCRIPTION
Added `undercurve.is-a.dev` using the [dashboard](https://manage.is-a.dev).