### PR TITLE
BETA: Register tsal.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-tsaliscepu.tsal.json
+++ b/domains/_github-pages-challenge-tsaliscepu.tsal.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tsaliscepu",
+        "email": "tsaliscepu@gmail.com"
+    },
+    "record": {
+        "TXT": "4d0b8a10baf5d30dfaf94e056d6b38"
+    }
+}

--- a/domains/tsal.json
+++ b/domains/tsal.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tsaliscepu",
+        "email": "tsaliscepu@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/tsaliscepu"
+    }
+}


### PR DESCRIPTION
Added `tsal.is-a.dev` using the [dashboard](https://manage.is-a.dev).