### PR TITLE
Create visualizeit.json

### DIFF
--- a/domains/visualizeit.json
+++ b/domains/visualizeit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Visualizeit",
+        "email": "visualize.it@outlook.com"
+    },
+    "records": {
+        "CNAME": "Visualizeit.github.io"
+    }
+}


### PR DESCRIPTION
This pull request adds a new domain ownership record for the `visualizeit` domain. The change specifies the owner information and sets a CNAME record for domain configuration.

* Domain ownership:
  * Added `visualizeit.json` with owner details (`username`: `Visualizeit`, `email`: `visualize.it@outlook.com`)

* DNS configuration:
  * Set the CNAME record to `Visualizeit.github.io` in `visualizeit.json`