### PR TITLE
Register sirigpt.is-a.dev

### DIFF
--- a/domains/sirigpt.json
+++ b/domains/sirigpt.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "SiriGPT",
+           "email": "123630128+SiriGPT@users.noreply.github.com",
+           "discord": "1123559095505518612"
+        },
+    
+        "record": {
+            "CNAME": "sirigpt.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register sirigpt.is-a.dev with CNAME record pointing to sirigpt.github.io.