### PR TITLE
Add JSON configuration for umamalfarizi.is-a.dev

### DIFF
--- a/domains/umamalfarizi.is-a.dev.json
+++ b/domains/umamalfarizi.is-a.dev.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "gper00",
+    "email": "alfariziuchiha@gmail.com"
+  },
+  "records": {
+    "TXT": "4db1167fab1a0c475bce72fe69ebcf"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file follows the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
[https://gper00.github.io](https://gper00.github.io)

# Additional Information
This PR adds the JSON configuration for my subdomain `umamalfarizi.is-a.dev` to be used for my personal portfolio and projects hosted on GitHub Pages.