### PR TITLE
add domain integration for mr-chetan.github.io

### DIFF
--- a/domains/chetan.json
+++ b/domains/chetan.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "mr-chetan",
+    "email": "contact@mrchetan.com"
+  },
+  "records": {
+    "CNAME": "mr-chetan.github.io"
+  }
+}


### PR DESCRIPTION
This pull request adds ownership and DNS record information for the `chetan` domain. The change assigns the domain to the appropriate owner and specifies its CNAME record.

* Ownership assignment: Added the `owner` field with `username` and `email` for the `chetan` domain in `domains/chetan.json`.
* DNS configuration: Set the `CNAME` record to point to `mr-chetan.github.io` in `domains/chetan.json`.

# Requirements

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. [Website](https://mr-chetan.github.io/mr-chetan/)
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<img width="1911" height="953" alt="image" src="https://github.com/user-attachments/assets/1372db5f-b3fd-4f94-bfcc-7a8a58c425eb" />
