### PR TITLE
Create url-encryption-tool.json

### DIFF
--- a/domains/url-encryption-tool.json
+++ b/domains/url-encryption-tool.json
@@ -1,0 +1,14 @@
+{
+  "owner": {
+    "username": "tijohncenna",
+    "email": "tijohncenna@gmail.com"
+  },
+  "records": {
+    "CNAME": "secure-tool.user-content.workers.dev",
+    "NS": [
+      "marissa.ns.cloudflare.com",
+      "odin.ns.cloudflare.com"
+    ]
+  },
+  "proxied": true
+}


### PR DESCRIPTION
I have Url Encryption Tool, fully made of JavaScript hosted on Cloudflare Workers. Now I want to use a custom domain with "is-a.dev". So I have to add a route in the workers dashboard and to do that I must have to add a zone/domain firstly; that's why I requested for NS method. I attached a screenshot of the issue.

![IMG_20250510_234529](https://github.com/user-attachments/assets/6871e190-eb58-48f8-9c63-ed89897e359d)
