### PR TITLE
remove denisklimenko.is-a.dev

### DIFF
--- a/domains/denisklimenko.json
+++ b/domains/denisklimenko.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "DenisKlimenko",
-    "email": "denis.klimenko.92@gmail.com"
-  },
-  "record": {
-    "NS": ["destiny.ns.cloudflare.com", "kirk.ns.cloudflare.com"]
-  }
-}


### PR DESCRIPTION
Cannot find any active usage using subdomainfinder.c99.nl, Google search, crt.sh. The root `denisklimenko.is-a.dev` does not resolve, and the only subdomain I found https://immich.denisklimenko.is-a.dev does not load.