### PR TITLE
Add TXT record for keybase site verification

### DIFF
--- a/domains/huskynarr.json
+++ b/domains/huskynarr.json
@@ -9,5 +9,5 @@
     "CNAME": "huskynarr.github.io",
     "TXT": "keybase-site-verification=OPYQ3YLB_JCVDblEPdCCjmd6Eev9q-MJ0nJ9A10x9aI"
   },
-  "proxied": false
+  "proxied": true
 }

--- a/domains/huskynarr.json
+++ b/domains/huskynarr.json
@@ -6,7 +6,8 @@
     "instagram": "@Huskynarr"
   },
   "records": {
-    "CNAME": "huskynarr.github.io"
+    "CNAME": "huskynarr.github.io",
+    "TXT": "keybase-site-verification=OPYQ3YLB_JCVDblEPdCCjmd6Eev9q-MJ0nJ9A10x9aI"
   },
   "proxied": false
 }


### PR DESCRIPTION
Added only txt record for keybase verification

# Requirements
- [X] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [X] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [X] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [X] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [X] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [X] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [X] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
https://huskynarr.is-a.dev