### PR TITLE
Added Cloudflare Nameservers

### DIFF
--- a/domains/umar.json
+++ b/domains/umar.json
@@ -4,6 +4,6 @@
     "email": "siddiquiumar0007@gmail.com"
   },
   "records": {
-    "CNAME": "personalportfolio-two-roan.vercel.app"
+    "NS": ["arch.ns.cloudflare.com", "nelly.ns.cloudflare.com"]
   }
 }


### PR DESCRIPTION
This pull request is to register/update my umar.is-a.dev subdomain for DNS management. Here is my reason:

I want to use Cloudflare's Email Routing to create a professional email address (me@umar.is-a.dev) The subdomain aligns perfectly with professional standards and reflects my personal brand, making it an ideal choice for a permanent email solution. By managing DNS through Cloudflare, I can easily configure MX and TXT records to set up email forwarding, ensuring a seamless and professional communication setup. This will support my long-term projects and professional presence online.

I confirm I will not use the domain for any illegal, inappropriate, or NSFW activities, nor will I share access with others. and I understand that any violation may result in domain suspension. pleaseeee approve this request 👍 