### PR TITLE
Register license.vulpine.is-a.dev

### DIFF
--- a/domains/license.vulpine.json
+++ b/domains/license.vulpine.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "VulpineFriend87",
+           "email": "alessandrobuday@gmail.com",
+           "discord": "911268706112397392"
+        },
+    
+        "record": {
+            "A": ["69.197.135.204"]
+        }
+    }
+    

--- a/domains/vulpine.json
+++ b/domains/vulpine.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "VulpineFriend87",
+           "email": "alessandrobuday@gmail.com",
+           "discord": "911268706112397392"
+        },
+    
+        "record": {
+            "CNAME": "vulpinefriend87.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register license.vulpine.is-a.dev with A record pointing to 69.197.135.204.