### PR TITLE
Register computerblade.is-a.dev

### DIFF
--- a/domains/computerblade.json
+++ b/domains/computerblade.json
@@ -1,7 +1,7 @@
 {
         "owner": {
            "username": "computerblade-official",
-           "email": "somabose2020@gmail.com",
+           "email": "ayproductionsteam@gmail.com",
            "discord": "1032603689069846549"
         },
     

--- a/domains/computerblade.json
+++ b/domains/computerblade.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "computerblade-official",
+           "email": "somabose2020@gmail.com",
+           "discord": "1032603689069846549"
+        },
+    
+        "record": {
+            "CNAME": "computerblade-official.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register computerblade.is-a.dev with CNAME record pointing to computerblade-official.github.io.