### PR TITLE
Request defendabot.is-a.dev

### DIFF
--- a/domains/defendabot.json
+++ b/domains/defendabot.json
@@ -1,8 +1,8 @@
 {
   "owner": {
-    "github": "SSDEDU-WEB"
+    "github": "maxyt5184"
   },
   "record": {
-    "CNAME": "SSDEDU-WEB.github.io"
+    "CNAME": "maxyt5184.github.io/Max-Dev-Bots-Invite"
   }
 }

--- a/domains/defendabot.json
+++ b/domains/defendabot.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "github": "SSDEDU-WEB"
+  },
+  "record": {
+    "CNAME": "SSDEDU-WEB.github.io"
+  }
+}


### PR DESCRIPTION
Hi! I'd like to request the subdomain `defendabot.is-a.dev` to point to my bot website hosted on GitHub Pages at `https://maxyt5184.github.io/Max-Dev-Bots-Invite/`.

Thanks!
