### PR TITLE
Register realityleaks.is-a.dev

### DIFF
--- a/domains/realityleaks.json
+++ b/domains/realityleaks.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "RealityLeaks",
+           "email": "getnukedbycreiloZ@proton.me",
+           "discord": "1186392267511042149"
+        },
+    
+        "record": {
+            "CNAME": "realityleaks.rf.gd"
+        }
+    }
+    


### PR DESCRIPTION
Register realityleaks.is-a.dev with CNAME record pointing to realityleaks.rf.gd.