### PR TITLE
Register m1raclemax.is-a.dev

### DIFF
--- a/domains/m1raclemax.json
+++ b/domains/m1raclemax.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "nerdwithcomputers",
+           "email": "hpscigeek@gmail.com",
+           "discord": "862452372987314216"
+        },
+    
+        "record": {
+            "CNAME": "nerdwithcomputers.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register m1raclemax.is-a.dev with CNAME record pointing to nerdwithcomputers.github.io.