### PR TITLE
BETA: Register tasko.is-a.dev

### DIFF
--- a/domains/tasko.json
+++ b/domains/tasko.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ahmadk953",
+        "email": "chofman@outoforgedu.onmicrosoft.com"
+    },
+    "record": {
+        "URL": "threads-clone-one-chi.vercel.app"
+    }
+}


### PR DESCRIPTION
Added `tasko.is-a.dev` using the [dashboard](https://manage.is-a.dev).