### PR TITLE
BETA: Register messiersixtyfour.is-a.dev

### DIFF
--- a/domains/messiersixtyfour.json
+++ b/domains/messiersixtyfour.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MessierSixtyFour",
+        "email": "messier1244@gmail.com"
+    },
+    "record": {
+        "CNAME": "messiersixtyfour.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `messiersixtyfour.is-a.dev` using the [dashboard](https://manage.is-a.dev).