### PR TITLE
BETA: Register alp.is-a.dev

### DIFF
--- a/domains/alp.json
+++ b/domains/alp.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "interdict0r",
+        "email": "veilhvh@protonmail.com"
+    },
+    "record": {
+        "CNAME": "polite-rock-04f47f603.4.azurestaticapps.net"
+    }
+}


### PR DESCRIPTION
Added `alp.is-a.dev` using the [dashboard](https://manage.is-a.dev).