### PR TITLE
BETA: Register damu.is-a.dev

### DIFF
--- a/domains/damu.json
+++ b/domains/damu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "damnUUUU",
+        "email": "damodar.sssihl@gmail.com"
+    },
+    "record": {
+        "A": ["103.174.70.38"]
+    }
+}


### PR DESCRIPTION
Added `damu.is-a.dev` using the [dashboard](https://manage.is-a.dev).