### PR TITLE
Add play.alora.is-a.dev

### DIFF
--- a/domains/play.alora.json
+++ b/domains/play.alora.json
@@ -1,11 +1,13 @@
 {
-  "description": "Making my MC server accessible via a custom domain name",
-  "repo": "https://www.minecraft.com/",
   "owner": {
     "username": "aloramiaa",
     "email": "xaloramia@gmail.com"
   },
   "record": {
-    "A": ["78.46.65.243"]
-  }
+    "A": [
+      "78.46.65.24"
+    ]
+  },
+  "description": "Making my MC server accessible via a custom domain name",
+  "repo": "https://www.minecraft.com/"
 }


### PR DESCRIPTION
## Domain Registration

I'd like to register `play.alora.is-a.dev`.

- **Description**: Making my MC server accessible via a custom domain name
- **Repository**: https://www.minecraft.com/


## Website Preview

![play.alora.is-a.dev Screenshot](https://raw.githubusercontent.com/aloramiaa/domain-screenshots/main/play.alora-1745070406410.png)

## Checklist

- [x] I've read the [documentation](https://is-a.dev/docs)
- [x] I've verified that my domain adheres to the [domain structure](https://is-a.dev/docs/#domain-structure)
- [x] I've verified that my JSON file is valid