### PR TITLE
Register zytre.is-a.dev

### DIFF
--- a/domains/zytre.json
+++ b/domains/zytre.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "GGLVXD",
+           "email": "gglvmax@gmail.com",
+           "discord": "689774740893859840"
+        },
+    
+        "record": {
+            "CNAME": "forum.gglvxd.eu.org"
+        }
+    }
+    


### PR DESCRIPTION
Register zytre.is-a.dev with CNAME record pointing to forum.gglvxd.eu.org.