### PR TITLE
BETA: Register novampr.is-a.dev

### DIFF
--- a/domains/novampr.json
+++ b/domains/novampr.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Novampr",
+        "email": "LimeDEV8756@gmail.com"
+    },
+    "record": {
+        "CNAME": "novampr.github.io"
+    }
+}


### PR DESCRIPTION
Added `novampr.is-a.dev` using the [dashboard](https://manage.is-a.dev).