### PR TITLE
Add subdomain oscuridad.is-a.dev with Zoho Mail DNS

### DIFF
--- a/oscuridad.json
+++ b/oscuridad.json
@@ -1,0 +1,10 @@
+{
+  "MX": [
+    { "host": "mx.zoho.com", "priority": 10 },
+    { "host": "mx2.zoho.com", "priority": 20 },
+    { "host": "mx3.zoho.com", "priority": 50 }
+  ],
+  "TXT": [
+    { "name": "@", "value": "v=spf1 include:zoho.com ~all" }
+  ]
+}


### PR DESCRIPTION
Se agrega la carpeta `oscuridad` con el archivo `oscuridad.json`, que contiene los registros MX y TXT necesarios para configurar el servicio de correo electrónico mediante Zoho Mail.

# Requisitos

- [x] He leído y acepto los [Términos de Servicio](https://is-a.dev/terms).  
- [x] Mi archivo cumple con la [estructura requerida](https://docs.is-a.dev/domain-structure/).  
- [x] El sitio web es accesible y está completo.  
- [x] El sitio web está relacionado con desarrollo de software.  
- [x] El sitio web no tiene fines comerciales.  
- [x] He proporcionado información de contacto suficiente en la clave `owner`.  
- [x] He incluido una vista previa de mi sitio web.

# Vista previa del sitio web

El subdominio `oscuridad.is-a.dev` está configurado para gestionar correo electrónico a través de Zoho Mail.