### PR TITLE
Register kappucino.is-a.dev

### DIFF
--- a/domains/kappucino.json
+++ b/domains/kappucino.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "kappucin",
+           "email": "132572179+kappucin@users.noreply.github.com",
+           "discord": "853170099392479253"
+        },
+    
+        "record": {
+            "CNAME": "kappucin.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register kappucino.is-a.dev with CNAME record pointing to kappucin.github.io.