### PR TITLE
BETA: Register shafi.is-a.dev

### DIFF
--- a/domains/shafi.json
+++ b/domains/shafi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Xshafi",
+        "email": "AkramSanghar10@gmail.com"
+    },
+    "record": {
+        "CNAME": "xshafi.github.io"
+    }
+}


### PR DESCRIPTION
Added `shafi.is-a.dev` using the [dashboard](https://manage.is-a.dev).