### PR TITLE
Register enderdevcom.is-a.dev

### DIFF
--- a/domains/enderdevcom.json
+++ b/domains/enderdevcom.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "enderfoxbg",
+           "email": "enderfoxbg670@gmail.com",
+           "discord": "970380468090437672"
+        },
+    
+        "record": {
+            "CNAME": "enderfoxbg.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register enderdevcom.is-a.dev with CNAME record pointing to enderfoxbg.github.io.