### PR TITLE
BETA: Register mark.is-a.dev

### DIFF
--- a/domains/mark.json
+++ b/domains/mark.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CashyOP",
+        "email": "markvtsaruk@gmail.com"
+    },
+    "record": {
+        "CNAME": "marks.party"
+    }
+}


### PR DESCRIPTION
Added `mark.is-a.dev` using the [dashboard](https://manage.is-a.dev).