### PR TITLE
BETA: Register codesoft.is-a.dev

### DIFF
--- a/domains/codesoft.json
+++ b/domains/codesoft.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CodeSoftGit",
+        "email": "owenwelfel@icloud.com"
+    },
+    "record": {
+        "CNAME": "https://bento.me/codesoft"
+    }
+}


### PR DESCRIPTION
Added `codesoft.is-a.dev` using the [dashboard](https://manage.is-a.dev).