### PR TITLE
Register _vercel.mantou.is-a.dev

### DIFF
--- a/domains/_vercel.mantou.json
+++ b/domains/_vercel.mantou.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Mantouisyummy",
+    "email": "",
+    "discord": "549056425943629825"
+  },
+  "record": {
+    "TXT": "vc-domain-verify=mantou.is-a.dev,c8a46ea52ff24c67a0a6"
+  }
+}


### PR DESCRIPTION
Register _vercel.mantou.is-a.dev with TXT record pointing to vc-domain-verify=mantou.is-a.dev,c8a46ea52ff24c67a0a6

I have already submitted and the pull request for the A record of this subdomain has been merged, so this PR does not include `mantou.json`.

Here: https://github.com/is-a-dev/register/pull/16566

My site:
https://www.mantouuwu.top