### PR TITLE
Register melody.is-a.dev

### DIFF
--- a/domains/melody.json
+++ b/domains/melody.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "phantonducthang",
+           "email": "phantonducthang@hotmail.com",
+           "discord": "1190624410630099046"
+        },
+    
+        "record": {
+            "CNAME": "melody.64342fb9f8-hosting.gitbook.io"
+        }
+    }
+    


### PR DESCRIPTION
Register melody.is-a.dev with CNAME record pointing to melody.64342fb9f8-hosting.gitbook.io.