### PR TITLE
BETA: Register clubtree.is-a.dev

### DIFF
--- a/domains/clubtree.json
+++ b/domains/clubtree.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "rubiconx35",
+        "email": "msm_dev@yahoo.com"
+    },
+    "record": {
+        "A": ["45.154.3.61"]
+    }
+}


### PR DESCRIPTION
Added `clubtree.is-a.dev` using the [dashboard](https://manage.is-a.dev).