### PR TITLE
BETA: Register lol.is-a.dev

### DIFF
--- a/domains/lol.json
+++ b/domains/lol.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "fwij",
+        "email": "devthelast@outlook.com"
+    },
+    "record": {
+        "URL": "bio.link/juicewrld"
+    }
+}


### PR DESCRIPTION
Added `lol.is-a.dev` using the [dashboard](https://manage.is-a.dev).