### PR TITLE
Register klent.is-a.dev

### DIFF
--- a/domains/klent.json
+++ b/domains/klent.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "kleeiny",
+           "email": "kleeinlmao@gmail.com",
+           "discord": "763581985410121769"
+        },
+    
+        "record": {
+            "CNAME": "ghs.google.com"
+        }
+    }
+    


### PR DESCRIPTION
Register klent.is-a.dev with CNAME record pointing to ghs.google.com.