### PR TITLE
Add iosfinal2025.json with domain owner detail

### DIFF
--- a/domains/iosfinal2025.json
+++ b/domains/iosfinal2025.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "yerassylmukan",
+    "email": "yerassylmukan@outlook.com"
+  },
+  "records": {
+    "A": ["3.79.185.15"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Link: http://3.79.185.15:5200/swagger/index.html

Description:  
This is a personal, non-commercial backend API project.
The website hosts Swagger (OpenAPI) documentation for a REST API and is intended strictly for software development, testing, and educational purposes. No commercial services, products, or monetization are involved.


Screenshot:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/74534bc7-58f4-4a29-bc41-144c8b581465" />
