### PR TITLE
Migrating to SimpleLogin

### DIFF
--- a/domains/dhilipan.json
+++ b/domains/dhilipan.json
@@ -6,7 +6,7 @@
   },
   "record": {
     "A": ["75.2.60.5"],
-    "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
-    "TXT": "v=spf1 include:spf.improvmx.com ~all"
+    "MX": ["mx1.simplelogin.co.", "mx2.simplelogin.co."],
+    "TXT": ["sl-verification=wpdcbpaapmqwevjvnaifhpwdvozldi", "v=spf1 include:simplelogin.co ~all"]
   }
 }

--- a/domains/dhilipan.json
+++ b/domains/dhilipan.json
@@ -7,6 +7,6 @@
   "record": {
     "A": ["75.2.60.5"],
     "MX": ["mx1.simplelogin.co.", "mx2.simplelogin.co."],
-    "TXT": ["sl-verification=wpdcbpaapmqwevjvnaifhpwdvozldi", "v=spf1 include:simplelogin.co ~all"]
+    "TXT": ["sl-verification=wpdcbpaapmqwevjvnaifhpwdvozldi", "v=spf1 include:simplelogin.co. ~all"]
   }
 }

--- a/domains/dhilipan.json
+++ b/domains/dhilipan.json
@@ -6,7 +6,7 @@
   },
   "record": {
     "A": ["75.2.60.5"],
-    "MX": ["mx1.simplelogin.co.", "mx2.simplelogin.co."],
+    "MX": ["mx1.simplelogin.co", "mx2.simplelogin.co"],
     "TXT": ["sl-verification=wpdcbpaapmqwevjvnaifhpwdvozldi", "v=spf1 include:simplelogin.co. ~all"]
   }
 }


### PR DESCRIPTION
Changed MX records and TXT records to migrate from improvmx to simplelogin.
Added verification TXT record and SPF. Added MX records of SimpleLogin for forwarding.
