### PR TITLE
BETA: Register koopa.is-a.dev

### DIFF
--- a/domains/koopa.json
+++ b/domains/koopa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "KoopaCode",
+        "email": "AndrewLife92@gmail.com"
+    },
+    "record": {
+        "URL": "https://koopa.pro/koopa"
+    }
+}


### PR DESCRIPTION
Added `koopa.is-a.dev` using the [dashboard](https://manage.is-a.dev).