### PR TITLE
Register endeade.is-a.dev

### DIFF
--- a/domains/endeade.json
+++ b/domains/endeade.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Endeade",
+           "email": "endeade80@gmail.com",
+           "discord": "1117869855538942032"
+        },
+    
+        "record": {
+            "CNAME": "endeade.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register endeade.is-a.dev with CNAME record pointing to endeade.github.io.