### PR TITLE
BETA: Register naps.is-a.dev

### DIFF
--- a/domains/naps.json
+++ b/domains/naps.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "FILMA0010",
+        "email": "k3botxyz@gmail.com"
+    },
+    "record": {
+        "CNAME": "80.75.212.15"
+    }
+}


### PR DESCRIPTION
Added `naps.is-a.dev` using the [dashboard](https://manage.is-a.dev).