### PR TITLE
Add panduclouddev.is-a.dev

### DIFF
--- a/domains/panduclouddev.json
+++ b/domains/panduclouddev.json
@@ -1,0 +1,11 @@
+{
+  "description": "Pandu Ranga — Portfolio: AWS DevOps Engineer, Trainer, Freelancer, and Blogger",
+  "domain": "panduclouddev.is-a.dev",
+  "subdomain": "panduclouddev",
+  "owner": {
+    "email": "vuligittipandu@gmail.com"
+  },
+  "record": {
+    "CNAME": "pandurangaswamy-github-io.vercel.app"
+  }
+}


### PR DESCRIPTION
This pull request requests the subdomain panduclouddev.is-a.dev for my personal portfolio.

- Purpose: Personal portfolio for Pandu Ranga — showcases AWS DevOps projects, training offerings, freelancing portfolio, and blog posts.
- Site to point at: pandurangaswamy-github-io.vercel.app
- Contact: vuligittipandu@gmail.com

Please merge to approve the domain. Thank you!
