### PR TITLE
Register hazel.is-a.dev

### DIFF
--- a/domains/hazel.json
+++ b/domains/hazel.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "hablethedev",
+           "email": "xendyex@tutanota.com",
+           "discord": "1113284520737771621"
+        },
+    
+        "record": {
+            "CNAME": "https://hablethedev.github.io/hazelsite/"
+        }
+    }
+    

--- a/domains/hazel.json
+++ b/domains/hazel.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "CNAME": "https://hablethedev.github.io/hazelsite/"
+            "CNAME": "hablethedev.github.io"
         }
     }
     


### PR DESCRIPTION
Register hazel.is-a.dev with CNAME record pointing to https://hablethedev.github.io/hazelsite/.