### PR TITLE
Register qwertywasd.is-a.dev

### DIFF
--- a/domains/qwertywasd.json
+++ b/domains/qwertywasd.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "qwertywasdwasd",
+           "email": "iamacuteguy1@gmail.com",
+           "discord": "850031688209268756"
+        },
+    
+        "record": {
+            "CNAME": "qwertywasd.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register qwertywasd.is-a.dev with CNAME record pointing to qwertywasd.github.io.