### PR TITLE
Register privacy.is-a.dev

### DIFF
--- a/domains/privacy.json
+++ b/domains/privacy.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "andrewstech",
+           "email": "",
+           "discord": "598245488977903688"
+        },
+    
+        "record": {
+            "A": ["217.174.245.249"]
+        }
+    }
+    


### PR DESCRIPTION
Register privacy.is-a.dev with A record pointing to 217.174.245.249.