### PR TITLE
BETA: Register norelock.is-a.dev

### DIFF
--- a/domains/norelock.json
+++ b/domains/norelock.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "norelockk",
+        "email": "norbert.podbieglyyy@gmail.com"
+    },
+    "record": {
+        "A": ["3.120.151.77"]
+    }
+}


### PR DESCRIPTION
Added `norelock.is-a.dev` using the [dashboard](https://manage.is-a.dev).