### PR TITLE
Request subdomain: kcalu.is-a.dev

### DIFF
--- a/domains/kcalu.json
+++ b/domains/kcalu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "lucatruglia-dev",
+    "email": "info.truglialuca@gmail.com"
+  },
+  "records": {
+    "NS": ["georgia.ns.cloudflare.com", "rocky.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
<!--
!!!
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, IT IS NOT OPTIONAL.
IF YOU DO NOT FILL OUT THIS PR TEMPLATE TO ITS ENTIRETY, YOUR PR WILL BE IMMEDIATELY DENIED.
!!!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] to mark it as checked. Do not keep the spaces between the parentheses. -->

- [x] I have **read** and **understood** the [Terms of Service](https://is-a.dev/terms). <!-- Your domain MUST follow the TOS to be approved. -->
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric. <!-- Your file's name is yourname.json, not YourName.json or your_name.json. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied websites. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g., X, Discord) for contact. -->

# NameServer Reason (updated)

I prefer to have full control over my subdomain because I already manage all my domains through Cloudflare. I'm used to its interface and features, and I need to point this subdomain to my VPS.

Using Cloudflare allows me to:
Properly proxy traffic to my VPS while hiding its IP address
Easily manage DNS records and perform changes without relying on PRs
Maintain consistency across all my domains in terms of security and DNS management

Since I started programming, I’ve always relied on Cloudflare to keep my servers safe and protected. It's a matter of both security and efficiency.


# Website Preview
<!-- Provide a link or screenshot of your website below. You MUST complete this step for your PR to be approved. -->
[https://lucatruglia.it](https://lucatruglia.it)