### PR TITLE
BETA: Register abyss.is-a.dev

### DIFF
--- a/domains/abyss.json
+++ b/domains/abyss.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ultimduck",
+        "email": "zultimduk@gmail.com"
+    },
+    "record": {
+        "CNAME": "ultimduck.github.io"
+    }
+}


### PR DESCRIPTION
Added `abyss.is-a.dev` using the [dashboard](https://manage.is-a.dev).