### PR TITLE
Add _vercel TXT record for domain verification

### DIFF
--- a/domains/_vercel.dymasyogaf.json
+++ b/domains/_vercel.dymasyogaf.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "dymasyogaf",
+    "email": "dymasyogaf11@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=dymasyogaf.is-a.dev,702be54b6118e076885c"
+  }
+}


### PR DESCRIPTION
Adding TXT record for Vercel domain verification.

- TXT: _vercel.dymasyogaf.is-a.dev
- Value: vc-domain-verify=dymasyogaf.is-a.dev,702be54b6118e076885c

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

- URL: https://dymasyogaf.vercel.app
- Description: Personal portfolio website for Dymas Yoga, showcasing web development projects and skills.
- Screenshot: (attached below)
