### PR TITLE
BETA: Register media.is-a.dev

### DIFF
--- a/domains/media.json
+++ b/domains/media.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "sprtlw",
+        "email": "sprtlw@pm.me"
+    },
+    "record": {
+        "CNAME": "media69.duckdns.org"
+    }
+}


### PR DESCRIPTION
Added `media.is-a.dev` using the [dashboard](https://manage.is-a.dev).