### PR TITLE
BETA: Register guillot.is-a.dev

### DIFF
--- a/domains/guillot.json
+++ b/domains/guillot.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "pabloguillot",
+        "email": "pabguifon@gmail.com"
+    },
+    "record": {
+        "CNAME": "guillot.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `guillot.is-a.dev` using the [dashboard](https://manage.is-a.dev).