### PR TITLE
Register rose1440.is-a.dev

### DIFF
--- a/domains/rose1440.json
+++ b/domains/rose1440.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "RocketLauncher21",
+           "email": "ferkomrkvicka3456@gmail.com",
+           "discord": "832603218223431710"
+        },
+    
+        "record": {
+            "CNAME": "rocketlauncher21.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register rose1440.is-a.dev with CNAME record pointing to rocketlauncher21.github.io.