### PR TITLE
BETA: Register seba.is-a.dev

### DIFF
--- a/domains/seba.json
+++ b/domains/seba.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ssxbaa",
+        "email": "ssxbaa@proton.me"
+    },
+    "record": {
+        "CNAME": "ssxbaa.github.io"
+    }
+}


### PR DESCRIPTION
Added `seba.is-a.dev` using the [dashboard](https://manage.is-a.dev).