### PR TITLE
Register corruptedarc.is-a.dev

### DIFF
--- a/domains/corruptedarc.json
+++ b/domains/corruptedarc.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Ishaan1313",
+           "email": "89083494+Ishaan1313@users.noreply.github.com",
+           "discord": "692993163333337139"
+        },
+    
+        "record": {
+            "CNAME": "phones-sells.gl.at.ply.gg:50105"
+        }
+    }
+    


### PR DESCRIPTION
Register corruptedarc.is-a.dev with CNAME record pointing to phones-sells.gl.at.ply.gg:50105.