### PR TITLE
Register lumix.is-a.dev

### DIFF
--- a/domains/lumix.json
+++ b/domains/lumix.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "o-lumix",
+           "email": "lumixofficiel@gmail.com",
+           "discord": "828313756827516949"
+        },
+    
+        "record": {
+            "CNAME": "o-lumix.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register lumix.is-a.dev with CNAME record pointing to o-lumix.github.io.