### PR TITLE
BETA: Register dav.is-a.dev

### DIFF
--- a/domains/dav.json
+++ b/domains/dav.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Davdav05",
+        "email": "github_davdav05@2200.io"
+    },
+    "record": {
+        "CNAME": "192.168.1.1"
+    }
+}


### PR DESCRIPTION
Added `dav.is-a.dev` using the [dashboard](https://manage.is-a.dev).