### PR TITLE
allow letsencrypt to issue certs for filip.is-a.dev

### DIFF
--- a/domains/filip.json
+++ b/domains/filip.json
@@ -5,6 +5,7 @@
     "username": "totalolage",
     "email": "filip@kalny.net"
   },
+  "proxied": true,
   "record": {
     "CNAME": "vps1.kalny.net",
     "CAA": [

--- a/domains/filip.json
+++ b/domains/filip.json
@@ -6,6 +6,13 @@
     "email": "filip@kalny.net"
   },
   "record": {
-    "CNAME": "vps1.kalny.net"
+    "CNAME": "vps1.kalny.net",
+    "CAA": [
+      {
+        "flags": 0,
+        "tag": "issue",
+        "value": "letsencrypt.org"
+      }
+    ]
   }
 }


### PR DESCRIPTION
<!--
!!!
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, IT IS NOT OPTIONAL.
IF YOU DO NOT FILL OUT THIS PR TEMPLATE TO ITS ENTIRETY, YOUR PR WILL BE IMMEDIATELY DENIED.
!!!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] to mark it as checked. Do not keep the spaces between the parentheses. -->

- [x] I have **read** and **understood** the [Terms of Service](https://is-a.dev/terms). <!-- Your domain MUST follow the TOS to be approved. -->
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied websites. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g., X, Discord) for contact. -->

# Website Preview
[totalolage.github.io](https://totalolage.github.io)
vps1.kalny.net is a Traefik proxy of filip.is-a.dev to the above GitHub pages site, but I am unable to issue a cert to it due to CAA failure: https://letsdebug.net/filip.is-a.dev/2381463
