### PR TITLE
Delete NaTDeveloper's domains

### DIFF
--- a/domains/762.json
+++ b/domains/762.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "NaTDeveloper",
-    "email": "devihermeena@gmail.com"
-  },
-  "record": {
-    "CNAME": "treker.betteruptime.com"
-  }
-}

--- a/domains/dangnat.json
+++ b/domains/dangnat.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "NaTDeveloper",
-    "email": "devihermeena@gmail.com"
-  },
-  "record": {
-    "CNAME": "natdev-5ffb.onrender.com"
-  }
-}


### PR DESCRIPTION
User was terminated from the service due to opening a PR adding an IP and webcam logging website. See #16215.