### PR TITLE
Register kokofixcomputers.is-a.dev

### DIFF
--- a/domains/kokofixcomputers.json
+++ b/domains/kokofixcomputers.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "kokofixcomputers",
+           "email": "113046561+kokofixcomputers@users.noreply.github.com",
+           "discord": "1096839213313446019"
+        },
+    
+        "record": {
+            "MX": ["mail0.serv00.com"]
+        }
+    }
+    


### PR DESCRIPTION
Register kokofixcomputers.is-a.dev with MX record pointing to mail0.serv00.com.