### PR TITLE
BETA: Register desiredesign.is-a.dev

### DIFF
--- a/domains/desiredesign.json
+++ b/domains/desiredesign.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Gh053d413x",
+        "email": "ghostedalex@gmail.com"
+    },
+    "record": {
+        "URL": "https://sites.google.com/view/desiredesign"
+    }
+}


### PR DESCRIPTION
Added `desiredesign.is-a.dev` using the [dashboard](https://manage.is-a.dev).