### PR TITLE
Register noahgao.is-a.dev

### DIFF
--- a/domains/noahgao.json
+++ b/domains/noahgao.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "noahziheng",
+           "email": "ziheng1719@163.com",
+           "discord": "900791393931362374"
+        },
+    
+        "record": {
+            "CNAME": "noahziheng.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register noahgao.is-a.dev with CNAME record pointing to noahziheng.github.io.