### PR TITLE
Register crystalcoding.is-a.dev

### DIFF
--- a/domains/crystalcoding.json
+++ b/domains/crystalcoding.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "crystalcoding9999",
+           "email": "crystalcraft9999@gmail.com",
+           "discord": "1102272783712522331"
+        },
+    
+        "record": {
+            "CNAME": "crystalcoding9999.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register crystalcoding.is-a.dev with CNAME record pointing to crystalcoding9999.github.io.