### PR TITLE
BETA: Register zeranamu.is-a.dev

### DIFF
--- a/domains/zeranamu.json
+++ b/domains/zeranamu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Zeranamu",
+        "email": "zeranamu@gmail.com"
+    },
+    "record": {
+        "CNAME": "zeranamu.github.io"
+    }
+}


### PR DESCRIPTION
Added `zeranamu.is-a.dev` using the [dashboard](https://manage.is-a.dev).