### PR TITLE
BETA: Register goose.is-a.dev

### DIFF
--- a/domains/goose.json
+++ b/domains/goose.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ServerDeveloper9447",
+        "email": "soumalyaghosh2022@gmail.com"
+    },
+    "record": {
+        "CNAME": "glitch.edgeapp.net"
+    }
+}


### PR DESCRIPTION
Added `goose.is-a.dev` using the [dashboard](https://manage.is-a.dev).