### PR TITLE
BETA: Register maruf.is-a.dev

### DIFF
--- a/domains/maruf.json
+++ b/domains/maruf.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MarufFLyInfosoft",
+        "email": "maruf@flyinfosoftbd.com"
+    },
+    "record": {
+        "URL": "0xmaruf.tech"
+    }
+}


### PR DESCRIPTION
Added `maruf.is-a.dev` using the [dashboard](https://manage.is-a.dev).