### PR TITLE
BETA: Register lutherantz.is-a.dev

### DIFF
--- a/domains/lutherantz.json
+++ b/domains/lutherantz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "lutherantz",
+        "email": "akamecanic@gmail.com"
+    },
+    "record": {
+        "CNAME": "lutherantz.github.io"
+    }
+}

--- a/domains/seka.json
+++ b/domains/seka.json
@@ -1,0 +1,12 @@
+{
+    "description": "lutherantz.is-a.dev",
+    "repo": "https://github.com/lutherantz/lutherantz.github.io",
+    "owner": {
+        "username": "lutherantz",
+        "email": "sekausername@gmail.com",
+        "twitter": "sekateur_"
+    },
+    "record": {
+        "CNAME": "lutherantz.github.io"
+    }
+} 


### PR DESCRIPTION
Added `lutherantz.is-a.dev` using the [dashboard](https://manage.is-a.dev).