### PR TITLE
Add kernkraftconsult.is-a.dev for Resend email setup

### DIFF
--- a/domains/kernkraftconsult.json
+++ b/domains/kernkraftconsult.json
@@ -1,0 +1,30 @@
+{
+  "kernkraftconsult": {
+    "owner": {
+      "username": "@Moore99",
+      "email": "johnmoore01@gmail.com"
+    },
+    "records": {
+      "MX": [
+        {
+          "value": "feedback-smtp.us-east-1.amazonses.com",
+          "priority": 10
+        }
+      ],
+      "TXT": [
+        {
+          "name": "send.kernkraftconsult.is",
+          "value": "v=spf1 include:amazonses.com ~all"
+        },
+        {
+          "name": "resend._domainkey.kernkraftconsult.is",
+          "value": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCcQggBLf7IzXIrzEz3WzIuZ0Nkp5OjBc3x8APbGhK9ROZKQRIx2MF5CV1T/zmaKRj0clRW6l8mNVit1JNzhbNB+LH/pbejvyFx8EG3B9xwnkFoccZ6ihxMnfFyM/QmKyfXeCQyrY1eKLBeVZj84BfGHOnURwVhDm0xI5Y1ue1thQIDAQAB"
+        },
+        {
+          "name": "_dmarc",
+          "value": "v=DMARC1; p=none;"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the kernkraftconsult.is-a.dev subdomain to the is-a.dev registry. The domain is configured for use with [Resend](https://resend.com/) email services and includes the necessary DNS records:
- ✅ SPF record for Amazon SES
- ✅ DKIM record for domain signing
- ✅ DMARC policy
- ✅ MX record for mail routing
The domain owner is @Moore99 and the contact email is johnmoore01@gmail.com.
Thank you for maintaining this awesome service!

- [ X] I have **read** and **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [ X] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [X ] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [ X] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [X ] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [X ] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [ X] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->

Under development. Domain needed for email functionality through Resend.
<img width="1827" height="1823" alt="image" src="https://github.com/user-attachments/assets/64ea77c3-870a-483c-878b-6809249d3bdb" />
