### PR TITLE
Register blitzbrian.is-a.dev

### DIFF
--- a/domains/blitzbrian.json
+++ b/domains/blitzbrian.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "blitzbrian",
+           "email": "brianvoorbij@gmail.com",
+           "discord": "814555302178455604"
+        },
+    
+        "record": {
+            "CNAME": "blitzbrian.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register blitzbrian.is-a.dev with CNAME record pointing to blitzbrian.github.io.