### PR TITLE
Register fafu.is-a.dev

### DIFF
--- a/domains/fafu.json
+++ b/domains/fafu.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "faaafu",
+           "email": "shimni22@gmail.com",
+           "discord": "816079800908513290"
+        },
+    
+        "record": {
+            "CNAME": "faaafu.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register fafu.is-a.dev with CNAME record pointing to faaafu.github.io.