### PR TITLE
BETA: Register onlive.is-a.dev

### DIFF
--- a/domains/onlive.json
+++ b/domains/onlive.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Onlive1337",
+        "email": "tabdulov2006@gmail.com"
+    },
+    "record": {
+        "CNAME": "https://onlive1337.github.io/bio/"
+    }
+}


### PR DESCRIPTION
Added `onlive.is-a.dev` using the [dashboard](https://manage.is-a.dev).