### PR TITLE
BETA: Register fisch.is-a.dev

### DIFF
--- a/domains/f1schi1667.json
+++ b/domains/f1schi1667.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Fischss",
+        "email": "dev.F1schi@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/fischss"
+    }
+}

--- a/domains/fisch.json
+++ b/domains/fisch.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Fischss",
+        "email": "dev.F1schi@gmail.com"
+    },
+    "record": {
+        "URL": "fish.is-a.dev"
+    }
+}

--- a/domains/fish.json
+++ b/domains/fish.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Fischss",
+        "email": "dev.F1schi@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/fischss"
+    }
+}


### PR DESCRIPTION
Added `fisch.is-a.dev` using the [dashboard](https://manage.is-a.dev).