### PR TITLE
Register seven.is-a.dev

### DIFF
--- a/domains/seven.json
+++ b/domains/seven.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "7op3",
+           "email": "134126156+7op3@users.noreply.github.com",
+           "discord": "882124409945587773"
+        },
+    
+        "record": {
+            "CNAME": "7op3.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register seven.is-a.dev with CNAME record pointing to 7op3.github.io.