### PR TITLE
BETA: Register srlebel.is-a.dev

### DIFF
--- a/domains/srlebel.json
+++ b/domains/srlebel.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "SrLebel",
+        "email": "dev.juansimancas@proton.me"
+    },
+    "record": {
+        "URL": "https://srlebel.netlify.app/"
+    }
+}


### PR DESCRIPTION
Added `srlebel.is-a.dev` using the [dashboard](https://manage.is-a.dev).