### PR TITLE
chore(dns): switch mulugeta.is-a.dev from CNAME to A record

### DIFF
--- a/domains/mulugeta.json
+++ b/domains/mulugeta.json
@@ -7,7 +7,7 @@
     "linkedin": "https://www.linkedin.com/in/mulugeta-adamu/",
     "x": "https://x.com/MuleBeteAmhara"
   },
-  "records": {
-    "CNAME": "cname.vercel-dns.com"
-  }
+"records": {
+  "A": ["216.198.79.1"]
+}
 }


### PR DESCRIPTION
Updated DNS configuration to follow Vercel’s latest recommendation:
- Removed old CNAME record (cname.vercel-dns.com)
- Added new A record (216.198.79.1)

This change ensures compatibility with Vercel’s new Anycast IP range and removes the “DNS Change Recommended” warning in the dashboard.

<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->
