### PR TITLE
Add pilotseye.is-a.dev domain

### DIFF
--- a/domains/pilotseye.json
+++ b/domains/pilotseye.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "YFFKJB",
+    "email": "1261546255@qq.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "description": "PilotsEYE Studio Accounting System - A web-based accounting system for PilotsEYE Studio"
+}


### PR DESCRIPTION
Request for pilotseye.is-a.dev domain

- Domain: pilotseye.is-a.dev
- Purpose: Hosting a web-based accounting system for PilotsEYE Studio
- Website: https://accounting-system-q8mwnyuih-pilotseye-projects.vercel.app

I confirm that:
- [x] I own this domain
- [x] The domain will be used for the stated purpose
- [x] The website content will comply with the terms of service