### PR TITLE
Add ariff.json for ariff.is-a.dev subdomain

### DIFF
--- a/domains/ariff.json
+++ b/domains/ariff.json
@@ -1,0 +1,53 @@
+{
+  "owner": {
+    "username": "ariff",
+    "email": "ariff@example.com"
+  },
+  "records": {
+    "A": ["192.0.2.1", "198.51.100.1"],
+    "AAAA": ["2001:db8::1", "2001:db8::2"],
+    "CAA": [
+      { "flags": 0, "tag": "issue", "value": "letsencrypt.org" },
+      { "flags": 0, "tag": "issuewild", "value": "comodoca.com" }
+    ],
+    "CNAME": "ariff.example.com",
+    "DS": [
+      {
+        "key_tag": 2371,
+        "algorithm": 13,
+        "digest_type": 2,
+        "digest": "2BB183AF5F22588179A53B0A98631FAD1A292118"
+      }
+    ],
+    "MX": [
+      { "target": "mx1.mail.example.com", "priority": 10 },
+      { "target": "mx2.mail.example.com", "priority": 20 }
+    ],
+    "NS": ["ns1.example.com", "ns2.example.com"],
+    "SRV": [
+      {
+        "priority": 10,
+        "weight": 5,
+        "port": 443,
+        "target": "srv.example.com"
+      }
+    ],
+    "TLSA": [
+      {
+        "usage": 1,
+        "selector": 1,
+        "matching_type": 1,
+        "certificate": "0A3D7A56686E972F93E1EE6E88"
+      }
+    ],
+    "TXT": ["v=spf1 include:mail.example.com ~all", "google-site-verification=1234567890abcdef"],
+    "URL": "https://ariff.example.com"
+  },
+  "proxied": true,
+  "redirect_config": {
+    "custom_paths": {
+      "/github": "https://github.com/ariff"
+    },
+    "redirect_paths": true
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file follows the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software‑development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key of my JSON file.
- [x] I have provided a preview of my website below.

# Website Preview
My site is reachable at **https://ariff.example.com** and showcases my personal software‑development projects and open‑source contributions. The site contains several completed projects, technical articles, and source code repositories relevant to the developer community.

# Additional Information / NS Rationale
This PR registers the subdomain **ariff.is-a.dev**. The accompanying `ariff.json` file contains all supported DNS record types (A, AAAA, CAA, CNAME, DS, MX, NS, SRV, TLSA, TXT and URL), with the `proxied` flag enabled to allow mixing a `CNAME` with other record types.  

I am requesting NS records because my hosting provider for certain services (for example, game servers on Aternos) requires full NS delegation. The built‑in record types are insufficient for that provider, and they only support custom subdomains via NS delegation.  I understand NS records are restricted and have provided reasonable justification here.
