### PR TITLE
BETA: Register bru.is-a.dev

### DIFF
--- a/domains/bru.json
+++ b/domains/bru.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "BrunoWithoutH",
+        "email": "pinheirobrunoevaristo@gmail.com"
+    },
+    "record": {
+        "CNAME": "brunowithouth.github.io"
+    }
+}


### PR DESCRIPTION
Added `bru.is-a.dev` using the [dashboard](https://manage.is-a.dev).