### PR TITLE
BETA: Register barnacl437.is-a.dev

### DIFF
--- a/domains/barnacl437.json
+++ b/domains/barnacl437.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Barnacl437",
+        "email": "barnacl437@proton.me"
+    },
+    "record": {
+        "CNAME": "barnacl437.github.io"
+    }
+}


### PR DESCRIPTION
Added `barnacl437.is-a.dev` using the [dashboard](https://manage.is-a.dev).