### PR TITLE
BETA: Register geenzo.is-a.dev

### DIFF
--- a/domains/geenzo.json
+++ b/domains/geenzo.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "geenzo69",
+        "email": "geenzogamer164@gmail.com"
+    },
+    "record": {
+        "CNAME": "server.geenzo.eu.org"
+    }
+}


### PR DESCRIPTION
Added `geenzo.is-a.dev` using the [dashboard](https://manage.is-a.dev).