### PR TITLE
Add Vercel TXT record for yashwant.is-a.dev

### DIFF
--- a/domains/yashwant.json
+++ b/domains/yashwant.json
@@ -6,6 +6,9 @@
     "email": "kumarkyashwant@gmail.com"
   },
   "records": {
-    "CNAME": "portfolio2-kappa-flame.vercel.app"
+    "CNAME": "portfolio2-kappa-flame.vercel.app",
+    "TXT": {
+      "_vercel": "vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"
+    }
   }
 }


### PR DESCRIPTION
Adding the required TXT record for Vercel domain verification.

This allows Vercel to verify ownership of yashwant.is-a.dev and issue SSL so the subdomain works correctly with the deployment.

PR includes:
- CNAME: portfolio2-kappa-flame.vercel.app
- TXT: _vercel -> vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca

Website preview: https://portfolio2-kappa-flame.vercel.app/

# Requirements
- [x] I have read and agreed to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the owner key.
- [x] I have provided a preview of my website.

