### PR TITLE
BETA: Register preston-code.is-a.dev

### DIFF
--- a/domains/preston-code.json
+++ b/domains/preston-code.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Preston-Riley",
+        "email": "pres1234569@gmail.com"
+    },
+    "record": {
+        "CNAME": "https://hulking-lettuce.surge.sh/preston-code/prestoncode.wixsite.com/website-2.html"
+    }
+}


### PR DESCRIPTION
Added `preston-code.is-a.dev` using the [dashboard](https://manage.is-a.dev).