### PR TITLE
Register law.is-a.dev

### DIFF
--- a/domains/law.json
+++ b/domains/law.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "lawlol",
+           "email": "lawlaw00@proton.me",
+           "discord": "1219031488016679033"
+        },
+    
+        "record": {
+            "CNAME": "https://github.com/lawlol/is.a.devsite/blob/main/index.html"
+        }
+    }
+    


### PR DESCRIPTION
Register law.is-a.dev with CNAME record pointing to https://github.com/lawlol/is.a.devsite/blob/main/index.html.