### PR TITLE
Register backcode.is-a.dev

### DIFF
--- a/domains/backcode.json
+++ b/domains/backcode.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "DeveloperMusu",
+           "email": "165336839+DeveloperMusu@users.noreply.github.com",
+           "discord": "1137798050522337304"
+        },
+    
+        "record": {
+            "CNAME": "developermusu.github.io/backcodes.github.io/"
+        }
+    }
+    


### PR DESCRIPTION
Register backcode.is-a.dev with CNAME record pointing to developermusu.github.io/Backcodes.github.io/.