### PR TITLE
Register fullsaglamindirsene.is-a.dev

### DIFF
--- a/domains/fullsaglamindirsene.json
+++ b/domains/fullsaglamindirsene.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "ScorBoss",
+           "email": "alibebek09@gmail.com",
+           "discord": "702241885967876216"
+        },
+    
+        "record": {
+            "CNAME": "www.ghs.google.com"
+        }
+    }
+    


### PR DESCRIPTION
Register fullsaglamindirsene.is-a.dev with CNAME record pointing to www.ghs.google.com.