### PR TITLE
fix: add ns for netlify subdomain

### DIFF
--- a/domains/angela-caldas.json
+++ b/domains/angela-caldas.json
@@ -4,6 +4,6 @@
         "email": "aes.caldas@gmail.com"
     },
     "records": {
-        "URL": "https://angelacaldas.netlify.app/"
+        "A": ["75.2.60.5"]
     }
 }


### PR DESCRIPTION
# Requirements

- [x] I have **read** and **understood** the [Terms of Service](https://is-a.dev/terms). <!-- Your domain MUST follow the TOS to be approved. -->
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied websites. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g., X, Discord) for contact. -->

# Reason
I've replaced URL record with A record so my website really uses the `is-a.dev` subdomain instead of just redirecting