### PR TITLE
BETA: Register whistle.is-a.dev

### DIFF
--- a/domains/whistle.json
+++ b/domains/whistle.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "thewhistledev",
+        "email": "lewis.lt27@gmail.com"
+    },
+    "record": {
+        "URL": "https://morphstudios.org/"
+    }
+}


### PR DESCRIPTION
Added `whistle.is-a.dev` using the [dashboard](https://manage.is-a.dev).