### PR TITLE
Register dnnihad.is-a.dev

### DIFF
--- a/domains/dnnihad.json
+++ b/domains/dnnihad.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "DNNIHAD",
+           "email": "101970745+DNNIHAD@users.noreply.github.com",
+           "discord": "1249469798153453703"
+        },
+    
+        "record": {
+            "CNAME": "https://github.com/dnnihad/dnnihad.github.io/"
+        }
+    }
+    


### PR DESCRIPTION
Register dnnihad.is-a.dev with CNAME record pointing to https://github.com/DNNIHAD/dnnihad.github.io/.