### PR TITLE
BETA: Register devlori.is-a.dev

### DIFF
--- a/domains/devlori.json
+++ b/domains/devlori.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "evefind",
+        "email": "fivemgtarp50@gmail.com"
+    },
+    "record": {
+        "CNAME": "evefind.github.io"
+    }
+}


### PR DESCRIPTION
Added `devlori.is-a.dev` using the [dashboard](https://manage.is-a.dev).