### PR TITLE
chore: point fry69 to github.io

### DIFF
--- a/domains/fry69.json
+++ b/domains/fry69.json
@@ -7,7 +7,7 @@
         },
     
         "record": {
-            "CNAME": "fry69-dev.karleo.workers.dev"
+            "CNAME": "fry69.github.io"
         }
     }
     


### PR DESCRIPTION
<!-- Please complete this template so we can review your pull request faster. -->

## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] The file's name is all lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Twitter) so we can contact you. -->

## Website Link/Preview
<!-- Please provide a link or preview of your website below. If you can't make the website visible, then an image of the website is also fine! -->

https://fry69.github.io/

Reason: Cloudflare still throws an `error code: 1014` with the current CNAME, so let's try GitHub pages to get this to work.

Update: I found out where the problem is. I use a static assets worker instead of Clouflare pages to host my site (recommended by Cloudflare for new projects, as pages seem to get soft-deprecated and moved to workers, see [here](https://discord.com/channels/595317990191398933/789155108529111069/1300208359445757952)). This seems to be not supported or require a NS record to work.

Should I send a PR for the docs to add this as a note in the Cloudflare pages guide?