### PR TITLE
Register disophane.is-a.dev

### DIFF
--- a/domains/disophane.json
+++ b/domains/disophane.json
@@ -1,0 +1,13 @@
+{
+        "owner": {
+           "username": "disophane",
+           "email": "",
+           "discord": "934509072827449364",
+           "OWL": "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJaa1VsRmRqVThiUEstLXVVM2JJR09PVHFYYVFFS1ZINFVXOW53MTR6WTJnIn0.H9cWfhjsv_xzeo99-7kpcKIF1lUndqp_KtZ1oF-f5m-SGe6DCJ3W-JkvFTQaLqQUtOCsG_fokq1mINa_HOxcj47L2cpBaXYrwPVVj0av4MsmbrbJ4zCZqHow_2QCYib5Z_WdSknEIvr9sWjQGsPBl1wAv5wzyiAznvFbY3TAUXu1dQndtX1TVEc3QWrzNadow2S0J8-nRk50b68GkvkARuGFPBWCQ3fM-4imujsT7Gy3CXG6k8cvKbu2QPJYyANsRNKNw9_56lHZk36isQ5aNF55tkZZc6EpDA8wvY-oRf89UGtSlAlJsura94_PFZMl71pcNpawIh4jomUckYAOtw.SwWgLrnprBx2AnYllkluYg.PxqpEWt7oB2z-iSwwDQCSFHAd7unzbAWod0rOeJyaKsn5W145Zf6WCfzmocE_PfK6aPQvw9n4mSlhq6HDtN-axP9ANHw32Ermedujj62oPvVior0liW8OWB2U-ThXJJT.t083d19fVxafdikheTOYRw"
+        },
+    
+        "record": {
+            "CNAME": "github.com/disophane"
+        }
+    }
+    


### PR DESCRIPTION
Register disophane.is-a.dev with CNAME record pointing to github.com/disophane.