### PR TITLE
Create _atproto.lua.json

### DIFF
--- a/domains/_atproto.lua.json
+++ b/domains/_atproto.lua.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "notxlua",
+        "email": "notxlua@gmail.com"
+    },
+    "record": {
+        "TXT": "did=did:plc:j7iap5lpvblnrr7lygisgjzp"
+    }
+}


### PR DESCRIPTION
Atproto is the connection DNS for bluesky. I figure I can just modify the prefix, since both discord and bluesky require the same data to connect domains.

<!--
!!!
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, IT IS NOT OPTIONAL.
IF YOU DO NOT FILL OUT THIS PR TEMPLATE TO ITS ENTIRETY, YOUR PR WILL BE IMMEDIATELY DENIED.
!!!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] to mark it as checked. Do not keep the spaces between the parentheses. -->

- [x] I have **read** and **understood** the [Terms of Service](https://is-a.dev/terms). <!-- Your domain MUST follow the TOS to be approved. -->
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied websites. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g., X, Discord) for contact. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. You MUST complete this step for your PR to be approved. -->

Website link: https://lua.is-a.dev/
