### PR TITLE
fix: remove cloudflare proxied status from erenay.json

### DIFF
--- a/domains/erenay.json
+++ b/domains/erenay.json
@@ -5,6 +5,5 @@
   },
   "records": {
     "CNAME": "erenaydev.com.tr"
-  },
-  "proxied": true
+  }
 }


### PR DESCRIPTION
Removed Cloudflare `proxied` status due to `CNAME Cross-User Banned` error

# Requirements
- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://erenaydev.com.tr