### PR TITLE
Register rh.is-a.dev

### DIFF
--- a/domains/rh.json
+++ b/domains/rh.json
@@ -1,0 +1,12 @@
+{
+        "owner": {
+           "username": "xgeneric",
+           "discord": "1194494419064328296",
+           "OWL": "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAiLCJraWQiOiJaa1VsRmRqVThiUEstLXVVM2JJR09PVHFYYVFFS1ZINFVXOW53MTR6WTJnIn0.ZtZQsJTtFUyYhqLYNct9qcURDeHFnE5Ugn5lKWqREmwWqCAuGrwNRn1zp85VPPaH8Bk4Q1ATD9ImX6Y9ImThgE4xe2stIjZnhctvNxnAmZWekpmWwcAuuCvHTObM5qLWr6NeiHJ8J9bR2HqFa40s6u3T3dBS-xxqhVK4CWWgoIXGyWuiX0qZ2FTqAoyhnFZI_UeN29UaJTaobyxmI6mapHxEfz3GdO5SMqsefrU21i7eNQQefzMcbhyYZUR8TomivC0FzMQ5zVDj7JTm3ezqhZIl6p4cu7LmybiGq0sv0BDZCgtYMlcj8uLkUbjClJeKzJmpmJbMt__sD_niRZDKyA.WVnasMUFnhSKWJpsSLkLPg.gUTYVhrtgb368DU4qtJVK8M8U6lD3cAp_sqIqGR3t1tEE8txRYRGKV-a8_TWfVO5BxEzGpJVUhjWxnU91k40SW6qoy4TXW38Ptn15z6ebSHId5hBzRSEo9UB5KVjwhtY.7ttPpw2KH1r6ClFsiGanfw"
+        },
+    
+        "record": {
+            "CNAME": "browsercf.rammerhead.org"
+        }
+    }
+    


### PR DESCRIPTION
Register rh.is-a.dev with CNAME record pointing to browsercf.rammerhead.org.