### PR TITLE
Register blackneeed.is-a.dev

### DIFF
--- a/domains/blackneeed.json
+++ b/domains/blackneeed.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Blackneeed",
+           "email": "kontododatkowe.marcelclay@gmail.com",
+           "discord": "928360278683443210"
+        },
+    
+        "record": {
+            "CNAME": "blackneeed.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register blackneeed.is-a.dev with CNAME record pointing to blackneeed.github.io.