### PR TITLE
Add vicky.is-a.dev

### DIFF
--- a/domains/vicky.json
+++ b/domains/vicky.json
@@ -1,0 +1,10 @@
+{
+  "description": "Personal website for Vicky",
+  "repo": "https://github.com/Ajinkya2441/Vicky.p.dev.24.web",
+  "owner": {
+    "username": "Ajinkya2441"
+  },
+  "record": {
+    "CNAME": "ajinkya2441.github.io"
+  }
+}


### PR DESCRIPTION
Hello maintainers 

I would like to request the domain `vicky.is-a.dev` for my personal/project website.  
This domain should point to my GitHub Pages site: https://ajinkya2441.github.io/Vicky.p.dev.24.web/

I have added the `vicky.json` file under the `domains/` folder with the correct CNAME record.

Thank you for this free service 
