### PR TITLE
Update with TXT record for Github Verification for shaunfurtado.github.io

### DIFF
--- a/domains/_github-pages-challenge-Shaunfurtado.blog.shaunfurtado.json
+++ b/domains/_github-pages-challenge-Shaunfurtado.blog.shaunfurtado.json
@@ -1,6 +1,5 @@
 {
   "description": "Verification for blog.shaunfurtado.is-a.dev in Github Pages",
-  "repo": "https://github.com/Shaunfurtado/DevHavok",
     "owner": {
       "username": "Shaunfurtado",
       "email": "shaunf1801@gmail.com"

--- a/domains/_github-pages-challenge-Shaunfurtado.blog.shaunfurtado.json
+++ b/domains/_github-pages-challenge-Shaunfurtado.blog.shaunfurtado.json
@@ -1,0 +1,11 @@
+{
+  "description": "Verification for blog.shaunfurtado.is-a.dev in Github Pages",
+  "repo": "https://github.com/Shaunfurtado/DevHavok",
+    "owner": {
+      "username": "Shaunfurtado",
+      "email": "shaunf1801@gmail.com"
+    },
+  "record": {
+    "TXT": "08ce2f232e7028cbeb1a6baf8c8e49"
+  }
+}


### PR DESCRIPTION
Merge _github-pages-challenge-Shaunfurtado.blog.shaunfurtado.json 

This pull request adds a configuration file (blog.shaunfurtado.json) for Shaun Furtado's blog website. The details include a description, repository URL, owner information, and TXT record for GIthub Pages Verification.

The live link for the current website from GitHub Pages: [link](https://shaunfurtado.is-a.dev/DevHavok/)