### PR TITLE
Switch `daniel.is-a.dev` to Cloudflare

### DIFF
--- a/domains/daniel.json
+++ b/domains/daniel.json
@@ -5,8 +5,6 @@
     "twitter": "hackermondev"
   },
   "records": {
-    "A": ["34.120.194.28"],
-    "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
-    "TXT": "v=spf1 include:spf.improvmx.com ~all"
+    "NS": ["armfazh.ns.cloudflare.com", "kehlani.ns.cloudflare.com"]
   }
 }


### PR DESCRIPTION
I'm trying to switch to Cloudflare email routing. I've been getting spammed on my emails recently, and ImprovMX is completely useless:

<img width="265" height="342" alt="image" src="https://github.com/user-attachments/assets/65a27e87-86b5-44ee-9b8f-206ca9f19885" />


# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
I plan to set up a redirect to https://github.com/hackermondev on Cloudflare