### PR TITLE
Update record to url redirect

### DIFF
--- a/domains/snelusha.json
+++ b/domains/snelusha.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "CNAME": "snelusha.dev"
+            "URL": "https://snelusha.dev"
         }
     }
     


### PR DESCRIPTION
I registered snelusha.is-a.dev with a CNAME record, but it is not working. I’m not sure what the issue is, but the site is hosted on Vercel, which might be causing the problem. I need to set up a direct redirect to the URL.