### PR TITLE
Create zmail._domainkey.sigmacat.json (Adding DKIM record for ZohoMail)

### DIFF
--- a/domains/zmail._domainkey.sigmacat.json
+++ b/domains/zmail._domainkey.sigmacat.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "SigmaCat01"
+  },
+  "records": {
+    "TXT": "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCmwy0YYWvOLFv8G31gmIliUBdULUocGkpwUQVSbHZNRJ6ETGSKqtO3zLmigPW+Te3xi9OzD7QSJv15b6gZFUF88lrYwXarCEkrAOvveYBWVniqr+K+sg1r0X+g3HJjNbQg/Hc5a7mkGHLSV+XcdY9iSmouyMXxjC52mV1pbREigQIDAQAB"
+  }
+}


### PR DESCRIPTION
Around 8 days ago, I opened a PR (22794) in order to add the TXT record for ZohoMail's domain verification and the MX records, and today, it got merged, but now, I want to add the DKIM record, and according to a few guys in the Discord server, I must create a new file and open a new PR in order to add ZohoMail's DKIM record.

- [x] I have **read** and **understood** the [Terms of Service](https://is-a.dev/terms).
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric.
- [x] My website is **reachable** and **completed**.
- [x] I have provided sufficient contact information in the `owner` key.

# Website Preview
Provided in the previous PR, 22717