### PR TITLE
change akshay.co to cloudflare pages directly to avoid cloudflare errors

### DIFF
--- a/domains/akshaykatyal.json
+++ b/domains/akshaykatyal.json
@@ -4,6 +4,6 @@
     "email": "github@akshay.co"
   },
   "records": {
-    "CNAME": "akshay.co"
+    "CNAME": "website-d7g.pages.dev"
   }
 }


### PR DESCRIPTION
My website is hosted by cloudflare & it throws `Error 1014 CNAME Cross-User Banned` if i use my domain directly. Hence, pointing it directly to my cloudflare page site.


<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->
<img width="878" height="733" alt="Screenshot 2025-09-27 at 14 17 58" src="https://github.com/user-attachments/assets/81ae7cbe-2259-4dc1-bcc2-6e291cef6eb0" />
