### PR TITLE
Register formuna.is-a.dev (but this time without vercel)

### DIFF
--- a/domains/formuna.json
+++ b/domains/formuna.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "FormunaGit",
+           "email": "",
+           "discord": "754657845563097108"
+        },
+    
+        "record": {
+            "CNAME": "formunagit.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register formuna.is-a.dev with CNAME record pointing to formunagit.github.io.