### PR TITLE
BETA: Register newswacafi.is-a.dev

### DIFF
--- a/domains/newswacafi.json
+++ b/domains/newswacafi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Moussier24",
+        "email": "papicisse24@gmail.com"
+    },
+    "record": {
+        "A": ["173.249.41.98"]
+    }
+}


### PR DESCRIPTION
Added `newswacafi.is-a.dev` using the [dashboard](https://manage.is-a.dev).