### PR TITLE
BETA: Register jinsek.is-a.dev

### DIFF
--- a/domains/jinsek.json
+++ b/domains/jinsek.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "JinToSek",
+        "email": "jinsekmail@gmail.com"
+    },
+    "record": {
+        "CNAME": "jinsek.rfg"
+    }
+}


### PR DESCRIPTION
Added `jinsek.is-a.dev` using the [dashboard](https://manage.is-a.dev).

Note; The content URL should have been http://jinsek.rf.gd, that website is also not done. 