### PR TITLE
BETA: Register hentai.is-a.dev

### DIFF
--- a/domains/hentai.json
+++ b/domains/hentai.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Sourayen",
+        "email": "soumodas4536@gmail.com"
+    },
+    "record": {
+        "URL": "https://sourayen.github.io/hemtai"
+    }
+}


### PR DESCRIPTION
Added `hentai.is-a.dev` using the [dashboard](https://manage.is-a.dev).