### PR TITLE
Register thequiz.zer8.is-a.dev

### DIFF
--- a/domains/thequiz.zer8.json
+++ b/domains/thequiz.zer8.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "TheQuizzer",
+           "email": "thequizzer8@gmail.com",
+           "discord": "1026560784530157588"
+        },
+    
+        "record": {
+            "CNAME": "thequizzer.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register thequiz.zer8.is-a.dev with CNAME record pointing to thequizzer.github.io.