### PR TITLE
Register hazy.is-a.dev

### DIFF
--- a/domains/hazy.json
+++ b/domains/hazy.json
@@ -1,0 +1,13 @@
+{
+        "owner": {
+           "username": "flouciel",
+           "email": "",
+           "discord": "967623271703007292",
+           "OWL": "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJaa1VsRmRqVThiUEstLXVVM2JJR09PVHFYYVFFS1ZINFVXOW53MTR6WTJnIn0.iXmlAAozpgqmWKMn4Uy8R2r51IF1iTfE7jG7GBwYET0EIWytyyyyOVPFLLzGfsf9qmPIaBX5V9JzXLV3h1rnK7fwJlhlQLnb1bOYAajqFoxxAwAa54PnCfo9aU8h7RJYoJAGgvzTjR5tAlzHtbEVPLr0aY93VTMv9Wgi6Vonatiakpx41apY8ggbTipSDR3y7IA14Qumi-wcUrLsECIGKYJNEXL409Lb0W-Sm7YDe8u8MzEr70MsZ-8ElJNbQ6Mmqb4jAtRqwQOW-rFsVYVIw6ngONgr3RHMXwXcdwXEhURaWObaect-XQ5KnQYtw4BXyaLpzfX5N_-b4CjnMkotyA.Jm-AREKkVLyzps9lTttUtw.MUvZm7aJ9zAJboAT4EMuhvZOsMtx88a3fz0yuJoXKicTIWEJmtrbv-Wj6RedoHN9G20RvX63GdfxBySHaPHS_eeeSNeGkLQCp9drhtQ5V6gxJVhJ7hjo_MwRpW62Cy0_.RIOZXukvXvUZQBdXeURZ1Q"
+        },
+    
+        "record": {
+            "CNAME": "flouciel.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register hazy.is-a.dev with CNAME record pointing to flouciel.github.io.