### PR TITLE
BETA: Register dpen.is-a.dev

### DIFF
--- a/domains/dpen.json
+++ b/domains/dpen.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "despenser08",
+        "email": "despenser08@gmail.com"
+    },
+    "record": {
+        "URL": "https://camorad.xyz/"
+    }
+}


### PR DESCRIPTION
Added `dpen.is-a.dev` using the [dashboard](https://manage.is-a.dev).