### PR TITLE
BETA: Register zwu.is-a.dev

### DIFF
--- a/domains/zwu.json
+++ b/domains/zwu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "wu000168",
+        "email": "wuzed@seas.upenn.edu"
+    },
+    "record": {
+        "CNAME": "https://github.com/wu000168"
+    }
+}


### PR DESCRIPTION
Added `zwu.is-a.dev` using the [dashboard](https://manage.is-a.dev).