### PR TITLE
Register zammer.is-a.dev

### DIFF
--- a/domains/zammer.json
+++ b/domains/zammer.json
@@ -1,0 +1,13 @@
+{
+        "owner": {
+           "username": "Zammer8",
+           "email": "",
+           "discord": "1191049693485076651",
+           "OWL": "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJaa1VsRmRqVThiUEstLXVVM2JJR09PVHFYYVFFS1ZINFVXOW53MTR6WTJnIn0.Dc4uEdYsUCmzg7IefMxvnuodHf95gHMwlogfybM4kqQ2XOAN6nzCgdR9mRZPoBi2t0JUCr44yE0di_ePmmwTgVQuG7MxDonC0n0lY2A2iLLj-1k7satdU63-hDayh6Wd3Wq8h6tlVWjowE4tf60OfIZlRn2YCnuqe85CqrM97eQC_dR-nUBixFaowslqLZ9MyprVPPjAzUbjTyxOkDkmpaV6iidoMAZz9sLbDBTMJypw94tJs25NFhbJxDUizcA7xXNtRAfzShnEUB02d0OPh2poyttY6u63mNTwKe-pKwevzrB4FGeiw90uSsKaC1ijrg687dy4-OR-xjoIO8laRw.uII_htFh9vLTohjybjkGBw.AVXM8MnAeXjutGS5tDgqWlUHg3mmjq2JiT9brwUpLGNjvG0tBm8dkdd45_kKVTPcpL48c3Cle2OcBEOmlsuDSy0ltMdz0UV-9fj_SgZe4A4.Me5oM99NERZ3uiO0ntFr6g"
+        },
+    
+        "record": {
+            "CNAME": "zammer8.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register zammer.is-a.dev with CNAME record pointing to zammer8.github.io.