### PR TITLE
0xio32.is-a.dev: Move to cloudflare nameserver

### DIFF
--- a/domains/0xio32.json
+++ b/domains/0xio32.json
@@ -4,6 +4,14 @@
     "email": "markus.probst@posteo.de"
   },
   "records": {
-    "CNAME": "0xio32-is-a-dev.pages.dev"
+    "NS": ["decker.ns.cloudflare.com", "kia.ns.cloudflare.com"],
+    "DS": [
+      {
+        "key_tag": 2371,
+        "algorithm": 13,
+        "digest_type": 2,
+        "digest": "4F33A1EF934B3296CF449307F81107BC746AC2E84BF9D6A51DFB3E145994CA8E"
+      }
+    ]
   }
 }


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [X] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [X] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [X] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [X] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [X] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [X] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [X] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. -->
<img width="1885" height="840" alt="image" src="https://github.com/user-attachments/assets/588c33cc-98d4-4159-8a72-b17a6f13d28a" />
Link: https://0xio32-is-a-dev.pages.dev
<br><br>
Some notes to the website:<br>
- Mimics fish + starship + bat in a terminal (it uses xterm.js under the hood) <br>
- Some of the elements in the terminal are clickable <br>
- Font size can be smaller, depending on the screen size


# Reasons for the NS record / move to Cloudflare DNS

Preamble: If the reasons are not clear enough, just ask and I will provide more info.



> We allow NS records only when:
> The standard DNS record types we support aren't sufficient.

**The "HTTPS" dns record** seems nice to have (advertising HTTPS v3, Quic support. Encrypted ClientHello).

> A provider (e.g. Aternos) requires NS delegation and does not have any other method of setting up a subdomain.
> This is mostly regarding SaaS providers, not DNS providers like Cloudflare or deSEC.

1. This isn't a problem for the root website, but I want to delegate some subdomains to my NAS, which is under a **"Dynamic IP"**, without an API (like the one Cloudflare provides) to update the ip, this wouldn't be possible.

2. Cloudflares email routing isn't available, if the domain isn't registered in Cloudflare (nice to have, but not required)

> We do not allow NS records for:
> Self hosting
> Note: This can vary from case to case

I like to have everything under one subdomain, the dev website and some self-hosted services, if thats ok.

> Convenience or ease of use

I don't use it as reason, but Cloudflare would definitely provide it.

> Unverifiable or unsupported claims
> Non-functional or placeholder purposes
> Self hosting websites that can be easily hosted on a free platform like GitHub Pages

Not the case

> If we have security or abuse concerns

I hope thats not the case.

> New users of is-a.dev
> If you have not had an is-a.dev subdomain for at least 30 days, you will be denied due to security reasons.

On the 25.12.2025 the 30 days will be over.
So I will also use this as a reason: **It's Christmas** (at the time this pr is mergable by your requirements). Meaning this would be a christmas gift.

> Users that have abused is-a.dev subdomains in the past

Nothing that I am aware of

<br>

Thanks
\- Markus Probst