### PR TITLE
BETA: Register sebb.is-a.dev

### DIFF
--- a/domains/sebb.json
+++ b/domains/sebb.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "WiseFrederick",
+        "email": "plen.plan.plane.plene@gmail.com"
+    },
+    "record": {
+        "CNAME": "sebb.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `sebb.is-a.dev` using the [dashboard](https://manage.is-a.dev).