### PR TITLE
BETA: Register harukipy.is-a.dev

### DIFF
--- a/domains/harukipy.json
+++ b/domains/harukipy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "haruki-py",
+        "email": "aanandkrishna344@gmail.com"
+    },
+    "record": {
+        "A": ["37.114.37.132"]
+    }
+}


### PR DESCRIPTION
Added `harukipy.is-a.dev` using the [dashboard](https://manage.is-a.dev).