### PR TITLE
Add dill.is-a.dev

### DIFF
--- a/domains/dill.json
+++ b/domains/dill.json
@@ -1,0 +1,9 @@
+{
+  "description": "Personal site for Dill, full-stack engineer.",
+  "owner": {
+    "email": "dill.ruzz.official@gmail.com"
+  },
+  "record": {
+    "CNAME": "dill-dev.netlify.app"
+  }
+}


### PR DESCRIPTION
Requesting dill.is-a.dev

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).  
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).  
- [x] My website is **reachable** and **completed**.  
- [x] My website is **software development** related.  
- [x] My website is **not for commercial use**.  
- [x] I have provided contact information in the `owner` key.  
- [x] I have provided a preview of my website below.  

# Website Preview

- Website URL: [https://dill-dev.netlify.app](https://dill-dev.netlify.app)  
- Screenshot: 
<img width="1918" height="907" alt="image" src="https://github.com/user-attachments/assets/02ea94bf-87ba-4221-bd5a-1ffee99c60d2" />

- Description: My personal full-stack software development portfolio showcasing projects, skills, and contact information.
