### PR TITLE
Add williamdev.is-a.dev

### DIFF
--- a/domains/williamdev.json
+++ b/domains/williamdev.json
@@ -1,8 +1,8 @@
 {
   "owner": {
-    "github": "will11521"
+    "username": "Will11521"
   },
   "records": {
-    "CNAME": "will11521.github.io/portfolio"
+    "CNAME": "will11521.github.io"
   }
 }

--- a/domains/williamdev.json
+++ b/domains/williamdev.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "github": "will11521"
+  },
+  "records": {
+    "CNAME": "will11521.github.io/portfolio"
+  }
+}


### PR DESCRIPTION
This PR adds the subdomain `williamdev.is-a.dev` for my personal portfolio, hosted at:
🔗 https://will11521.github.io/portfolio/

# Requirements
- [x] I have **read** and **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] I understand my domain will be removed if I violate the [Terms of Service](https://is-a.dev/terms).
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and alphanumeric.
- [x] My website is **reachable** and **completed**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided sufficient reasoning for obtaining NS records. <!-- if you're not requesting NS records, leave as-is -->

# Website Preview
Live preview: https://will11521.github.io/portfolio/
