### PR TITLE
BETA: Register porant.is-a.dev

### DIFF
--- a/domains/porant.json
+++ b/domains/porant.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "porant",
+        "email": "porant@gmail.com"
+    },
+    "record": {
+        "A": ["178.26.182.120"]
+    }
+}


### PR DESCRIPTION
Added `porant.is-a.dev` using the [dashboard](https://manage.is-a.dev).