### PR TITLE
add github domain verification for opik.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-taufiqtab.opik.json
+++ b/domains/_github-pages-challenge-taufiqtab.opik.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "taufiqtab",
+        "email": "taufiqtab77@gmail.com"
+    },
+    "records": {
+        "TXT": "f89b2014e8f687d51544afd97f5340"
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->
<img width="1478" height="946" alt="image" src="https://github.com/user-attachments/assets/80fbb558-fa0c-4d00-8482-2902fd0851a3" />

url : t[aufiqtab.github.io](aufiqtab.github.io) / [opik.is-a.dev](opik.is-a.dev)

notes :
Verifying opik.is-a.dev Subdomain with GitHub Pages