### PR TITLE
Add kash.is-a.dev subdomain for Prakash Maheshwaran

### DIFF
--- a/domains/_vercel.kash.json
+++ b/domains/_vercel.kash.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Prakashmaheshwaran",
+    "email": "pmaheshwaran@binghamton.edu"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=kash.is-a.dev,3eae4b9e5c818c9f6ae6"
+  }
+}

--- a/domains/kash.json
+++ b/domains/kash.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Prakashmaheshwaran",
+    "email": "pmaheshwaran@binghamton.edu"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
   # Registering subdomain kash.is-a.dev

   This PR adds the subdomain kash.is-a.dev pointing to my portfolio website.

   ## Requirements

   * I have read and agreed to the Terms of Service.
   * My file is following the domain structure.
   * My website is reachable and completed.
   * My website is software development related.
   * My website is not for commercial use.
   * I have provided sufficient contact information in the `owner` key.
   * I have provided a preview of my website below.

   ## Website Preview

   URL: https://modern-dynamic-portfolio.vercel.app/

   ```