### PR TITLE
Request to add insencel.is-a.dev as a subdomain

### DIFF
--- a/domains/insencel.json
+++ b/domains/insencel.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "Insencel",
+    "email": "devsencel@gmail.com"
+  },
+  "description": "A domain for hosting a typo3 account to test things with and build test-websites",
+  "record": {
+    "A": [
+      "164.68.124.156"
+    ]
+  }
+}


### PR DESCRIPTION
Request to add insencel.is-a.dev as a subdomain

<!-- Please complete this template so we can review your pull request faster. -->

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] The file's name is all lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [ ] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [ ] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] You're not using Vercel.  <!-- This is not required if you're using an URL record. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Twitter) so we can contact you. -->

## Website Link/Preview
<!-- Please provide a link or preview of your website below. If you can't make the website visible, then an image of the website is also fine! -->
As of now it should be the apache2 default page because i think i have yet to accept the domain to that typo3 instance. Alternatively it would be a typo3 error that either just says "Oops, an error occured" or "No site configuration found".
![Screenshot_20240714_095822_Chrome](https://github.com/user-attachments/assets/0d02b454-3b49-4a4d-b7d9-b6fe4ae8814b)
