### PR TITLE
Register revolux.is-a.dev

### DIFF
--- a/domains/revolux.json
+++ b/domains/revolux.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "rxvolux",
+           "email": "",
+           "discord": "1133072082431913994"
+        },
+    
+        "record": {
+            "CNAME": "rxvolux.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register revolux.is-a.dev with CNAME record pointing to rxvolux.github.io.