### PR TITLE
Add Vercel domain verification record for lawjarp.is-a.dev

### DIFF
--- a/domains/_vercel.lawjarp.json
+++ b/domains/_vercel.lawjarp.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "LawJarp-A",
+        "email": "prajwalanagani@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=lawjarp.is-a.dev,952c8d1596d72d13d055"
+    }
+}


### PR DESCRIPTION
## Request for _vercel.lawjarp.is-a.dev TXT record

### Requirements

- [x] I have read and agreed to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the owner key.

I have provided a preview of my website below.

### Website Preview
https://lawjarp-webpage.vercel.app/

This TXT record is needed for Vercel domain verification to enable SSL for the custom domain.

Thank you\!