### PR TITLE
Add lab.is-a.dev – personal static site and frontend experiments

### DIFF
--- a/domains/free2025.json
+++ b/domains/free2025.json
@@ -1,0 +1,11 @@
+{
+  "domain": "free2025",
+  "owner": {
+    "username": "litao1231",
+    "email": "negis79704@badfist.com"
+  },
+  "record": {
+    "url": "https://dry-mountain-ffd9.6j73j41by5.workers.dev/sub",
+    "description": "Personal VLESS proxy"
+  }
+}

--- a/domains/lab.json
+++ b/domains/lab.json
@@ -1,0 +1,11 @@
+{
+  "domain": "lab",
+  "description": "Personal frontend experiments and static site hosting",
+  "owner": {
+    "username": "litao1231",
+    "email": "negis79704@badfist.com"
+  },
+  "record": {
+    "CNAME": "pages.dev"
+  }
+}


### PR DESCRIPTION
Add lab.is-a.dev – personal static site and frontend experiments

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms)
- [x] I have searched the existing subdomains to make sure this is not already registered
- [x] The domain I am registering is not prohibited (e.g. no trademarks, no offensive terms)
- [x] I understand that this is a free service and there is no SLA
- [x] I will not use this for phishing, malware, or any illegal activity

# Additional info (optional)
Personal dev site for hosting static assets and frontend demos.