### PR TITLE
fix: use CNAME instead or URL so github can use this

### DIFF
--- a/domains/blog.anirbaaaan.json
+++ b/domains/blog.anirbaaaan.json
@@ -4,6 +4,6 @@
     "email": "anirbanrc@proton.me"
   },
   "record": {
-    "URL": "https://anirbaaaan183.github.io/blog"
+    "CNAME": "anirbaaaan183.github.io"
   }
 }


### PR DESCRIPTION
FIX broken record. Use CNAME to base github domain instead of URL redirecting.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] The file's name is all lowercased and alphanumeric.
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.
- [x] There is sufficient information at the `owner` field.

## Website Link/Preview
https://anirbaaaan.is-a.dev/blog