### PR TITLE
Register geostatic.is-a.dev

### DIFF
--- a/domains/geostatic.json
+++ b/domains/geostatic.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Jkingwalagam",
+           "email": "",
+           "discord": "1100459863592685640"
+        },
+    
+        "record": {
+            "CNAME": "geostatic-github-io.pages.dev"
+        }
+    }
+    


### PR DESCRIPTION
Register geostatic.is-a.dev with CNAME record pointing to geostatic-github-io.pages.dev.