### PR TITLE
Register koodarimpi.is-a.dev

### DIFF
--- a/domains/koodarimpi.json
+++ b/domains/koodarimpi.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Nikolas-Lehto",
+           "email": "nikolas.lehto1@outlook.com",
+           "discord": "883467091133489193"
+        },
+    
+        "record": {
+            "CNAME": "koodarimpi.duckdns.org"
+        }
+    }
+    


### PR DESCRIPTION
Register koodarimpi.is-a.dev with CNAME record pointing to koodarimpi.duckdns.org.