### PR TITLE
Revert "Create _discord.dscbmr.is-a.dev.json"

### DIFF
--- a/domains/_discord.dscbmr.is-a.dev.json
+++ b/domains/_discord.dscbmr.is-a.dev.json
@@ -1,9 +1,0 @@
-{
-    "owner": {
-        "username": "SRPVT",
-        "email": "syedyaseeralirayan@gmail.com"
-    },
-    "record": {
-        "TXT": "dh=af0561dc7d2f7eb0ef153cb3a270c0b98fe5c36e"
-    }
-} 


### PR DESCRIPTION
Reverts is-a-dev/register#14001

wrong file format, it should not have been merged

I'm very sorry that I didn't check it throughoutly before merging it.
Since you have already got another domain at dscbmr.json if you still use https://dscbmr.is-a.dev then it will be fine. Nothing will be done to that domain. This only affects the domain https://dscbmr.is-a.dev.is-a.dev (which has is-a.dev twice and you probably don't use it)
@SRPVT 