### PR TITLE
Register zester.is-a.dev

### DIFF
--- a/domains/zester.json
+++ b/domains/zester.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "sxtxnzester",
+           "email": "lollo11020210@gmail.com",
+           "discord": "1133362142461050980"
+        },
+    
+        "record": {
+            "CNAME": "zester.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register zester.is-a.dev with CNAME record pointing to zester.github.io.