### PR TITLE
 Add citysphere.is-a.dev

### DIFF
--- a/domains/citysphere.json
+++ b/domains/citysphere.json
@@ -1,0 +1,1 @@
+{"description": "CitySphere app hosted on Firebase","subdomain": "citysphere","owner": {"username": "krishnasai2006","email": "krishnasai2006@gmail.com"},"record": {"CNAME": "studio-5482260737-30fed.web.app"}}


### PR DESCRIPTION
Adding DNS configuration for citysphere.is-a.dev subdomain

- Adding CNAME record for Firebase hosting verification
- Domain: citysphere.is-a.dev
- CNAME: studio-5482260737-30fed.web.app
