### PR TITLE
Register sxinar.is-a.dev

### DIFF
--- a/domains/sxinar.json
+++ b/domains/sxinar.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Sxinar",
+           "email": "130384567+Sxinar@users.noreply.github.com",
+           "discord": "1247896918957490198"
+        },
+    
+        "record": {
+            "CNAME": "ghs.google.com"
+        }
+    }
+    


### PR DESCRIPTION
Register sxinar.is-a.dev with CNAME record pointing to ghs.google.com.