### PR TITLE
BETA: Register musiccorn01.is-a.dev

### DIFF
--- a/domains/musiccorn01.json
+++ b/domains/musiccorn01.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ondirisuliuly",
+        "email": "ondirisuliuly@gmail.com"
+    },
+    "record": {
+        "A": ["185.239.48.45"]
+    }
+}


### PR DESCRIPTION
Added `musiccorn01.is-a.dev` using the [dashboard](https://manage.is-a.dev).