### PR TITLE
Register zb60458066.klent.is-a.dev

### DIFF
--- a/domains/zb60458066.klent.json
+++ b/domains/zb60458066.klent.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "kleeiny",
+           "email": "kleeinlmao@gmail.com",
+           "discord": "763581985410121769"
+        },
+    
+        "record": {
+            "CNAME": "zmverify.zoho.com"
+        }
+    }
+    


### PR DESCRIPTION
Register zb60458066.klent.is-a.dev with CNAME record pointing to zmverify.zoho.com.