### PR TITLE
Register debarchito.is-a.dev

### DIFF
--- a/domains/debarchito.json
+++ b/domains/debarchito.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "debarchito",
+           "email": "44723456+debarchito@users.noreply.github.com",
+           "discord": "739497344780992564"
+        },
+    
+        "record": {
+            "CNAME": "https://debarchito.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register debarchito.is-a.dev with CNAME record pointing to https://debarchito.github.io.