### PR TITLE
add truly.is-a.dev and _vercel.truly.is-a.dev for Vercel wildcard app

### DIFF
--- a/domains/_vercel.truly.json
+++ b/domains/_vercel.truly.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "1ndrajeet",
+    "email": "1ndrajeet@proton.me"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=truly.is-a.dev,f47c4c3ff28a0a323906"
+  }
+}

--- a/domains/truly.json
+++ b/domains/truly.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "1ndrajeet",
+    "email": "1ndrajeet@proton.me"
+  },
+  "records": {
+    "*.truly": {
+      "cname": "truly-is-a-dev.vercel.app"
+    }
+  },
+  "proxied": true
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements

- [x] I have **read** and **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a preview of my website below.


# Website Preview
🔗 [https://truly-is-a-dev.vercel.app](https://truly-is-a-dev.vercel.app)
![image](https://github.com/user-attachments/assets/4eea6c7c-e991-4a71-a8ac-2c8a9ecb55e1)


This is a multi-tenant SaaS app for developers, hosted on Vercel.  
Each subdomain (e.g., `user.truly.is-a.dev`) loads personalized content using wildcard routing.
Thank you to the is-a.dev team! 🙏