### PR TITLE
BETA: Register ntmusic.is-a.dev

### DIFF
--- a/domains/ntmusic.json
+++ b/domains/ntmusic.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "gunawan092w",
+        "email": "gunawan092w@gmail.com"
+    },
+    "record": {
+        "CNAME": "ntmusic.github.io"
+    }
+}


### PR DESCRIPTION
Added `ntmusic.is-a.dev` using the [dashboard](https://manage.is-a.dev).
https://gunawan092w.github.io/ntmusic/