### PR TITLE
Update xvannn07.json

### DIFF
--- a/domains/xvannn07.json
+++ b/domains/xvannn07.json
@@ -4,7 +4,7 @@
         "username": "Xvannn07"
     },
     "record": {
-        "CNAME": "xvannn.xyz"
+        "CNAME": "https://silly-arithmetic-ef452c.netlify.app/"
     },
     "proxy": false
 }

--- a/domains/xvannn07.json
+++ b/domains/xvannn07.json
@@ -4,7 +4,7 @@
         "username": "Xvannn07"
     },
     "record": {
-        "CNAME": "https://silly-arithmetic-ef452c.netlify.app/"
+        "CNAME": "silly-arithmetic-ef452c.netlify.app"
     },
     "proxy": false
 }


### PR DESCRIPTION
This pull request adds the subdomain `xvannn07.is-a.dev` to the domains list. The subdomain is configured to point to my Netlify-hosted portfolio at `silly-arithmetic-ef452c.netlify.app`.

The JSON file `xvannn07.json` has been added under the `domains` folder with the following configuration:
```json
{
    "owner": {
        "email": "xvannn07@example.com",
        "username": "Xvannn07"
    },
    "record": {
        "CNAME": "https://silly-arithmetic-ef452c.netlify.app/"
    },
    "proxy": false
}