### PR TITLE
BETA: Register dangnat.is-a.dev

### DIFF
--- a/domains/dangnat.json
+++ b/domains/dangnat.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "NaTDeveloper",
+        "email": "devihermeena@gmail.com"
+    },
+    "record": {
+        "CNAME": "trekhosting.onrender.com"
+    }
+}


### PR DESCRIPTION
Added `dangnat.is-a.dev` using the [dashboard](https://manage.is-a.dev).