### PR TITLE
Register renn.is-a.dev

### DIFF
--- a/domains/renn.json
+++ b/domains/renn.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "LyVoid",
+           "email": "ezzbro121@gmail.com",
+           "discord": "1202338769379008515"
+        },
+    
+        "record": {
+            "CNAME": "lyvoid.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register renn.is-a.dev with CNAME record pointing to LyVoid.github.io.