### PR TITLE
BETA: Register timesquared.is-a.dev

### DIFF
--- a/domains/timesquared.json
+++ b/domains/timesquared.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TimeCubed",
+        "email": "SummerNugget1@gmail.com"
+    },
+    "record": {
+        "A": ["8.8.8.8"]
+    }
+}


### PR DESCRIPTION
Added `timesquared.is-a.dev` using the [dashboard](https://manage.is-a.dev).