### PR TITLE
Create joshuanoeldeke.json

### DIFF
--- a/domains/joshuanoeldeke.json
+++ b/domains/joshuanoeldeke.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "joshuanoeldeke",
+        "email": "joshua.noeldeke@me.com"
+    },
+    "record": {
+        "NS": ["adrian.ns.cloudflare.com","keaton.ns.cloudflare.com"]
+    }
+}


### PR DESCRIPTION
I am planning to use the subdomain in combination with cloudflare tunnels to host several applications like portainer, immich, home assistant and more. Because i want to use cloudflare tunnels instead of a reverse proxy like nginx proxy manager, i need to set an NS record to let Cloudflare manage the subdomains DNS.

My main reason for wanting to use cloudflare tunnels, and thus needing to set the NS record is security. With cloudflare tunnels, i don't need to expose a port on my router to access my applications remotely, which can be a major security issue.

# Requirements
Unless explicitly specified otherwise by a **maintainer** or in the requirement description, your domain **MUST** pass **ALL** the indicated requirements below.

<!-- Change each checkbox to [x] to mark it as checked. Do not keep the spaces between the parentheses. -->
- [x] I have **read** and **understood** the [Terms of Service](https://is-a.dev/terms). <!-- Your domain MUST follow the TOS to be approved. -->
- [x] My domain is **not** for commercial use. <!-- e.g. Your domain should not be selling products & services -->
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] My website is **reachable**.
- [x] I have **completed** my website. <!-- We do not permit simple "Hello, world!" websites. -->
- [x] My website is related to **software development**. <!-- We don't permit websites for domains unrelated to development (e.g. Discord servers, gaming guilds, etc.) -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g., X, Discord) for contact. -->
- [x] I have followed and read the [documentation](https://docs.is-a.dev).
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).

# Website Preview

![image](https://github.com/user-attachments/assets/a7cb028d-d6d0-4590-8782-ff220b4dde10)