### PR TITLE
Add base.json for base.is-a.dev domain

### DIFF
--- a/domains/base.json
+++ b/domains/base.json
@@ -1,0 +1,12 @@
+{
+  "description": "Base L2 Developer - Building the future of onchain apps on Coinbase's Base Chain",
+  "repo": "https://github.com/FoodGoods/FoodGoods.github.io",
+  "owner": {
+    "username": "FoodGoods",
+    "email": "tinyboxxxxx@gmail.com",
+    "twitter": "FoodGoods"
+  },
+  "records": {
+    "CNAME": "FoodGoods.github.io"
+  }
+}


### PR DESCRIPTION
## Summary
- Add base.json domain registration file for base.is-a.dev
- Points to FoodGoods.github.io for Base L2 developer portfolio
- CNAME record configured for GitHub Pages deployment

## Test plan
- [x] Verified JSON format matches existing domain files
- [x] Confirmed CNAME record syntax is correct
- [x] Repository URL is valid and accessible

🤖 Generated with [Claude Code](https://claude.ai/code)