### PR TITLE
BETA: Register gabs.is-a.dev

### DIFF
--- a/domains/gabs.json
+++ b/domains/gabs.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "gabswastaken",
+        "email": "gabrielnunes3106@gmail.com"
+    },
+    "record": {
+        "CNAME": "gabswastaken.github.io"
+    }
+}


### PR DESCRIPTION
Added `gabs.is-a.dev` using the [dashboard](https://manage.is-a.dev).