### PR TITLE
BETA: Register spotify.trung.is-a.dev

### DIFF
--- a/domains/spotify.trung.json
+++ b/domains/spotify.trung.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vuthanhtrung2010",
+        "email": "vuthanhtrungsuper@gmail.com"
+    },
+    "record": {
+        "A": ["34.125.141.93"]
+    }
+}


### PR DESCRIPTION
Added `spotify.trung.is-a.dev` using the [dashboard](https://manage.is-a.dev).