### PR TITLE
BETA: Register cvfa.is-a.dev

### DIFF
--- a/domains/cvfa.json
+++ b/domains/cvfa.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CVFA-Dev",
+        "email": "cavifeal@duck.com"
+    },
+    "record": {
+        "URL": "cvfa.is-a.dev"
+    }
+}


### PR DESCRIPTION
Added `cvfa.is-a.dev` using the [dashboard](https://manage.is-a.dev).