### PR TITLE
Remove `iusearchbtw.is-a.dev` since it got hijacked

### DIFF
--- a/domains/iusearchbtw.json
+++ b/domains/iusearchbtw.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "iamnotmega",
-    "email": "uksningaken@gmail.com"
-  },
-  "record": {
-    "CNAME": "iamnotmega.github.io"
-  }
-}


### PR DESCRIPTION
Image says it all
![image](https://github.com/user-attachments/assets/4e6f5e06-2286-476b-b35f-2b6af89d4e63)
![image](https://github.com/user-attachments/assets/4b00617b-b679-4419-9f65-724d062a1c76)
