### PR TITLE
Add sadam.is-a.dev domain

### DIFF
--- a/domains/sadam.json
+++ b/domains/sadam.json
@@ -1,0 +1,5 @@
+{
+  "subdomain": "sadam",
+  "owner": "jjuregistrar",
+  "repository": "sadam"
+}


### PR DESCRIPTION

This PR adds the sadam.is-a.dev subdomain for my GitHub Pages site hosted at:
https://jjuregistrar.github.io/sadam/

Purpose: Jigjiga University Registrar System (public information site).
