### PR TITLE
Register official.is-a.dev

### DIFF
--- a/domains/official.json
+++ b/domains/official.json
@@ -1,0 +1,11 @@
+{
+  "description": "My personal website",
+  "subdomain": "official",
+  "owner": {
+    "username": "enis-on-air",
+    "email": "enisonaiir@gmail.com"
+  },
+  "record": {
+    "CNAME": "enis-on-air.github.io"
+  }
+}


### PR DESCRIPTION
Subdomain: official.is-a.dev
Target (CNAME): enis-on-air.github.io
Purpose: ENIS ON AIR! radio club website

