### PR TITLE
Add bdalmonico.is-a.dev (personal and Brevo integration domain)

### DIFF
--- a/domains/bdalmonico.json
+++ b/domains/bdalmonico.json
@@ -1,0 +1,11 @@
+{
+  "description": "Dominio principal para portfolio y proyecto de integración Brevo con Frappe Framework.",
+  "subdomain": "bdalmonico",
+  "owner": {
+    "username": "bdalmonico",
+    "email": "b.dalmonico@gmail.com"
+  },
+  "records": {
+    "CNAME": "bdalmonico.github.io"
+  }
+}


### PR DESCRIPTION
Added JSON configuration for the bdalmonico domain.

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. -->
<img width="1913" height="1023" alt="image" src="https://github.com/user-attachments/assets/48cd54fe-6a37-4813-a7f6-9902bfec56e4" />
https://bdalmonico.github.io/ 

