### PR TITLE
Add email records for clyron.is-a.dev

### DIFF
--- a/domains/clyron.json
+++ b/domains/clyron.json
@@ -6,6 +6,10 @@
     "email": "onenonlyclyron@gmail.com"
   },
   "record": {
-    "CNAME": "theclyron.github.io"
+    "CNAME": "theclyron.github.io",
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ]
   }
 }


### PR DESCRIPTION
This pull request updates clyron.json to add two MX records required for the emails side of things (so one can send an email to [something]@clyron.is-a.dev). The MX records are provided by ImprovMX, which is my service of choice for this stuff