### PR TITLE
Add hemachander.is-a.dev domain configuration

### DIFF
--- a/domains/hemachander.json
+++ b/domains/hemachander.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Juni-crypto",
+        "email": "founder@chumaoruworks.com"
+    },
+    "records": {
+        "A": ["75.2.60.5"]
+    }
+}


### PR DESCRIPTION
# Add hemachander.is-a.dev domain configuration

- Portfolio website for Hemachander
- Points to Netlify deployment (75.2.60.5)
- Owner: Juni-crypto (founder@chumaoruworks.com)

<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<img width="1034" alt="Screenshot 2025-07-03 at 1 16 08 AM" src="https://github.com/user-attachments/assets/24bd3d16-fff1-4356-a29e-04f626cd39ed" />

**Live Website:** https://hcport.netlify.app

This is a professional portfolio website showcasing:
- Software development projects and experience
- Technical skills and expertise
- Professional background and achievements
- Contact information and social links

The website is fully functional, responsive, and demonstrates software development capabilities. It will be accessible at `hemachander.is-a.dev` once the domain is approved.

**Domain Configuration:**
- Subdomain: `hemachander.is-a.dev`
- DNS Record: A record pointing to `75.2.60.5` (Netlify)
- Owner: Juni-crypto (founder@chumaoruworks.com)