### PR TITLE
BETA: Register nff50.is-a.dev

### DIFF
--- a/domains/nff50.json
+++ b/domains/nff50.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "nff50",
+        "email": "fishermanfor50@gmail.com"
+    },
+    "record": {
+        "URL": "nff50.github.io"
+    }
+}


### PR DESCRIPTION
Added `nff50.is-a.dev` using the [dashboard](https://manage.is-a.dev).