### PR TITLE
BETA: Register redtab-api-dev.is-a.dev

### DIFF
--- a/domains/redtab-api-dev.json
+++ b/domains/redtab-api-dev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "khanhlinh2823",
+        "email": "khanhlinh200823@set.edu.vn"
+    },
+    "record": {
+        "A": ["155.94.160.171"]
+    }
+}


### PR DESCRIPTION
Added `redtab-api-dev.is-a.dev` using the [dashboard](https://manage.is-a.dev).