### PR TITLE
Switch protyush.is-a.dev from Vercel to Cloudflare Pages

### DIFF
--- a/domains/protyush.json
+++ b/domains/protyush.json
@@ -4,6 +4,6 @@
         "email": "ghorui.protyushraj@gmail.com"
     },
     "records": {
-        "CNAME": "cname.vercel-dns.com"
+        "CNAME": "protyush.pages.dev"
     }
 }


### PR DESCRIPTION
The subdomain was previously pointed to Vercel.  
Due to persistent domain verification and ownership issues on Vercel,  
the site has been migrated to Cloudflare Pages.

# Requirements

- [x] I agree to the Terms of Service
- [x] My file follows the domain structure
- [x] My website is reachable and completed
- [x] My website is software development related
- [x] My website is not for commercial use
- [x] I have provided contact information in the owner key
- [x] I have provided a preview of my website below

# Website Preview

https://protyush.pages.dev
