### PR TITLE
Create _dmarc.sigmacat.json (Adding DMARC record for ZohoMail)

### DIFF
--- a/domains/_dmarc.sigmacat.json
+++ b/domains/_dmarc.sigmacat.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "SigmaCat01"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=reject"
+  }
+}


### PR DESCRIPTION
Today, I opened a PR (22984) in order to add the DKIM record for ZohoMail and... surprisingly, it got merged a few minutes later, but now, I want to add the DMARC record. (I apologize for opening two PRs within a short timeframe).

- [x] I have **read** and **understood** the [Terms of Service](https://is-a.dev/terms).
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric.
- [x] My website is **reachable** and **completed**.
- [x] I have provided sufficient contact information in the `owner` key.

# Website Preview
Provided in the first PR (22717).