### PR TITLE
Add zenarc.is-a.dev subdomain

### DIFF
--- a/domains/{   "description": "Minecraft server via Cloudflare Tunnel",   "subdomain": "zenarc",   "owner": {     "repo": "your-github-username/zenarc.is-a.dev.json
+++ b/domains/{   "description": "Minecraft server via Cloudflare Tunnel",   "subdomain": "zenarc",   "owner": {     "repo": "your-github-username/zenarc.is-a.dev.json
@@ -1,0 +1,10 @@
+{
+  "subdomain": "zenarc",
+  "owner": {
+    "repo": "ArnavKapadnis/is-a.dev",
+    "email": "your-email@example.com"
+  },
+  "record": {
+    "CNAME": "b8b3f3f7-b24d-44ca-b211-7c7df5258b8b.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I have read and agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is reachable and completed.
- [x] My website is software development or hobby related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://arnavka.github.io/zenarc-site/

# Additional Information
The `zenarc.is-a.dev` subdomain will point to my personal hobby project — a private Minecraft server site.  
This server is hosted locally and is only accessible to 2–3 friends for personal multiplayer gaming.  
Cloudflare Tunnel is used for connection because port forwarding is not possible on our network.  
The server is not open to the public and is purely for personal learning and fun.