### PR TITLE
Register matytyma.is-a.dev

### DIFF
--- a/domains/matytyma.json
+++ b/domains/matytyma.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "matytyma",
+           "email": "matytyma22@gmail.com",
+           "discord": "803549121247838209"
+        },
+    
+        "record": {
+            "CNAME": "matytyma.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register matytyma.is-a.dev with CNAME record pointing to matytyma.github.io.