### PR TITLE
Fix Vercel domain integration for kaveenexe.is-a.dev

### DIFF
--- a/domains/_vercel.kaveenexe.json
+++ b/domains/_vercel.kaveenexe.json
@@ -4,6 +4,6 @@
     "email": "kaveenuththara@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "TXT": "vc-domain-verify=kaveenexe.is-a.dev,04af95741625a25e60f1"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
[Website Preview](https://kaveen.vercel.app/)
