### PR TITLE
BETA: Register zach.is-a.dev

### DIFF
--- a/domains/zach.json
+++ b/domains/zach.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "notcobalt",
+        "email": "Bayonetfort@gmail.com"
+    },
+    "record": {
+        "CNAME": "porkbun.com"
+    }
+}


### PR DESCRIPTION
Added `zach.is-a.dev` using the [dashboard](https://manage.is-a.dev).