### PR TITLE
Register vustron.is-a.dev

### DIFF
--- a/domains/vustron.json
+++ b/domains/vustron.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Vustron",
+           "email": "runa.michaeljoshua@dnsc.edu.ph",
+           "discord": "874628195108929537"
+        },
+    
+        "record": {
+            "CNAME": "https://vustron-vustronus.vercel.app/"
+        }
+    }
+    


### PR DESCRIPTION
Register vustron.is-a.dev with CNAME record pointing to https://vustron-vustronus.vercel.app/.