### PR TITLE
archinova.is-a.dev domain

### DIFF
--- a/domains/archinova.json
+++ b/domains/archinova.json
@@ -1,0 +1,11 @@
+{
+  "description": "Portfolio website for ArchiNova Interiors by Gaurav Sharma",
+  "domain": "is-a.dev",
+  "subdomain": "archinova",
+  "owner": {
+    "email": "archinova1317@gmail.com"
+  },
+  "records": {
+    "CNAME": "archinova1317.github.io"
+  }
+}


### PR DESCRIPTION
Added domain configuration for ArchiNova Interiors portfolio site.
Subdomain: archinova.is-a.dev
CNAME points to: archinova1317.github.io
