### PR TITLE
Register astrowin.is-a.dev

### DIFF
--- a/domains/astrowin.json
+++ b/domains/astrowin.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "enderfoxbg",
+           "email": "enderfoxbg670@gmail.com",
+           "discord": "970380468090437672"
+        },
+    
+        "record": {
+            "CNAME": "astrowin.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register astrowin.is-a.dev with CNAME record pointing to astrowin.github.io.