### PR TITLE
Create really.json

### DIFF
--- a/domains/really.json
+++ b/domains/really.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ukriu",
+    "email": "isadev@ukriu.com"
+  },
+  "record": {
+    "NS": ["love.ns.cloudflare.com", "pete.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
`really.is-a.dev` uses NS records. I just felt like its fitting.
I can start my own rival subdomain project! /j
I just wanna give my friends nested subdomains or redirects.

This is REALLY stupid. I totally agree with you guys if this doesn't get merged.
(can't believe `really` isn't claimed yet. Even if this doesn't get merged I'm calling dibs on `really`)

Here's a test subdomain: 
https://test.ukriu.is-a.dev/
(It does work)