### PR TITLE
Use Cloudflare DNS for longnt subdomain

### DIFF
--- a/domains/longnt.json
+++ b/domains/longnt.json
@@ -1,6 +1,6 @@
 {
   "owner": {
-    "username": "longnt",
+    "username": "simel0",
     "email": "longnt2204+dev@gmail.com"
   },
   "record": {

--- a/domains/longnt.json
+++ b/domains/longnt.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "longnt",
+    "email": "longnt2204+dev@gmail.com"
+  },
+  "record": {
+    "NS": ["armfazh.ns.cloudflare.com", "stella.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
<!-- Please complete this template so we can review your pull request faster. -->

I plan to use a free subdomain from is-a.dev to host several applications and pet projects. To do this, I need to use Cloudflared Tunnels, and for that, I need to set an NS record to allow Cloudflare to manage the DNS for my subdomain.


## Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain must pass **ALL** the indicated requirements above.

Please note that we reserve the rights not to accept any domain at our own discretion.

- [x] The file is in the `domains` folder and is in the JSON format.
- [x] The file's name is all lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] You have completed your website. <!-- This is not required if the domain you're registering is for emails. -->
- [x] The website is reachable.  <!-- This is not required if the domain you're registering is for emails. -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.  <!-- You need to have your email presented at `email` field. If you don't want to provide your email for any reason, you can specify another social platform (e.g. Twitter) so we can contact you. -->

## Website Link/Preview
<!-- Please provide a link or preview of your website below. If you can't make the website visible, then an image of the website is also fine! -->
![image](https://github.com/user-attachments/assets/e14aeca0-4ecb-4e30-a97a-a00bba380453)

## Why I need NS records?
I need nameserver records as I need to use cloudflare tunnelling, and not having nameserver records could expose my home ip address