### PR TITLE
BETA: Register yol.is-a.dev

### DIFF
--- a/domains/yol.json
+++ b/domains/yol.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "YoelNath",
+        "email": "yoelnathanael1@gmail.com"
+    },
+    "record": {
+        "CNAME": "yoelnath.github.io"
+    }
+}


### PR DESCRIPTION
Added `yol.is-a.dev` using the [dashboard](https://manage.is-a.dev).