### PR TITLE
Register courier.is-a.dev

### DIFF
--- a/domains/courier.json
+++ b/domains/courier.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "couriervn",
+           "email": "2familan2011@Gmail.com",
+           "discord": "689407629709410314"
+        },
+    
+        "record": {
+            "CNAME": "https://couriervn.github.io/"
+        }
+    }
+    


### PR DESCRIPTION
Register courier.is-a.dev with CNAME record pointing to https://couriervn.github.io/.