### PR TITLE
Add kash.is-a.dev subdomain for Prakash Maheshwaran

### DIFF
--- a/domains/kash.json
+++ b/domains/kash.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Prakashmaheshwaran",
+    "email": "pmaheshwaran@binghamton.edu"
+  },
+  "records": {
+    "CNAME": "modern-dynamic-portfolio.vercel.app"
+  }
+}


### PR DESCRIPTION
Description:
# Registering subdomain kash.is-a.dev

This PR adds the subdomain kash.is-a.dev pointing to my portfolio website.

## Requirements
- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the \`owner\` key.
- [x] I have provided a preview of my website below.

## Website Preview
URL: https://modern-dynamic-portfolio.vercel.app/

<img width="1435" height="741" alt="Screenshot 2025-10-15 at 1 53 17 PM" src="https://github.com/user-attachments/assets/c7898194-b5d5-480b-8c49-237aef883eb1" />
