### PR TITLE
Add TXT record domain verification for datag.is-a.dev

### DIFF
--- a/domains/datag.json
+++ b/domains/datag.json
@@ -5,6 +5,8 @@
     "discord": "374945433010700288"
   },
   "records": {
-    "CNAME": "datag.github.io"
-  }
+    "CNAME": "datag.github.io",
+    "TXT": "google-site-verification=mElJLqlhcmyQv_rFaCpBtwPmAPBi2m6rQy3y2rhg-EI"
+  },
+  "proxied": true
 }


### PR DESCRIPTION
This PR updates the TXT record for Google search console verification.

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

<img width="778" height="973" alt="image" src="https://github.com/user-attachments/assets/42f8a4ac-12c5-4edd-a647-da1f7c513fbd" />
