### PR TITLE
chore(domain): update CNAME for hosting migration

### DIFF
--- a/domains/zylo.json
+++ b/domains/zylo.json
@@ -6,6 +6,6 @@
     "description": "👋 Hello! I'm Zylo, a passionate developer with expertise in efficient web solutions. Explore my portfolio and contact me on GitHub.",
     "repo": "https://github.com/Zylo23/personal-website",
     "record": {
-        "URL": "https://zylo23.vercel.app/"
+        "CNAME": "zylo23.pages.dev"
     }
 }


### PR DESCRIPTION
- Changed domain configuration to point to zylo23.pages.dev from zylo23.vercel.app.

This update reflects a change in the hosting provider for the website.

<!-- Please complete this template so we can review your pull request faster. -->

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [ ] The file is in the `domains` folder and is in the JSON format.
- [ ] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [ ] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [ ] You're not using Vercel or Netlify.  <!-- This is not required if you're using an URL record. -->
- [ ] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [ ] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Twitter) so we can contact you. -->

## Website Link/Preview
<!-- Please provide a link or preview of your website below. -->
