### PR TITLE
BETA: Register gcm.is-a.dev

### DIFF
--- a/domains/gcm.json
+++ b/domains/gcm.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Goncermor",
+        "email": "goncalocerto9morais@gmail.com"
+    },
+    "record": {
+        "CNAME": "nprx.goncermor.com"
+    }
+}


### PR DESCRIPTION
Added `gcm.is-a.dev` using the [dashboard](https://manage.is-a.dev).