### PR TITLE
BETA: Register sonarqube.is-a.dev

### DIFF
--- a/domains/sonarqube.json
+++ b/domains/sonarqube.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hxhieu",
+        "email": "hugh.hoang@gmail.com"
+    },
+    "record": {
+        "A": ["20.53.134.188"]
+    }
+}


### PR DESCRIPTION
Added `sonarqube.is-a.dev` using the [dashboard](https://manage.is-a.dev).