### PR TITLE
Revert `socials.chiragnahata.is-a.dev`

### DIFF
--- a/domains/socials.chiragnahata.json
+++ b/domains/socials.chiragnahata.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "chiragnahata",
-    "email": "chiragnahata05@gmail.com"
-  },
-  "record": {
-    "A": ["129.213.151.29"]
-  }
-}


### PR DESCRIPTION
Reverting the PR since this domain LITERALLY HAD CASINO SPAMS.

@chiragnahata friendly reminder that we have tried contacting you about it, but you simply ignore it. https://discord.com/channels/830872854677422150/1057228967972716584/1322503272820379729

I do not feel like this domain should be merged, hence why I'm reverting it.