### PR TITLE
BETA: Register cloudpanel.is-a.dev

### DIFF
--- a/domains/cloudpanel.json
+++ b/domains/cloudpanel.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TheJ00ker",
+        "email": "pgjolley@hotmail.com"
+    },
+    "record": {
+        "A": ["86.25.20.158"]
+    }
+}


### PR DESCRIPTION
Added `cloudpanel.is-a.dev` using the [dashboard](https://manage.is-a.dev).