### PR TITLE
Register tweets.clyron.is-a.dev

### DIFF
--- a/domains/tweets.clyron.json
+++ b/domains/tweets.clyron.json
@@ -1,0 +1,11 @@
+{
+  "description": "Personal website of Clyron",
+  "repo": "https://github.com/theclyron/theclyron.github.io",
+  "owner": {
+    "username": "theclyron",
+    "email": "onenonlyclyron@gmail.com"
+  },
+  "record": {
+    "CNAME": "theclyron.github.io"
+  }
+}


### PR DESCRIPTION
This pull request adds tweets.clyron.json, functioning as a nested subdomain where to host a public archive of my old Twitter account