### PR TITLE
Register gabivlg.is-a.dev

### DIFF
--- a/domains/gabivlg.json
+++ b/domains/gabivlg.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "GabiVlg",
+           "email": "gabivoinea111111@yahoo.com",
+           "discord": "368732292408934403"
+        },
+    
+        "record": {
+            "CNAME": "gabivlg.is-a.dev 10800 in cname domain.par.clever-cloud.com."
+        }
+    }
+    


### PR DESCRIPTION
Register gabivlg.is-a.dev with CNAME record pointing to gabivlg.is-a.dev 10800 IN CNAME domain.par.clever-cloud.com..