### PR TITLE
Delete domains/eevee.json

### DIFF
--- a/domains/eevee.json
+++ b/domains/eevee.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "Eevee-Gaming",
-    "email": "nonothug59@gmail.com"
-  },
-  "records": {
-    "URL": "https://eeveegaming.cf"
-  }
-}


### PR DESCRIPTION
@Eevee-Gaming Your domain is being removed due to it violating our Terms of Service. (Your domain was made before that but I don't think this should be up really.)