### PR TITLE
BETA: Register fluoresced.is-a.dev

### DIFF
--- a/domains/fluoresced.json
+++ b/domains/fluoresced.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "8FrMc",
+        "email": "pijuskaminskas1@gmail.com"
+    },
+    "record": {
+        "URL": "https://guns.lol/ecq"
+    }
+}


### PR DESCRIPTION
Added `fluoresced.is-a.dev` using the [dashboard](https://manage.is-a.dev).