### PR TITLE
Register deknoinarak.is-a.dev

### DIFF
--- a/domains/deknoinarak.json
+++ b/domains/deknoinarak.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Deknoinarak",
+           "email": "chitah09@gmail.com",
+           "discord": "581409063590690837"
+        },
+    
+        "record": {
+            "CNAME": "deknoinarak.thddns.net"
+        }
+    }
+    


### PR DESCRIPTION
Register deknoinarak.is-a.dev with CNAME record pointing to deknoinarak.thddns.net.