### PR TITLE
BETA: Register zyronixbot.mznking.is-a.dev

### DIFF
--- a/domains/zyronixbot.mznking.json
+++ b/domains/zyronixbot.mznking.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mznking",
+        "email": "maazinking23@gmail.com"
+    },
+    "record": {
+        "CNAME": "zyronixbot.onrender.com"
+    }
+}


### PR DESCRIPTION
Added `zyronixbot.mznking.is-a.dev` using the [dashboard](https://manage.is-a.dev).