### PR TITLE
Replace CNAME with NS records for praharsh.is-a.dev

### DIFF
--- a/domains/praharsh.json
+++ b/domains/praharsh.json
@@ -4,6 +4,6 @@
     "email": "praharshsamria@gmail.com"
   },
   "records": {
-    "CNAME": "praharsh.zz.mu"
+    "NS": ["otto.ns.cloudflare.com", "teagan.ns.cloudflare.com"]
   }
 }


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->
Replace CNAME with NS records for praharsh.is-a.dev

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->

<img src="https://private-user-images.githubusercontent.com/12197448/490435207-69d467e7-5d13-4cd1-a688-1b1fde67a262.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTgxMTE2ODEsIm5iZiI6MTc1ODExMTM4MSwicGF0aCI6Ii8xMjE5NzQ0OC80OTA0MzUyMDctNjlkNDY3ZTctNWQxMy00Y2QxLWE2ODgtMWIxZmRlNjdhMjYyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA5MTclMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwOTE3VDEyMTYyMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTBkMDY0NzIzMWRlMjVlOGE0N2ExY2VhY2E1OTdlM2EzODAwMTE0ZTlmZmIzZTYxMWQ2ZWUzNGFlYTc0MzY1ZTkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.lNM8qNGj9TA0-y5O25ZuIf3QSrq1zyHMXKMX7ual6zg" />


# NS Records Reasoning
I have been using the CNAME: praharsh.zz.mu, this subdomain was provided by my hosting provider free of charge. However, there was a recent communication from them that they will no longer support ".zz.mu" subdomains after September 28, 2025 and hence I have no option but to move to NS records.

To keep my website accessible, I am left with two options -
- Use name servers from my hosting provider, or
- Use cloudflare's name servers.

I am choosing to go ahead with cloudflare's NS because they allow me to benefit from cloudflare's free plan and make my website more available (by serving cached version in case of downtimes). Furthermore, I do not have to change NS records in this repo if I choose to move to a different hosting provider in the future.

Here is the screenshot of the email - 
<img width="1491" height="346" alt="Screenshot 2025-09-17 at 5 42 27 PM" src="https://github.com/user-attachments/assets/8dc9e8f9-a36f-4ca1-a49a-49f3b351dc98" />


# Responsibility
- The subdomain is my name, Praharsh.
- I take full responsibility for everything under it.
- I will ensure it is used only for safe and legitimate projects.
 

# Domain History
Maintained praharsh.is-a.dev with a CNAME for more than a year (since Apr 10, 2024)
Always followed is-a.dev’s terms of service
Only used for development-related projects
Never had any abuse or policy issues