### PR TITLE
Register horizon.is-a.dev

### DIFF
--- a/domains/horizon.json
+++ b/domains/horizon.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Horizon1010",
+           "email": "",
+           "discord": "877848431983493132"
+        },
+    
+        "record": {
+            "CNAME": "lunar-hangout.pages.dev"
+        }
+    }
+    


### PR DESCRIPTION
Register horizon.is-a.dev with CNAME record pointing to lunar-hangout.pages.dev.