### PR TITLE
Add Vercel verification TXT for kar1m.is-a.dev

### DIFF
--- a/domains/_vercel.kar1m.json
+++ b/domains/_vercel.kar1m.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "MkareemA",
+    "email": "kareem.online@proton.me"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=kar1m.is-a.dev,171c3460ab4131f45049"
+  }
+}


### PR DESCRIPTION
This pull request adds the required TXT record to verify
ownership of kar1m.is-a.dev on Vercel.

The domain was previously linked to another Vercel account,
and Vercel requires TXT verification to proceed.
