### PR TITLE
Emptying email and add alternate contacts

### DIFF
--- a/domains/arvindt.json
+++ b/domains/arvindt.json
@@ -3,7 +3,9 @@
     "repo": "https://github.com/ARVIN3108/arvin3108.github.io",
     "owner": {
         "username": "ARVIN3108",
-        "email": "31arvin08@gmail.com",
+        "email": "",
+        "discord": "arvin3108.id",
+        "instagram": "arvin_d.t",
         "twitter": "ARVIN3108_ID"
     },
     "record": {


### PR DESCRIPTION
Emptying the email because it was sent a phishing email and adding Discord and Instagram IDs as alternative contacts