### PR TITLE
Register cirkutry.is-a.dev

### DIFF
--- a/domains/cirkutry.json
+++ b/domains/cirkutry.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Cirkutry",
+           "email": "mrudhulmanuvs@gmail.com",
+           "discord": "787898769467375677"
+        },
+    
+        "record": {
+            "CNAME": "cirkutry.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register cirkutry.is-a.dev with CNAME record pointing to cirkutry.github.io.