### PR TITLE
BETA: Register skycode.is-a.dev

### DIFF
--- a/domains/skycode.json
+++ b/domains/skycode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Skyy-Development",
+        "email": "strikefn143@gmail.com"
+    },
+    "record": {
+        "CNAME": "skyy-development.github.io"
+    }
+}


### PR DESCRIPTION
Added `skycode.is-a.dev` using the [dashboard](https://manage.is-a.dev).