### PR TITLE
BETA: Register luther.is-a.dev

### DIFF
--- a/domains/luther.json
+++ b/domains/luther.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "SeizedForge",
+        "email": "gamebringerdev@gmail.com"
+    },
+    "record": {
+        "URL": "lutherkorsan.mooo.com"
+    }
+}


### PR DESCRIPTION
Added `luther.is-a.dev` using the [dashboard](https://manage.is-a.dev).