### PR TITLE
BETA: Register tsal.is-a.dev

### DIFF
--- a/domains/tsal.json
+++ b/domains/tsal.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tsaliscepu",
+        "email": "tsaliscepu@gmail.com"
+    },
+    "record": {
+        "URL": "tsaliscepu.github.io"
+    }
+}


### PR DESCRIPTION
Added `tsal.is-a.dev` using the [dashboard](https://manage.is-a.dev).