### PR TITLE
Register steeldev.is-a.dev

### DIFF
--- a/domains/steeldev.json
+++ b/domains/steeldev.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "steeldev0",
+           "email": "xrgaming272@gmail.com",
+           "discord": "976208121825460224"
+        },
+    
+        "record": {
+            "A": ["69.197.135.202"]
+        }
+    }
+    


### PR DESCRIPTION
Register steeldev.is-a.dev with A record pointing to 69.197.135.202.