### PR TITLE
BETA: Register omar.is-a.dev

### DIFF
--- a/domains/omar.json
+++ b/domains/omar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TheGr8Coder",
+        "email": "omarrushil@gmail.com"
+    },
+    "record": {
+        "URL": "https://github.com/thegr8coder/"
+    }
+}


### PR DESCRIPTION
Added `omar.is-a.dev` using the [dashboard](https://manage.is-a.dev).