### PR TITLE
Add jng.is-a.dev

### DIFF
--- a/domains/jng.json
+++ b/domains/jng.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jngonzales",
+    "email": "jngonz24@gmail.com"
+  },
+  "record": {
+    "CNAME": "url-shortener-production-6295.up.railway.app"
+  }
+}


### PR DESCRIPTION
Request for jng.is-a.dev subdomain for my URL shortener project.

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms)
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/)
- [x] My website is **reachable** and **completed**
- [x] My website is **software development** related
- [x] My website is **not for commercial use**
- [x] I have provided contact information in the `owner` key
- [x] I have provided a preview of my website below

# Website Preview

My URL shortener service is live at: https://url-shortener-sandy-phi.vercel.app

**Purpose:** Personal URL shortening service built with React, Node.js, and MongoDB.

**Target:** url-shortener-production-6295.up.railway.app
<img width="1919" height="981" alt="Screenshot 2025-10-29 122525" src="https://github.com/user-attachments/assets/744e99c4-397e-4c28-a3a0-7f7081a26656" />
