### PR TITLE
Add jenin.is-a.dev

### DIFF
--- a/domains/jenin.json
+++ b/domains/jenin.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "jeninh",
+    "email": "cubingjulian@gmail.com"
+  },
+  "record": {
+    "CNAME": "jeninh.github.io"
+  },
+  "description": "A website for me to show my various website stuff, like a blog with Church studies, some Canadian political election tracking services, and some cool stuff like that. For now I have a placeholder site until I can secure the domain :)"
+}


### PR DESCRIPTION
## Domain Registration

I'd like to register `jenin.is-a.dev`.

- **Description**: A website for me to show my various website stuff, like a blog with Church studies, some Canadian political election tracking services, and some cool stuff like that. For now I have a placeholder site until I can secure the domain :)


## Website Preview

![jenin.is-a.dev Screenshot](https://raw.githubusercontent.com/jeninh/domain-screenshots/main/jenin-1745280365022.png)

## Checklist

- [x] I've read the [documentation](https://is-a.dev/docs)
- [x] I've verified that my domain adheres to the [domain structure](https://is-a.dev/docs/#domain-structure)
- [x] I've verified that my JSON file is valid