### PR TITLE
BETA: Register wasim.is-a.dev

### DIFF
--- a/domains/wasim.json
+++ b/domains/wasim.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "misaw-kun",
+        "email": "w.akram.1912@protonmail.com"
+    },
+    "record": {
+        "CNAME": "misaw-kun.bearblog.dev"
+    }
+}


### PR DESCRIPTION
Added `wasim.is-a.dev` using the [dashboard](https://manage.is-a.dev).