### PR TITLE
Add omidzamani.is-a.dev domain registration (A record)

### DIFF
--- a/domains/omidzamani.json
+++ b/domains/omidzamani.json
@@ -4,6 +4,6 @@
     "email": "omidzamani2@gmail.com"
   },
   "records": {
-    "URL": "https://linktr.ee/omidzamani"
+    "A": "46.101.254.9"
   }
 }

--- a/domains/omidzamani.json
+++ b/domains/omidzamani.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "OmidZamani",
+    "email": "omidzamani2@gmail.com"
+  },
+  "records": {
+    "URL": "https://linktr.ee/omidzamani"
+  }
+}


### PR DESCRIPTION
## Domain Registration Request

Domain: omidzamani.is-a.dev
Owner: OmidZamani
Email: omidzamani2@gmail.com
Target: Server IP 46.101.254.9

### Description

This pull request adds a new domain registration for omidzamani.is-a.dev which will point to the owner's server via A record.

### Domain Configuration

• Type: A record
• Target IP: 46.101.254.9
• Owner verification: Domain owner confirmed via GitHub username OmidZamani

### Checklist

[✓] Domain configuration file created
[✓] Valid JSON format
[✓] Owner information provided
[✓] Target IP is accessible
[✓] Domain name follows naming conventions