### PR TITLE
Create coder.json

### DIFF
--- a/domains/coder.json
+++ b/domains/coder.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "turbomaster95",
+    "email": "devamidhun.3c.kmbvm@gmail.com"
+  },
+  "record": {
+    "NS": [
+      "aria.ns.cloudflare.com",
+      "leonard.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
# Website Preview
https://coderrrrrsite.vercel.app


This pull request, is to register my domain for a NS record. Here are my reasons:

- I have an old laptop at home, and I want to host some services like Gitea, Vaultwarden, a Matrix server, etc. I need a domain to put my server behind Cloudflare Tunnels, because my ISP doesn't provide any kind of public ip address (v4 or v6).
- It is much easier for me to manage my domain's DNS records via the Cloudflare Dashboard.
- I confirm I will not use the domain for any illegal/inappropriate/NSFW activities, nor give access to another person. If this happens, my domain will be suspended.

(I did take some things from @actuallyundefined's pr (#16758). So thanks @actuallyundefined for your example!)