### PR TITLE
Delete anime.is-a.dev (Violate Terms of Services)

### DIFF
--- a/domains/anime.json
+++ b/domains/anime.json
@@ -1,9 +1,0 @@
-{
-    "owner": {
-        "username": "zarqizoubir",
-        "email": "zarqi.ezzoubair@etu.uae.ac.ma"
-    },
-    "record": {
-        "CNAME": "zarqizoubir.github.io"
-    }
-}


### PR DESCRIPTION
The domain anime.is-a.dev, which currently is using is-a.dev for subdomain, is violating Terms of Services of "Prohibited Activities", which states that "You agree not to use the is-a.dev service for: Hosting illegal content, including but not limited to pirated software, malware, or copyrighted materials without authorization."