### PR TITLE
Register Udaneth.is-a.dev

### DIFF
--- a/domains/udaneth.json
+++ b/domains/udaneth.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Udanethme",
+           "email": "",
+           "discord": "1015652854725365830"
+        },
+    
+        "record": {
+            "CNAME": "udaneth cname loquacious-griffin-a0f978.netlify.app."
+        }
+    }
+    


### PR DESCRIPTION
Register Udaneth.is-a.dev with CNAME record pointing to udaneth CNAME loquacious-griffin-a0f978.netlify.app..