### PR TITLE
BETA: Register hazardpro.is-a.dev

### DIFF
--- a/domains/hazardpro.json
+++ b/domains/hazardpro.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Ardimua7",
+        "email": "amstoregen2@gmail.com"
+    },
+    "record": {
+        "MX": ["tempm.com"]
+    }
+}


### PR DESCRIPTION
Added `hazardpro.is-a.dev` using the [dashboard](https://manage.is-a.dev).