### PR TITLE
Remove pixelbend.is-a.dev (migrated away)

### DIFF
--- a/domains/pixelbend.json
+++ b/domains/pixelbend.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "pixelbend",
-    "email": "m.arkamfahry@gmail.com"
-  },
-  "records": {
-    "CNAME": "pixelbend.github.io"
-  }
-}


### PR DESCRIPTION
I’ve migrated away from the pixelbend.is-a.dev domain and no longer need it. Please remove the record from the registry.

Domain to remove: pixelbend.is-a.dev

Best,
arkamfahry