### PR TITLE
Register germanfoxdev.is-a.dev

### DIFF
--- a/domains/germanfoxdev.json
+++ b/domains/germanfoxdev.json
@@ -1,0 +1,13 @@
+{
+        "owner": {
+           "username": "GermanFoxDev",
+           "email": "",
+           "discord": "1073620716152434830",
+           "OWL": "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJaa1VsRmRqVThiUEstLXVVM2JJR09PVHFYYVFFS1ZINFVXOW53MTR6WTJnIn0.GsPN4QZJZ53Om9rp-MBka8t2OeY-ev1xFBEei9DSRGEJDSVKR23x6xYuT4a1nfAhV0dgUi_WFIm-vGwF-oHkKEcGZo8nr-zH_hwR2HxnmfmBs6qUEKhpIeTQYx34Ws0B3n36aNk6odCO2Tz0LgtIr6bwq8WgAa985WD0_secI4WHCodhXMfAMZttW_kZT109B8iBq-3rjhjMWG1Xcix9mvUkbUREF17oIK0G70QlmEFvLOxp5rSg1SfHWZ251oOnIqfqrZ90_OHk9FVNDKex4OwCt7klesABNi0v8V7wWVhKlHgtojhdHY-oz87_YCz7orLcMpCxwmuCFJtLFEmlZw.IVb7t0DdLgHkH_YFU0vnyg.r9q1gsR3Uw33QGFExZZad6NNiyuO8YFEXPvX-OmhHw8TTVZkT9F0wUAJrSK7pGM3jf0-GnBlV6LTOcC-M20bdaOjTJK2ytnxRYG4Uk3pYOg.U6vvLC1-IjAWWDFFIKKAVA"
+        },
+    
+        "record": {
+            "CNAME": "germanfoxdev.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register germanfoxdev.is-a.dev with CNAME record pointing to germanfoxdev.github.io.