### PR TITLE
Register solus.is-a.dev

### DIFF
--- a/domains/solus.json
+++ b/domains/solus.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "solusisadev",
+           "email": "fraimerdelacruzjaziel@gmail.com",
+           "discord": "953834900870557768"
+        },
+    
+        "record": {
+            "CNAME": "solusisadev.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register solus.is-a.dev with CNAME record pointing to solusisadev.github.io.