### PR TITLE
Register cylis.is-a.dev

### DIFF
--- a/domains/cylis.json
+++ b/domains/cylis.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Cylis-Dragneel",
+           "email": "craftingcaptain456@gmail.com",
+           "discord": "372363585394966528"
+        },
+    
+        "record": {
+            "CNAME": "cylis-dragneel.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register cylis.is-a.dev with CNAME record pointing to cylis-dragneel.github.io.