### PR TITLE
Add aslabs.is-a.dev domain

### DIFF
--- a/domains/aslabs.json
+++ b/domains/aslabs.json
@@ -1,0 +1,15 @@
+{
+    "owner": {
+        "username": "robertpreshyl"
+    },
+    "description": "ASLabs - Development and Testing Environment",
+    "repo": "https://github.com/robertpreshyl/aslabs-webtools",
+    "records": {
+        "A": ["129.80.62.45"],
+        "MX": ["mail.aslabs.is-a.dev."],
+        "TXT": [
+            "v=spf1 mx a ip4:129.80.62.45 ~all"
+        ]
+    },
+    "proxied": false
+}


### PR DESCRIPTION
## Domain Registration Request

### Domain Details
- **Subdomain**: aslabs.is-a.dev
- **Points to**: 129.80.62.45
- **Purpose**: ASLabs Development and Testing Environment
- **Repository**: https://github.com/robertpreshyl/aslabs-webtools

### Checklist
- [x] I own the domain or have permission to use it
- [x] The domain points to the correct IP address
- [x] I have read and understood the documentation
- [x] My JSON file follows the correct format
- [x] I am not using this for any malicious purposes

### Additional Information
This subdomain will be used for hosting development and testing environments for ASLabs web applications and services.