### PR TITLE
BETA: Register live.is-a.dev

### DIFF
--- a/domains/live.json
+++ b/domains/live.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tomgxz",
+        "email": "tomgxz138@gmail.com"
+    },
+    "record": {
+        "CNAME": "oyqkpa3p.up.railway.app"
+    }
+}


### PR DESCRIPTION
Added `live.is-a.dev` using the [dashboard](https://manage.is-a.dev).