### PR TITLE
BETA: Register la.is-a.dev

### DIFF
--- a/domains/07jjskks.json
+++ b/domains/07jjskks.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mrlabani",
+        "email": "abcdefgh96684@gmail.com"
+    },
+    "record": {
+        "CNAME": "torrent-api-py-ftbc.onrender.com"
+    }
+}

--- a/domains/ksodkskske.json
+++ b/domains/ksodkskske.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "mrlabani",
+    "email": "abcdefgh96684@gmail.com"
+  },
+  "record": {
+    "URL": "https://torrent-api-py-ftbc.onrender.com"
+  }
+}

--- a/domains/labanii.json
+++ b/domains/labanii.json
@@ -1,0 +1,11 @@
+{
+  "description": "lbni website",
+  "repo": "https://github.com/mrlabani/lbni.github.io",
+  "owner": {
+    "username": "mrlabani",
+    "email": "abcdefgh96684@gmail.com"
+  },
+  "record": {
+    "CNAME": "lbni.github.io"
+  }
+}


### PR DESCRIPTION
Added `la.is-a.dev` using the [dashboard](https://manage.is-a.dev).