### PR TITLE
BETA: Register roing.is-a.dev

### DIFF
--- a/domains/roing.json
+++ b/domains/roing.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Roing",
+        "email": "yang4421@outlook.com"
+    },
+    "record": {
+        "A": ["47.120.72.157"]
+    }
+}


### PR DESCRIPTION
Added `roing.is-a.dev` using the [dashboard](https://manage.is-a.dev).