### PR TITLE
Register GermanFoxDev.is-a.dev

### DIFF
--- a/domains/germanfoxdev.json
+++ b/domains/germanfoxdev.json
@@ -1,0 +1,13 @@
+{
+        "owner": {
+           "username": "GermanFoxDev",
+           "email": "",
+           "discord": "1073620716152434830",
+           "OWL": "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJaa1VsRmRqVThiUEstLXVVM2JJR09PVHFYYVFFS1ZINFVXOW53MTR6WTJnIn0.JQ62vH-ylL9WZzmsXwB57iCVuBqqnB2xTbEJbKApu3ORP3g91xegAqUxT1N9U88KjXdHA_EPKmoau-3hkKqqOKz49gQl6WQ9Ad6j10ZVnRXntSZlkeJ_G3hO5F8LwXlIcwdPFBFeYMqNnTLujZygsE1LH6Wj7CNHlFGyVXBoxtwb7riqN9m-o5-pxY5dcwEIxec9EX7rilyTrGwy7Hft_xnk2BFRBiZL8Va9wQ_b2jbRJfpyxyE5Uh3My9kpHaLejlNh2lZabOsuaHEdEsvTQetrEkixGhDN7PYGD2hVS33HWVtEiCJz2TNVSol5JVI8TyNfNxmsF0GyOyGbkhyI1A.VfdNn0mO4KGJsaPFK5BL7Q.Xb1iQDutlBL4b6q1P3DtJPbJ6lJo-zyLb9A92mAs1lSCorzc2fb2zm9X1vsSOQEzQC3reS6VYZVjfRz0t2g_6EStDQfWHswUuwYxkNAn38I.o0WvBcMFag1-E2YkGakKGg"
+        },
+    
+        "record": {
+            "CNAME": "germanfoxdev.github.io/website/"
+        }
+    }
+    


### PR DESCRIPTION
Register GermanFoxDev.is-a.dev with CNAME record pointing to germanfoxdev.github.io/website/.