### PR TITLE
BETA: Register valoop.is-a.dev

### DIFF
--- a/domains/valoop.json
+++ b/domains/valoop.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "valoopselsewhere",
+        "email": "temmiemeow2@gmail.com"
+    },
+    "record": {
+        "AAAA": "3001:0db7:3c5d:0024:0000:0000:1a2f:3c1b"
+    }
+}


### PR DESCRIPTION
Added `valoop.is-a.dev` using the [dashboard](https://manage.is-a.dev).