### PR TITLE
BETA: Register shikawa.is-a.dev

### DIFF
--- a/domains/shikawa.json
+++ b/domains/shikawa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "devFelipeCustodio",
+        "email": "felipelinscustodio@proton.me"
+    },
+    "record": {
+        "URL": "https://rest-countries-api-with-color-theme-switcher-blond.vercel.app/"
+    }
+}


### PR DESCRIPTION
Added `shikawa.is-a.dev` using the [dashboard](https://manage.is-a.dev).