### PR TITLE
BETA: Register glitchblog.mrdev88.is-a.dev

### DIFF
--- a/domains/glitchblog.mrdev88.json
+++ b/domains/glitchblog.mrdev88.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Mrdev88",
+        "email": "RuizMahdi@gmx.com"
+    },
+    "record": {
+        "CNAME": "1nw25jjg5f4id14j87.fastly-validations.com"
+    }
+}


### PR DESCRIPTION
Added `glitchblog.mrdev88.is-a.dev` using the [dashboard](https://manage.is-a.dev).