### PR TITLE
chore: add `con` to invalid domains

### DIFF
--- a/utils/invalid-domains.json
+++ b/utils/invalid-domains.json
@@ -6,6 +6,7 @@
   "_github-challenge-is-a-dev",
   "_github-pages-challenge-is-a-dev",
   "_gitlab-pages-verification-code",
+  "con",
   "help",
   "no-reply",
   "noreply",


### PR DESCRIPTION
Windows systems do not support file names that include `con` and it therefore causes an issue when cloning.