### PR TITLE
BETA: Register fyz.is-a.dev

### DIFF
--- a/domains/fyz.json
+++ b/domains/fyz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "w8fyz",
+        "email": "fyzdesignyt@gmail.com"
+    },
+    "record": {
+        "CNAME": "fyz.sh"
+    }
+}


### PR DESCRIPTION
Added `fyz.is-a.dev` using the [dashboard](https://manage.is-a.dev).