### PR TITLE
BETA: Register luyende.is-a.dev

### DIFF
--- a/domains/luyende.json
+++ b/domains/luyende.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "coangsang",
+        "email": "sangtkx2@gmail.com"
+    },
+    "record": {
+        "CNAME": "gv-dc5d3bwhw7btmc.dv.googlehosted.com"
+    }
+}


### PR DESCRIPTION
Added `luyende.is-a.dev` using the [dashboard](https://manage.is-a.dev).