### PR TITLE
Register averagepcweb.is-a.dev

### DIFF
--- a/domains/averagepcweb.json
+++ b/domains/averagepcweb.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "FaultyFaulty-glitch",
+           "email": "",
+           "discord": "1102928631191322675"
+        },
+    
+        "record": {
+            "CNAME": "averagepcweb.pages.dev"
+        }
+    }
+    

--- a/domains/faultysden.json
+++ b/domains/faultysden.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "FaultyFaulty-glitch",
+           "email": "faultywindows+github@gmail.com",
+           "discord": "1041028534690386051"
+        },
+    
+        "record": {
+            "TXT": "google-site-verification=ix1jczu2q87igryc4eaexvdv1vrzjxolu14sjfpsnko"
+        }
+    }
+    


### PR DESCRIPTION
Register averagepcweb.is-a.dev with CNAME record pointing to averagepcweb.pages.dev.