### PR TITLE
Create cyberglot.json

### DIFF
--- a/domains/cyberglot.json
+++ b/domains/cyberglot.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "cyberglot",
+    "email": "cyberglot@gmail.com"
+  },
+  "record": {
+    "CNAME": "cyberglot.github.io"
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] The file's name is all lowercased and alphanumeric. 
- [x] You have completed your website. 
- [?] The website is reachable. 
- [x] The CNAME record doesn't contain `https://` or `/`. 
- [x] There is sufficient information at the `owner` field. 

## Website Link/Preview
I want to move my website, [cyberglot.space](https://cyberglot.space), to `cyberglot.is-a.dev`. `cyberglot.space` is pointing to `cyberglot.github.io`, which is why the original GitHub one returns 404. I want to get `cyberglot.is-a.dev` working before changing `cyberglot.space` to redirect to it.
