### PR TITLE
Add promptly.is-a.dev

### DIFF
--- a/domains/promptly.json
+++ b/domains/promptly.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "harshilarora250"
+  },
+  "records": {
+    "CNAME": "main.d1lk36ozjwq1wx.amplifyapp.com/"
+  },
+  "website": "https://main.d1lk36ozjwq1wx.amplifyapp.com/"
+}


### PR DESCRIPTION
I'd like to register the domain promptly.is-a.dev

CNAME → main.d1lk36ozjwq1wx.amplifyapp.com
GitHub: @harshilarora250
Live site: hhttps://main.d1lk36ozjwq1wx.amplifyapp.com/

I agree to the is-a.dev terms and conditions.
