### PR TITLE
BETA: Register quadeer.is-a.dev

### DIFF
--- a/domains/quadeer.json
+++ b/domains/quadeer.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "maquadeer",
+        "email": "mdquadeer2003@gmail.com"
+    },
+    "record": {
+        "CNAME": "maquadeer.github.io"
+    }
+}


### PR DESCRIPTION
Added `quadeer.is-a.dev` using the [dashboard](https://manage.is-a.dev).