### PR TITLE
Register MavisHosting.is-a.dev

### DIFF
--- a/domains/mavishosting.json
+++ b/domains/mavishosting.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "neklayd",
+           "email": "Arifbekirov2008@gmail.com",
+           "discord": "919603718289252352"
+        },
+    
+        "record": {
+            "TXT": "mavishost"
+        }
+    }
+    


### PR DESCRIPTION
Register MavisHosting.is-a.dev with TXT record pointing to MavisHost.