### PR TITLE
Add exhost.is-a.dev

### DIFF
--- a/domains/exhost.json
+++ b/domains/exhost.json
@@ -1,0 +1,11 @@
+{
+  "description": "Cloudflare-protected WebAdmin and game hosting infrastructure for ExHost",
+  "domain": "is-a.dev",
+  "subdomain": "exhost",
+  "owner": {
+    "email": "info@exhost.hu"
+  },
+  "record": {
+    "A": ["146.59.72.76", "95.168.92.124"]
+  }
+}


### PR DESCRIPTION
Hello is-a.dev team 👋

I’d like to request the subdomain `exhost.is-a.dev` for my Cloudflare-protected WebAdmin and game hosting infrastructure.

The domain will point to two A records (main and local development servers):
- 146.59.72.76
- 95.168.92.124

I have read the documentation and agree to the terms.
Thank you for this amazing free service! ❤️
