### PR TITLE
Register toadvillebay.is-a.dev

### DIFF
--- a/domains/toadvillebay.json
+++ b/domains/toadvillebay.json
@@ -1,0 +1,13 @@
+{
+        "owner": {
+           "username": "notghostvista",
+           "email": "",
+           "discord": "907846380486291486",
+           "OWL": "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJaa1VsRmRqVThiUEstLXVVM2JJR09PVHFYYVFFS1ZINFVXOW53MTR6WTJnIn0.LcONtw79KouZ5CHwdUE19aYS3OPqr4tc-zYo1vI4hiyk_-q2ZWUnLchzwdBxILOFYfDPGPk9u7xrwmH4RsgNNNQlNUj5XYTeKPDE9EiSzf1vgWnJ-oQC9W75U_p0lxhf2gjlK1_6a7V8DLL8eYt_yEN65VM5z_oLxLDuGJycd-QfN9KB4M5GCnrDmaft36Izs8cF4fGy5PgI2Tg0xIg5UlPMK-q6UtQk16nFbMXMat8UxQ7Wha30qS5HNlI2iuCLQb8iwTcKnG4rpkWFS1UGQeBa2ZBRAJTDxdbaSfJqTb8b1zroVhhRc-txA1OBeLTuVaVzPvFAEwSsstGZXvEkmA.8Zfqqt1TD7xwGlYlsf5D0g.0IacuKDmXmhPtSrYzZAJj_gTPTwPNa1v7HRN0tOUoQMqwfj5avpIR4eCv7_tXPwpfk9hbjvXw3_AvVhlANGfOgO1GHhhIHltcDc2WWktd1c.WoQIyHoD15gcTvKBRhuM0w"
+        },
+    
+        "record": {
+            "CNAME": "notghostvista.github.io"
+        }
+    }
+    


### PR DESCRIPTION
Register toadvillebay.is-a.dev with CNAME record pointing to notghostvista.github.io.