### PR TITLE
BETA: Register webouille.is-a.dev

### DIFF
--- a/domains/webouille.json
+++ b/domains/webouille.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MrPidouille",
+        "email": "valentinrobin7500@gmail.com"
+    },
+    "record": {
+        "A": ["69.30.249.53"]
+    }
+}


### PR DESCRIPTION
Added `webouille.is-a.dev` using the [dashboard](https://manage.is-a.dev).