### PR TITLE
BETA: Register webcubed.is-a.dev

### DIFF
--- a/domains/webcubed.json
+++ b/domains/webcubed.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "webcubed",
+        "email": "lainathannlaiv2@gmail.com"
+    },
+    "record": {
+        "CNAME": "https://webcubed.vercel.app/"
+    }
+}


### PR DESCRIPTION
Added `webcubed.is-a.dev` using the [dashboard](https://manage.is-a.dev).