### PR TITLE
Create play.soymaycol.json

### DIFF
--- a/domains/play.soymaycol.json
+++ b/domains/play.soymaycol.json
@@ -1,0 +1,18 @@
+{
+  "owner": {
+    "username": "SoySapo6",
+    "email": "karatekidamericatv@gmail.com"
+  },
+  "records": {
+    "A": ["186.64.122.122"],
+    "SRV": [
+      {
+        "name": "_minecraft._tcp.play",
+        "priority": 0,
+        "weight": 5,
+        "port": 3002,
+        "target": "play.soymaycol.is-a.dev"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Subdomain Request for Minecraft Server 🎮

## Owner Information
- **Username:** SoySapo6
- **Email:** karatekidamericatv@gmail.com

## Description
This pull request adds the subdomain `play.soymaycol.is-a.dev` for a **Minecraft server**.  
The server runs on the IP address `186.64.122.122` and port `3002`.  
An **SRV record** is configured so players can connect without typing `:3002`.

## DNS Records
```json
{
  "A": ["186.64.122.122"],
  "SRV": [
    {
      "name": "_minecraft._tcp.play",
      "priority": 0,
      "weight": 5,
      "port": 3002,
      "target": "play.soymaycol.is-a.dev"
    }
  ]
}