### PR TITLE
Add `_vercel` to be a valid underscore name.

### DIFF
--- a/tests/validations.test.js
+++ b/tests/validations.test.js
@@ -88,6 +88,7 @@ describe("validateDomainData", () => {
         { ...defaultDomain, name: "_gh-is-a-dev" },
         { ...defaultDomain, name: "_domainkey" },
         { ...defaultDomain, name: "_improvmx" },
+        { ...defaultDomain, name: "_vercel" },
     ];
 
     const validCases = [
@@ -143,6 +144,7 @@ describe("validateDomainData", () => {
         { ...defaultDomain, name: "_domainkey.subdomain" },
         { ...defaultDomain, name: "mx._domainkey.subdomain" },
         { ...defaultDomain, name: '_improvmx.subdomain' },
+        { ...defaultDomain, name: '_vercel.subdomain' },
         { ...defaultDomain, name: "a.b" },
     ];
 

--- a/utils/invalid-domains.json
+++ b/utils/invalid-domains.json
@@ -8,6 +8,7 @@
     "_github-pages-challenge-is-a-dev",
     "_gitlab-pages-verification-code",
     "_improvmx",
+    "_vercel",
     "con",
     "help",
     "no-reply",

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -60,6 +60,7 @@ const extraSupportedNames = [
     R.equals("_dmarc"),
     R.equals("_domainkey"),
     R.equals("_improvmx"),
+    R.equals("_vercel"),
     testRegex(/^_gh-[a-z0-9-_]+$/i),
 ];
 


### PR DESCRIPTION
Context: In the community thread we made to Vercel about the problem, they have said that now it should be fixed and it functions simillar to the github pages txt verification. I did make a PR to see if it would work in #16073 , but I forgot to add `_vercel` to the list