### PR TITLE
BETA: Register cheesedev.is-a.dev

### DIFF
--- a/domains/cheesedev.json
+++ b/domains/cheesedev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CallenDV",
+        "email": "Callen12344@Gmail.com"
+    },
+    "record": {
+        "URL": "callendv.github.io"
+    }
+}


### PR DESCRIPTION
Added `cheesedev.is-a.dev` using the [dashboard](https://manage.is-a.dev).