### PR TITLE
Register horizon-server.is-a.dev

### DIFF
--- a/domains/horizon-server.json
+++ b/domains/horizon-server.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "HorizonFiles",
+           "email": "getbomb@bk.ru",
+           "discord": "1223721772051075193"
+        },
+    
+        "record": {
+            "CNAME": "horizonfiles.github.io/horizonserver"
+        }
+    }
+    


### PR DESCRIPTION
Register horizon-server.is-a.dev with CNAME record pointing to horizonfiles.github.io/HorizonServer.