### PR TITLE
BETA: Register servers.is-a.dev

### DIFF
--- a/domains/servers.json
+++ b/domains/servers.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Rage65",
+        "email": "123thetechguy@gmail.com"
+    },
+    "record": {
+        "CNAME": "rage65.duckdns.org"
+    }
+}


### PR DESCRIPTION
Added `servers.is-a.dev` using the [dashboard](https://manage.is-a.dev).