### PR TITLE
Add mail.bdalmonico.is-a.dev (Brevo email domain)

### DIFF
--- a/domains/mail.bdalmonico
+++ b/domains/mail.bdalmonico
@@ -1,0 +1,18 @@
+{
+  "description": "Subdomínio técnico usado exclusivamente para autenticação SPF, DKIM e DMARC do Brevo (Sendinblue). Nenhum conteúdo web hospedado.",
+  "subdomain": "mail.bdalmonico",
+  "owner": {
+    "username": "bdalmonico",
+    "email": "b.dalmonico@gmail.com"
+  },
+  "record": {
+    "TXT": [
+      "brevo-code:a9fcfd0fa7673158beb19acc01230760",
+      "v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com"
+    ],
+    "CNAME": {
+      "brevo1._domainkey": "b1.mail-bdalmonico-is-a-dev.dkim.brevo.com",
+      "brevo2._domainkey": "b2.mail-bdalmonico-is-a-dev.dkim.brevo.com"
+    }
+  }
+}


### PR DESCRIPTION
Added configuration for the mail.bdalmonico subdomain including Brevo email authentication records (TXT and DKIM).

This subdomain will be used exclusively for transactional and marketing email authentication via Brevo (Sendinblue).  
It will not host any website or visible content — only technical DNS records for SPF, DKIM, and DMARC verification.

---

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file follows the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] This is a **technical subdomain**, not intended to host a website.
- [x] My usage complies with non-commercial and open technical purposes.
- [x] I have provided contact information in the `owner` key.

---

# Additional Information

This domain (`mail.bdalmonico.is-a.dev`) will be used for:
- Brevo domain verification (`brevo-code`)
- DKIM signing (two CNAME records)
- DMARC reporting (TXT record)

The root domain `bdalmonico.is-a.dev` may later be used for a portfolio or project site, but this subdomain is **only for email authentication**.

Thank you!