### PR TITLE
mar-athon-us-edition.is-a.dev

### DIFF
--- a/domains/mar-athon-us-edition.json
+++ b/domains/mar-athon-us-edition.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "notpogix",
+    "email": "notpogix@gmail.com"
+  },
+  "record": {
+    "CNAME": "notpogix.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms). 
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**. 
- [x] My website is **software development** related. 
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the `owner` key. 
- [x] I have provided a preview of my website below.

# Website Preview

**Website:** mar-athon-us-edition.is-a.dev

**Purpose:** Live marathon tracker for Twitch streamer Marlon's 28-day US marathon stream. Tracks viewers, followers, top chatters, sub gifters, and bits donors in real-time.

**Screenshot/Link:** https://notpogix.github.io/MAR-ATHON/
