### PR TITLE
BETA: Register mercy.is-a.dev

### DIFF
--- a/domains/mercy.json
+++ b/domains/mercy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "v1per-xd",
+        "email": "vip3r.d4niel@gmail.com"
+    },
+    "record": {
+        "CNAME": "m3rcy.netlify.app"
+    }
+}


### PR DESCRIPTION
Added `mercy.is-a.dev` using the [dashboard](https://manage.is-a.dev).