### PR TITLE
Register tunnel.riviox.is-a.dev

### DIFF
--- a/domains/tunnel.riviox.json
+++ b/domains/tunnel.riviox.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "riviox",
+           "email": "rivioxyt@hotmail.com",
+           "discord": "1200520669570539620"
+        },
+    
+        "record": {
+            "CNAME": "https://tough-mink-modest.ngrok-free.app"
+        }
+    }
+    


### PR DESCRIPTION
Register tunnel.riviox.is-a.dev with CNAME record pointing to https://tough-mink-modest.ngrok-free.app.