### PR TITLE
Add sand-study.is-a.dev

### DIFF
--- a/domains/sand-study.json
+++ b/domains/sand-study.json
@@ -1,0 +1,11 @@
+
+  "description": "Sand Study - Timer app for focused work sessions",
+  "repo": "https://github.com/zrPchan/Sand-Study",
+  "owner": {
+    "username": "zrPchan",
+    "email": "4uth9gotegote@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/sand-study.json
+++ b/domains/sand-study.json
@@ -1,4 +1,4 @@
-
+{
   "description": "Sand Study - Timer app for focused work sessions",
   "repo": "https://github.com/zrPchan/Sand-Study",
   "owner": {
@@ -8,4 +8,4 @@
   "record": {
     "CNAME": "cname.vercel-dns.com"
   }
-
+}

--- a/domains/sand-study.json
+++ b/domains/sand-study.json
@@ -8,4 +8,4 @@
   "record": {
     "CNAME": "cname.vercel-dns.com"
   }
-}
+

--- a/domains/sand-study.json
+++ b/domains/sand-study.json
@@ -1,5 +1,5 @@
 {
-  "description": "Sand Study - Timer app for focused work sessions",
+  "description": "Sand Study - A focused work timer application",
   "repo": "https://github.com/zrPchan/Sand-Study",
   "owner": {
     "username": "zrPchan",

--- a/domains/sand-study.json
+++ b/domains/sand-study.json
@@ -5,7 +5,7 @@
     "username": "zrPchan",
     "email": "4uth9gotegote@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "cname.vercel-dns.com"
   }
 }


### PR DESCRIPTION
## Domain Request

- Domain: sand-study.is-a.dev
- Purpose: Hosting Sand Study timer app
- Target: Vercel deployment (cname.vercel-dns.com)
- Repo: https://github.com/zrPchan/Sand-Study