### PR TITLE
Register Arin.is-a.dev

### DIFF
--- a/domains/arin.json
+++ b/domains/arin.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "Arin06",
+           "email": "",
+           "discord": "431778810174898187"
+        },
+    
+        "record": {
+            "CNAME": "arin06.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register Arin.is-a.dev with CNAME record pointing to Arin06.github.io.