### PR TITLE
BETA: Register sammotta.is-a.dev

### DIFF
--- a/domains/sammotta.json
+++ b/domains/sammotta.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "SamMotta",
+        "email": "samuelsamuca953@gmail.com"
+    },
+    "record": {
+        "CNAME": "https://sammotta.github.io/doomfire-algorithm/"
+    }
+}


### PR DESCRIPTION
Added `sammotta.is-a.dev` using the [dashboard](https://manage.is-a.dev).