### PR TITLE
Add guru.is-a.dev for GURUPRASADPANDA

### DIFF
--- a/domains/guru.json
+++ b/domains/guru.json
@@ -1,9 +1,11 @@
 {
   "owner": {
-    "username": "Guru322",
-    "email": "sahoogurucharan00@gmail.com"
+    "username": "GURUPRASADPANDA"
   },
-  "records": {
-    "CNAME": "guru322.github.io"
-  }
+  "redirects": [
+    {
+      "source": "@",
+      "destination": "https://www.linkedin.com/in/guruprasadpanda/"
+    }
+  ]
 }


### PR DESCRIPTION
## Domain Registration Request

**Subdomain:** guru.is-a.dev  
**Owner GitHub Username:** GURUPRASADPANDA  
**Purpose:** Redirect to my LinkedIn profile  

This PR adds a redirect from `guru.is-a.dev` to my LinkedIn page:
https://www.linkedin.com/in/guruprasadpanda/

### JSON file details:
File created: /domains/guru.json  
Contents include:
- Owner: GURUPRASADPANDA
- Redirect from root domain (`@`) to LinkedIn profile

Thank you for maintaining the is-a.dev project!