### PR TITLE
BETA: Register nucc.is-a.dev

### DIFF
--- a/domains/nucc.json
+++ b/domains/nucc.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "EngurRuzgar",
+        "email": "ruzgarengur@protonmail.com"
+    },
+    "record": {
+        "URL": "apclvanillalatest.aternos.me"
+    }
+}


### PR DESCRIPTION
Added `nucc.is-a.dev` using the [dashboard](https://manage.is-a.dev).