### PR TITLE
BETA: Register palekiox.is-a.dev

### DIFF
--- a/domains/palekiox.json
+++ b/domains/palekiox.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "palekiox",
+        "email": "zigzagrpg@gmail.com"
+    },
+    "record": {
+        "CNAME": "palekiox.github.io"
+    }
+}


### PR DESCRIPTION
Added `palekiox.is-a.dev` using the [dashboard](https://manage.is-a.dev).