### PR TITLE
BETA: Register django.is-a.dev

### DIFF
--- a/domains/django.json
+++ b/domains/django.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mediaformat",
+        "email": "mediaformat.ux@gmail.com"
+    },
+    "record": {
+        "CNAME": "mediaformat.github.io"
+    }
+}


### PR DESCRIPTION
Added `django.is-a.dev` using the [dashboard](https://manage.is-a.dev).