### PR TITLE
BETA: Register sstudiosdev.is-a.dev

### DIFF
--- a/domains/sstudiosdev.json
+++ b/domains/sstudiosdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Sstudiosdev",
+        "email": "sstudiosdev@gmail.com"
+    },
+    "record": {
+        "CNAME": "sstudiosdev.github.io"
+    }
+}


### PR DESCRIPTION
Added `sstudiosdev.is-a.dev` using the [dashboard](https://manage.is-a.dev).