### PR TITLE
Add TXT and A records for Vercel domain verification

### DIFF
--- a/domains/alexander.json
+++ b/domains/alexander.json
@@ -5,6 +5,8 @@
     "email": "aalexlpez@gmail.com"
   },
   "records": {
-    "CNAME": "portfolio-alex-xi.vercel.app"
+    "CNAME": "portfolio-alex-xi.vercel.app",
+    "A": ["216.198.79.1"],
+    "TXT": ["vc-domain-verify=alexander.is-a.dev,d49036035013a0d0d8b6"]
   }
 }


### PR DESCRIPTION
This update adds the required TXT record for domain ownership verification with Vercel, and an A record as suggested by Vercel to complete the domain configuration. 

The CNAME record remains unchanged.

<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->
