### PR TITLE
Register clipflow.is-a.dev

### DIFF
--- a/domains/clipflow.json
+++ b/domains/clipflow.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "saivighnesh2190",
+    "email": "nsaivighnesh@zohomail.in"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering clipflow.is-a.dev subdomain for ClipFlow - an AI-powered DSA progress tracking platform hosted on Vercel.

**Domain:** clipflow.is-a.dev
**Type:** CNAME to cname.vercel-dns.com
**Purpose:** AI-powered DSA learning and progress tracking platform