### PR TITLE
Register kenobi.is-a.dev

### DIFF
--- a/domains/kenobi.json
+++ b/domains/kenobi.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "CapMactavish241",
+           "email": "pcexperts8@gmail.com",
+           "discord": "556028189638524949"
+        },
+    
+        "record": {
+            "CNAME": "11026906-e8af-47db-9a7f-a79eae56558d.cfargotunnel.com"
+        }
+    }
+    


### PR DESCRIPTION
Register kenobi.is-a.dev with CNAME record pointing to 11026906-e8af-47db-9a7f-a79eae56558d.cfargotunnel.com.