### PR TITLE
Revert "Updated fmotalleb record to use cloudflare NS"

### DIFF
--- a/domains/fmotalleb.json
+++ b/domains/fmotalleb.json
@@ -5,9 +5,6 @@
     "email": "fmotalleb@gmail.com"
   },
   "records": {
-    "NS": [
-      "lovisa.ns.cloudflare.com",
-      "sonny.ns.cloudflare.com"
-    ]
+    "CNAME": "wwww.lil-moti.ir"
   }
 }


### PR DESCRIPTION
Reverts is-a-dev/register#24534

This PR had zero reasoning. Also, NS record PRs can only be reviewed by me.