### PR TITLE
Add farmdirect.is-a.dev and api.farmdirect.is-a.dev subdomains

### DIFF
--- a/domains/api.farmdirect.json
+++ b/domains/api.farmdirect.json
@@ -1,0 +1,13 @@
+{
+  "description": "FarmDirect backend — Express API for e-commerce platform",
+  "domain": "is-a.dev",
+  "subdomain": "api.farmdirect",
+  "owner": {
+    "repo": "https://github.com/NicoleMumo/SERVER-ADMINISTRATION-HOSTED-WEBSITE-FARMDIRECT-E-COMMERCE",
+    "email": "nicolemumo3@gmail.com"
+  },
+  "record": {
+    "CNAME": "farmdirect-server.onrender.com"
+  },
+  "proxied": false
+}

--- a/domains/farmdirect.json
+++ b/domains/farmdirect.json
@@ -1,0 +1,13 @@
+{
+  "description": "FarmDirect frontend — React app for farmers and consumers",
+  "domain": "is-a.dev",
+  "subdomain": "farmdirect",
+  "owner": {
+    "repo": "https://github.com/NicoleMumo/SERVER-ADMINISTRATION-HOSTED-WEBSITE-FARMDIRECT-E-COMMERCE",
+    "email": "nicolemumo3@gmail.com"
+  },
+  "record": {
+    "CNAME": "server-administration-hosted-website.onrender.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Frontend: https://server-administration-hosted-website.onrender.com  
Backend: https://farmdirect-server.onrender.com  

These will map to:
-  https://farmdirect.is-a.dev → Frontend  
-  
<img width="948" height="474" alt="Screenshot 2025-11-07 154500" src="https://github.com/user-attachments/assets/4f0d0623-0c65-4348-984a-29811c322ab5" />
https://api.farmdirect.is-a.dev → Backend
