### PR TITLE
Register b4iterdev.is-a.dev

### DIFF
--- a/domains/b4iterdev.json
+++ b/domains/b4iterdev.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "b4iterdev",
+           "email": "thaimeo200389@gmail.com",
+           "discord": "480587458908651530"
+        },
+    
+        "record": {
+            "CNAME": "b4iterdev.net.eu.org"
+        }
+    }
+    


### PR DESCRIPTION
Register b4iterdev.is-a.dev with CNAME record pointing to b4iterdev.net.eu.org.