### PR TITLE
BETA: Register thenoppy12.is-a.dev (REMOVED)

### DIFF
--- a/domains/thenoppy12.json
+++ b/domains/thenoppy12.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BussyBakks",
+        "email": "lengochuykiengiang@gmail.com"
+    },
+    "record": {
+        "URL": "thenoppy12.github.io"
+    }
+}


### PR DESCRIPTION
Added `thenoppy12.is-a.dev` using the [dashboard](https://manage.is-a.dev).