### PR TITLE
Register tay.is-a.dev

### DIFF
--- a/domains/tay.json
+++ b/domains/tay.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "tayrp",
+           "email": "149682424+tayrp@users.noreply.github.com",
+           "discord": "1050531216589332581"
+        },
+    
+        "record": {
+            "CNAME": "tayrp.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register tay.is-a.dev with CNAME record pointing to tayrp.github.io.