### PR TITLE
Add TXT record for domain verification

### DIFF
--- a/domains/yashwant.json
+++ b/domains/yashwant.json
@@ -6,6 +6,9 @@
     "email": "kumarkyashwant@gmail.com"
   },
   "records": {
-    "CNAME": "portfolio2-kappa-flame.vercel.app"
+    "CNAME": "portfolio2-kappa-flame.vercel.app",
+    "TXT": {
+      "_vercel": "vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"
+    }
   }
 }

--- a/domains/yashwant.json
+++ b/domains/yashwant.json
@@ -5,6 +5,7 @@
     "username": "Yashwant176",
     "email": "kumarkyashwant@gmail.com"
   },
+  "proxied": true,
   "records": {
     "CNAME": "portfolio2-kappa-flame.vercel.app",
     "TXT": {

--- a/domains/yashwant.json
+++ b/domains/yashwant.json
@@ -8,8 +8,6 @@
   "proxied": true,
   "records": {
     "CNAME": "portfolio2-kappa-flame.vercel.app",
-    "_vercel": {
-      "TXT": ["vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"]
-    }
+    "TXT": ["vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"]
   }
 }

--- a/domains/yashwant.json
+++ b/domains/yashwant.json
@@ -8,6 +8,8 @@
   "proxied": true,
   "records": {
     "CNAME": "portfolio2-kappa-flame.vercel.app",
-    "TXT": ["vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"]
+    "_vercel": {
+      "TXT": ["vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"]
+    }
   }
 }

--- a/domains/yashwant.json
+++ b/domains/yashwant.json
@@ -8,8 +8,6 @@
   "proxied": true,
   "records": {
     "CNAME": "portfolio2-kappa-flame.vercel.app",
-    "TXT": {
-      "_vercel": "vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"
-    }
+    "TXT": ["vc-domain-verify=yashwant.is-a.dev,11b5c01be56a6a6d14ca"]
   }
 }


### PR DESCRIPTION
Adding the required TXT record for Vercel domain verification.

This allows Vercel to verify ownership of yashwant.is-a.dev and issue SSL so the subdomain works correctly with the deployment.

Website preview: https://portfolio2-kappa-flame.vercel.app/

<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is not for commercial use. <!-- Your website's purpose should not be to generate any form of revenue. -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->
