### PR TITLE
Register

### DIFF
--- a/domains/roufox.json
+++ b/domains/roufox.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Rouf0x",
+           "email": "gabriel.ruf@gmail.com",
+           "discord": "790712104058617876"
+        },
+    
+        "record": {
+            "CNAME": "https://guns.lol/roufox"
+        }
+    }
+    


### PR DESCRIPTION
Register Roufox.is-a.dev with CNAME record pointing to https://guns.lol/Roufox.