### PR TITLE
Register Kabya.is-a.dev

### DIFF
--- a/domains/kabya.json
+++ b/domains/kabya.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "KazzzKun",
+           "email": "kabyadeepdasbigboss@gmail.com",
+           "discord": "512993457883578389"
+        },
+    
+        "record": {
+            "CNAME": "kazzzkun.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register Kabya.is-a.dev with CNAME record pointing to KazzzKun.github.io.