### PR TITLE
Register cuxdi.is-a.dev

### DIFF
--- a/domains/cuxdi.json
+++ b/domains/cuxdi.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "CNAME": "https://cuxdii.github.io/"
+            "CNAME": "cuxdii.github.io/"
         }
     }
     

--- a/domains/cuxdi.json
+++ b/domains/cuxdi.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "cuxdii",
+           "email": "vihar2408+2@gmail.com",
+           "discord": "1156381555875385484"
+        },
+    
+        "record": {
+            "CNAME": "https://cuxdii.github.io/"
+        }
+    }
+    

--- a/domains/cuxdi.json
+++ b/domains/cuxdi.json
@@ -6,7 +6,7 @@
         },
     
         "record": {
-            "CNAME": "cuxdii.github.io/"
+            "CNAME": "cuxdii.github.io"
         }
     }
     


### PR DESCRIPTION
Register cuxdi.is-a.dev with CNAME record pointing to https://cuxdii.github.io/.