### PR TITLE
BETA: Register raman.is-a.dev

### DIFF
--- a/domains/raman.json
+++ b/domains/raman.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "kushalshah0",
+        "email": "code@kushalshah.com.np"
+    },
+    "record": {
+        "CNAME": "ramanshah0.github.io"
+    }
+}


### PR DESCRIPTION
Added `raman.is-a.dev` using the [dashboard](https://manage.is-a.dev).