### PR TITLE
Requesting subdomain: play.herobrine.is-a.dev

### DIFF
--- a/domains/play.herobrinecraft.json
+++ b/domains/play.herobrinecraft.json
@@ -1,0 +1,10 @@
+{
+  "name": "play.herobrine",
+  "type": "SRV",
+  "service": "_minecraft",
+  "proto": "_tcp",
+  "priority": 0,
+  "weight": 5,
+  "port": 13293,
+  "target": "8HerobrineCraft-dp95.aternos.me"
+}


### PR DESCRIPTION
This PR adds play.herobrine.is-a.dev for our Minecraft server.  
SRV record hides port 13293.  
Target: 8HerobrineCraft-dp95.aternos.me  
Created by amirsam & team.