### PR TITLE
BETA: Register raspi.is-a.dev

### DIFF
--- a/domains/raspi.json
+++ b/domains/raspi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mkrage",
+        "email": "manuel.krage@gmx.de"
+    },
+    "record": {
+        "A": ["192.168.178.88"]
+    }
+}


### PR DESCRIPTION
Added `raspi.is-a.dev` using the [dashboard](https://manage.is-a.dev).