### PR TITLE
BETA: Register ilz.is-a.dev

### DIFF
--- a/domains/ilz.json
+++ b/domains/ilz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "littletheworld",
+        "email": "littlehaofficial@gmail.com"
+    },
+    "record": {
+        "A": ["172.67.209.143"]
+    }
+}

--- a/domains/lnk.json
+++ b/domains/lnk.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "CNAME": "cname.short.io"
+            "CNAME": "littletheworld.github.io"
         }
     }
     


### PR DESCRIPTION
Added `ilz.is-a.dev` using the [dashboard](https://manage.is-a.dev).