### PR TITLE
Add lawjarp.is-a.dev domain

### DIFF
--- a/domains/lawjarp.json
+++ b/domains/lawjarp.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LawJarp-A",
+        "email": "prajwalanagani@gmail.com"
+    },
+    "records": {
+        "CNAME": "lawjarp-webpage.vercel.app"
+    }
+}


### PR DESCRIPTION
Request for lawjarp.is-a.dev subdomain

**Domain**: lawjarp.is-a.dev
**Target**: lawjarp-webpage.vercel.app
**Purpose**: Personal portfolio and tech blog

This domain will be used for my personal website featuring my portfolio as a Deep Learning Engineer and my tech blog "Why Should You Care" (WSYC).

Thank you for reviewing this request\!