### PR TITLE
BETA: Register merely.is-a.dev

### DIFF
--- a/domains/merely.json
+++ b/domains/merely.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MerelyMiserable",
+        "email": "MerelyMiserable@gmail.com"
+    },
+    "record": {
+        "CNAME": "merelymiserable.github.io"
+    }
+}


### PR DESCRIPTION
Added `merely.is-a.dev` using the [dashboard](https://manage.is-a.dev).