### PR TITLE
BETA: Register 50x.is-a.dev

### DIFF
--- a/domains/50x.json
+++ b/domains/50x.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MullerIsabella",
+        "email": "AlpineDreamer92@protonmail.com"
+    },
+    "record": {
+        "CNAME": "suisse.onrender.com"
+    }
+}


### PR DESCRIPTION
Added `50x.is-a.dev` using the [dashboard](https://manage.is-a.dev).