### PR TITLE
Register maskducks.is-a.dev

### DIFF
--- a/domains/maskducks.json
+++ b/domains/maskducks.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "MaskDuck",
+           "email": "70831061+MaskDuck@users.noreply.github.com",
+           "discord": "716134528409665586"
+        },
+    
+        "record": {
+            "MX": ["mx1.improvmx.com"]
+        }
+    }
+    


### PR DESCRIPTION
Register maskducks.is-a.dev with MX record pointing to mx1.improvmx.com.