### PR TITLE
Register Rouf0x.is-a.dev

### DIFF
--- a/domains/rouf0x.json
+++ b/domains/rouf0x.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Rouf0x",
+           "email": "gabriel.ruf@gmail.com",
+           "discord": "790712104058617876"
+        },
+    
+        "record": {
+            "CNAME": "rouf0x.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register Rouf0x.is-a.dev with CNAME record pointing to rouf0x.github.io.