### PR TITLE
BETA: Register zwei.is-a.dev

### DIFF
--- a/domains/zwei.json
+++ b/domains/zwei.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Vibred",
+        "email": "vibred@pm.me"
+    },
+    "record": {
+        "CNAME": "telegraph-image2-c9p.pages.dev"
+    }
+}


### PR DESCRIPTION
Added `zwei.is-a.dev` using the [dashboard](https://manage.is-a.dev).