### PR TITLE
BETA: Register windowsbuild3r.is-a.dev

### DIFF
--- a/domains/windowsbuild3r.json
+++ b/domains/windowsbuild3r.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "davidctinescu",
+        "email": "david.andrei.pisoi@gmail.com"
+    },
+    "record": {
+        "CNAME": "davidctinescu.github.io"
+    }
+}


### PR DESCRIPTION
Added `windowsbuild3r.is-a.dev` using the [dashboard](https://manage.is-a.dev).