### PR TITLE
Register adrianotech.is-a.dev

### DIFF
--- a/domains/adrianotech.json
+++ b/domains/adrianotech.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Adrik-LOL",
+           "email": "adrianopuglisi09@gmail.com",
+           "discord": "720306933252227072"
+        },
+    
+        "record": {
+            "TXT": "hosting-site=adrianotechwebsite"
+        }
+    }
+    


### PR DESCRIPTION
Register adrianotech.is-a.dev with TXT record pointing to hosting-site=adrianotechwebsite.