### PR TITLE
BETA: Register neo.is-a.dev

### DIFF
--- a/domains/melody.json
+++ b/domains/melody.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "phantonducthang",
+           "email": "phantonducthang@hotmail.com",
+           "discord": "1190624410630099046"
+        },
+    
+        "record": {
+            "CNAME": "melody.64342fb9f8-hosting.gitbook.io"
+        }
+    }
+    

--- a/domains/neo.json
+++ b/domains/neo.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "phantonducthang",
+        "email": "phantonducthang@hotmail.com"
+    },
+    "record": {
+        "CNAME": "64342fb9f8-hosting.gitbook.io"
+    }
+}


### PR DESCRIPTION
Added `neo.is-a.dev` using the [dashboard](https://manage.is-a.dev).