### PR TITLE
Add `shymega.is-a.dev` subdomain

### DIFF
--- a/domains/_discord.shymega.json
+++ b/domains/_discord.shymega.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "shymega",
+    "email": "shymega@shymega.org.uk",
+  },
+  "record": {
+    "TXT": "dh=43b627cccb9f6828d48ec7db6a573824bccfabc5"
+  }
+}

--- a/domains/_discord.shymega.json
+++ b/domains/_discord.shymega.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "shymega",
-    "email": "shymega@shymega.org.uk",
+    "email": "shymega@shymega.org.uk"
   },
   "record": {
     "TXT": "dh=43b627cccb9f6828d48ec7db6a573824bccfabc5"

--- a/domains/_github-pages-challenge-shymega.shymega.json
+++ b/domains/_github-pages-challenge-shymega.shymega.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "shymega",
+    "email": "shymega@shymega.org.uk"
+  },
+  "record": {
+    "TXT": "83c50be1b56ddbe89e971e9f77aa0b"
+  }
+}

--- a/domains/shymega.json
+++ b/domains/shymega.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "shymega",
+    "email": "shymega@shymega.org.uk"
+  },
+  "record": {
+    "CNAME": "dom-rodriguez-org-uk.pages.dev"
+  }
+}


### PR DESCRIPTION
This PR adds a subdomain for my portfolio website (WIP on another subdomain), with Discord and GitHub Pages verification TXT strings.

I may add MX records at a later date. I haven't decided yet.

But for now, these changes are sufficient.

<!-- Please complete this template so we can review your pull request faster. -->

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Twitter) so we can contact you. -->

## Website Link/Preview

My website is currently deployed on CloudFlare pages, on my main portfolio domain[0]. However, I came across is-a.dev on Discord, and thought it might be a good idea to utilise these services.

You can find the CloudFlare Pages direct deployment here[1], but the main subdomain is here[0].

[0]: https://dom.rodriguez.org.uk
[1]: https://dom-rodriguez-org-uk.pages.dev/