### PR TITLE
BETA: Register opott.is-a.dev

### DIFF
--- a/domains/opott.json
+++ b/domains/opott.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "opott",
+        "email": "om.potter09@gmail.com"
+    },
+    "record": {
+        "CNAME": "opott.github.io"
+    }
+}


### PR DESCRIPTION
Added `opott.is-a.dev` using the [dashboard](https://manage.is-a.dev).