### PR TITLE
Register meghdip.is-a.dev

### DIFF
--- a/domains/meghdip.json
+++ b/domains/meghdip.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "karmakarmeghdip",
+           "email": "karmakarmeghdip@gmail.com",
+           "discord": "479631349167423509"
+        },
+    
+        "record": {
+            "CNAME": "karmakarmeghdip.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register meghdip.is-a.dev with CNAME record pointing to karmakarmeghdip.github.io.