### PR TITLE
BETA: Register lipi.is-a.dev

### DIFF
--- a/domains/lipi.json
+++ b/domains/lipi.json
@@ -4,6 +4,6 @@
         "email": "lipisharma2911@gmail.com"
     },
     "record": {
-        "URL": "lipi.is-a.dev"
+        "URL": "https://lipi.is-a.dev"
     }
 }

--- a/domains/lipi.json
+++ b/domains/lipi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ReticentFacade",
+        "email": "lipisharma2911@gmail.com"
+    },
+    "record": {
+        "URL": "lipi.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `lipi.is-a.dev` using the [dashboard](https://manage.is-a.dev).