### PR TITLE
Add email records for clyron.is-a.dev

### DIFF
--- a/domains/mail.clyron.json
+++ b/domains/mail.clyron.json
@@ -1,0 +1,13 @@
+{
+  "owner": {
+    "username": "theclyron",
+    "email": "onenonlyclyron@gmail.com"
+  },
+  "record": {
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": "v=spf1 include:spf.improvmx.com ~all"
+  }
+}


### PR DESCRIPTION
Since apparently you can't use CNAME with other records (see pull request #15935 ), this pull request briefly adds email records for clyron.is-a.dev in a different way that is hopefully acceptable this time, specifically by creating a separate mail JSON file.