### PR TITLE
Register luthmc.is-a.dev

### DIFF
--- a/domains/luthmc.json
+++ b/domains/luthmc.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "LuthMC",
+           "email": "luthfi366822@gmail.com",
+           "discord": "861977118718820383"
+        },
+    
+        "record": {
+            "CNAME": "luthmc.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register luthmc.is-a.dev with CNAME record pointing to luthmc.github.io.