### PR TITLE
houdaelbarehoumi.is-a.dev

### DIFF
--- a/domains/_vercel.houdaelbarehoumi.json
+++ b/domains/_vercel.houdaelbarehoumi.json
@@ -1,0 +1,6 @@
+{
+  "owner": { "username": "HUUDAA6", "email": "houdaelbarehoumi@gmail.com" },
+  "records": {
+    "TXT": ["vc-domain-verify=houdaelbarehoumi.is-a.dev,804977c62d87e6d43506"]
+  }
+}

--- a/domains/houdaelbarehoumi.json
+++ b/domains/houdaelbarehoumi.json
@@ -1,0 +1,6 @@
+{
+  "owner": { "username": "HUUDAA6", "email": "houdaelbarehoumi@gmail.com" },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
## Domain
houdaelbarehoumi.is-a.dev

## Owner
GitHub: HUUDAA6  
Email: houdaelbarehoumi@gmail.com

## Records
A: 216.198.79.1  
TXT (_vercel): vc-domain-verify=houdaelbarehoumi.is-a.dev,804977c62d87e6d43506
## Purpose
Personal portfolio hosted on Vercel.

## Confirmations
- [x] I understand this is a public, free subdomain from is-a.dev.
- [x] I added the required JSON files in /domains.
- [x] The records point to my hosting provider and I can change them if needed.
- [x] Information provided is accurate.
