### PR TITLE
Register zvdxc.is-a.dev

### DIFF
--- a/domains/zvdxc.json
+++ b/domains/zvdxc.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "zvdxc",
+           "email": "zvdxc11@gmail.com",
+           "discord": "752165613513867294"
+        },
+    
+        "record": {
+            "CNAME": "zvdxc.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register zvdxc.is-a.dev with CNAME record pointing to zvdxc.github.io.