### PR TITLE
BETA: Register olxyz.is-a.dev

### DIFF
--- a/domains/olxyz.json
+++ b/domains/olxyz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "xyzendev",
+        "email": "adriangota2007@gmail.com"
+    },
+    "record": {
+        "CNAME": "mslb1702.up.railway.app"
+    }
+}


### PR DESCRIPTION
Added `olxyz.is-a.dev` using the [dashboard](https://manage.is-a.dev).