### PR TITLE
BETA: Register rasel.is-a.dev

### DIFF
--- a/domains/rasel.json
+++ b/domains/rasel.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "raselshikdar",
+        "email": "imrasel597@gmail.com"
+    },
+    "record": {
+        "URL": "https://rasel597.blogspot.com"
+    }
+}


### PR DESCRIPTION
Added `rasel.is-a.dev` using the [dashboard](https://manage.is-a.dev).