### PR TITLE
BETA: Register ray.is-a.dev

### DIFF
--- a/domains/ray.json
+++ b/domains/ray.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RayDev07",
+        "email": "jatingujjar.alive@gmail.com"
+    },
+    "record": {
+        "CNAME": "raydev07.github.io"
+    }
+}


### PR DESCRIPTION
Added `ray.is-a.dev` using the [dashboard](https://manage.is-a.dev).