### PR TITLE
BETA: Register dickerpopo.is-a.dev

### DIFF
--- a/domains/dickerpopo.json
+++ b/domains/dickerpopo.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DeveloperPopo",
+        "email": "d.dickerpopo@gmail.com"
+    },
+    "record": {
+        "CNAME": "dickerpopo.github.io"
+    }
+}


### PR DESCRIPTION
Added `dickerpopo.is-a.dev` using the [dashboard](https://manage.is-a.dev).