### PR TITLE
BETA: Register idkmaxi.is-a.dev

### DIFF
--- a/domains/idkmaxi.json
+++ b/domains/idkmaxi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Molret",
+        "email": "maximiliano.moldenhauer.r@marygraham.cl"
+    },
+    "record": {
+        "CNAME": "ns1.infinityfree.com"
+    }
+}


### PR DESCRIPTION
Added `idkmaxi.is-a.dev` using the [dashboard](https://manage.is-a.dev).