### PR TITLE
BETA: Register huz.is-a.dev

### DIFF
--- a/domains/huz.json
+++ b/domains/huz.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Nooby69",
+        "email": "farighinsaan123@gmail.com"
+    },
+    "record": {
+        "CNAME": "5b77bf69-39e2-433c-add4-e59c20476eab.id.repl.co"
+    }
+}


### PR DESCRIPTION
Added `huz.is-a.dev` using the [dashboard](https://manage.is-a.dev).