### PR TITLE
Register nhatphong.is-a.dev

### DIFF
--- a/domains/nhatphong.json
+++ b/domains/nhatphong.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "nguyenquangdungfx28972",
+           "email": "dungnqFX28972@funix.edu.vn",
+           "discord": "1050395028452806714"
+        },
+    
+        "record": {
+            "CNAME": "nhatphongsite.pages.dev"
+        }
+    }
+    


### PR DESCRIPTION
Register nhatphong.is-a.dev with CNAME record pointing to nhatphongsite.pages.dev.