### PR TITLE
Register Bois07.is-a.dev

### DIFF
--- a/domains/bois07.json
+++ b/domains/bois07.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "yigitboi07",
+           "email": "yigitamaprime@gmail.com",
+           "discord": "262557890995421184"
+        },
+    
+        "record": {
+            "MX": ["galileo.aternos.org"]
+        }
+    }
+    


### PR DESCRIPTION
Register Bois07.is-a.dev with MX record pointing to galileo.aternos.org.