### PR TITLE
Register zvdxc.is-a.dev

### DIFF
--- a/domains/zvdxc.json
+++ b/domains/zvdxc.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "zvdxc",
+           "email": "zvdxc11@gmail.com",
+           "discord": "752165613513867294"
+        },
+    
+        "record": {
+            "CNAME": "5a8ae6c4-7fd7-4478-a49f-ca0a8bc4f82d.cfargotunnel.com"
+        }
+    }
+    


### PR DESCRIPTION
Register zvdxc.is-a.dev with CNAME record pointing to 5a8ae6c4-7fd7-4478-a49f-ca0a8bc4f82d.cfargotunnel.com.