### PR TITLE
Add inventariotranmas.is-a.dev subdomain

### DIFF
--- a/domains/inventariotranmas.json
+++ b/domains/inventariotranmas.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "tranmas",
+    "email": "inventariotranmas@gmail.com"
+  },
+  "records": {
+    "CNAME": "a0cf5314-e424-4d00-88ff-90068e6dc723.cfargotunnel.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
This pull request adds the subdomain inventariotranmas.is-a.dev pointing to my Cloudflare Tunnel.
