### PR TITLE
Add base.is-a.dev subdomain for personal developer portfolio

### DIFF
--- a/domains/base.json
+++ b/domains/base.json
@@ -1,0 +1,12 @@
+{
+  "description": "Personal developer portfolio showcasing advanced smart contract development on Base network",
+  "repo": "https://github.com/FoodGoods/onchain-summer-2025",
+  "owner": {
+    "username": "FoodGoods",
+    "email": "tinyboxxxxx@gmail.com"
+  },
+  "record": {
+    "CNAME": "foodgoods.github.io"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
## Personal Developer Portfolio - Base Network Learning Project

**Purpose:** Educational showcase of advanced smart contract development skills

**Description:** This is my personal developer portfolio demonstrating blockchain development techniques learned through building 6 unique smart contracts on Base Sepolia testnet. The project showcases advanced DeFi mechanisms, security patterns, and cross-chain technology as part of my learning journey in blockchain development.

**Non-Commercial Use:** This is purely educational/personal portfolio work. No commercial activity, revenue, or business use intended.

**Repository:** https://github.com/FoodGoods/onchain-summer-2025

**Subdomain:** base.is-a.dev
**Points to:** foodgoods.github.io

This subdomain will be used to showcase my blockchain development work and serve as a professional developer portfolio link.