### PR TITLE
Remove `tools.is-a.dev` and add it back to the reserved list

### DIFF
--- a/domains/tools.json
+++ b/domains/tools.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "TheUselessCreator",
-    "email": "bot40games2@gmail.com"
-  },
-  "records": {
-    "URL": "https://beeper.is-a.dev"
-  }
-}

--- a/util/reserved.json
+++ b/util/reserved.json
@@ -131,6 +131,7 @@
     "team",
     "test",
     "testing",
+    "tools",
     "url",
     "util",
     "vpn",


### PR DESCRIPTION
Self explanatory title, domain should of been removed by now because it was just reserved
@TheUselessCreator If you notice that this domain doesn't work anymore, this is why