### PR TITLE
BETA: Register ralphpineda.is-a.dev

### DIFF
--- a/domains/ralphpineda.json
+++ b/domains/ralphpineda.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "rpineda26",
+        "email": "rp.pineda26@gmail.com"
+    },
+    "record": {
+        "CNAME": "rpineda26.github.io"
+    }
+}


### PR DESCRIPTION
Added `ralphpineda.is-a.dev` using the [dashboard](https://manage.is-a.dev).