### PR TITLE
Register M4RV1N.is-a.dev

### DIFF
--- a/domains/m4rv1n.json
+++ b/domains/m4rv1n.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "froschhuepfer",
+           "email": "froschhuepfer@web.de",
+           "discord": "368001402326351882"
+        },
+    
+        "record": {
+            "CNAME": "https://github.com/froschhuepfer/froschhuepfer.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register M4RV1N.is-a.dev with CNAME record pointing to https://github.com/froschhuepfer/froschhuepfer.github.io.