### PR TITLE
Register ukcai.is-a.dev

### DIFF
--- a/domains/ukcai.json
+++ b/domains/ukcai.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "ukcai696969",
+           "email": "111254389+ukcai696969@users.noreply.github.com",
+           "discord": "967904098047381587"
+        },
+    
+        "record": {
+            "CNAME": "countdown.ukcai.me"
+        }
+    }
+    


### PR DESCRIPTION
Register ukcai.is-a.dev with CNAME record pointing to countdown.ukcai.me.