### PR TITLE
Add saad.is-a.dev with InfinityFree nameservers

### DIFF
--- a/domains/msaad.json
+++ b/domains/msaad.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "spidex9",
+    "email": "devsaadmehar@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "ns1.infinityfree.com",
+      "ns2.infinityfree.com"
+    ]
+  }
+}


### PR DESCRIPTION
Created msaad.json to delegate msaad.is-a.dev to InfinityFree (ns1.infinityfree.com, ns2.infinityfree.com)

<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [ ] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [ ] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [ ] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [ ] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->
