### PR TITLE
Use Cloudflare DNS for yashasviallen subdomain

### DIFF
--- a/domains/yashasviallen.json
+++ b/domains/yashasviallen.json
@@ -5,6 +5,5 @@
   },
   "record": {
     "NS": ["bethany.ns.cloudflare.com", "miles.ns.cloudflare.com"]
-  },
-  "proxied": true
+  }
 }

--- a/domains/yashasviallen.json
+++ b/domains/yashasviallen.json
@@ -4,7 +4,7 @@
     "email": "yashasviallen@gmail.com"
   },
   "record": {
-    "CNAME": "yashasviallen.dynv6.net"
+    "NS": ["bethany.ns.cloudflare.com", "miles.ns.cloudflare.com"]
   },
   "proxied": true
 }


### PR DESCRIPTION
I am updating the records for yashasviallen subdomain to use Cloudflare nameservers. Here is my reasoning behind it:

- I have setup a cf proxy on my domain to hide the ip to my homeserver(dynv6) and also let ipv4 clients access my proxied ipv6 service.
  But this way I get the cf's antibot page whenever I try to access any hosted APIs behind my service **programatically**.
- It shows me "Just a moment..." after which it should ideally redirect me to the page, but it's not working due to the cf's antibot. 
- I am trying to fetch data from the API running behind the cf proxy, removing cf proxy as a whole won't work for me cuz my service is hosted on ipv6 and I'm using the cf proxy to let ipv4 clients access it. 
- I want the NS access to have the cf proxy and disable cf anti-bot for those things.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] The file's name is all lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Twitter) so we can contact you. -->

