### PR TITLE
Register communityforum.is-a.dev

### DIFF
--- a/domains/communityforum.json
+++ b/domains/communityforum.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "NickiBreeki",
+           "email": "nickibreeki@outlook.com",
+           "discord": "879907858735583262"
+        },
+    
+        "record": {
+            "CNAME": "8cd142c3-e4c3-472e-bb48-e7cf2e47c8e6.acmedns.infinityfree.net"
+        }
+    }
+    


### PR DESCRIPTION
Register communityforum.is-a.dev with CNAME record pointing to 8cd142c3-e4c3-472e-bb48-e7cf2e47c8e6.acmedns.infinityfree.net.