### PR TITLE
Register aesyncio.is-a.dev

### DIFF
--- a/domains/aesyncio.json
+++ b/domains/aesyncio.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "aesyncio",
+           "email": "ssupercow@proton.me",
+           "discord": "1235901872649539604"
+        },
+    
+        "record": {
+            "CNAME": "aesyncio.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register aesyncio.is-a.dev with CNAME record pointing to aesyncio.github.io.