### PR TITLE
chore: add MX and SPF records for alexgaming.is-a.dev

### DIFF
--- a/domains/alexgaming.json
+++ b/domains/alexgaming.json
@@ -3,8 +3,15 @@
         "username": "alexgamingstudio",
         "email": "team.alexgaming@icloud.com"
     },
-    "description": "Developer portfolio and templates",
+    "description": "Portfolio and Email Forwarding",
     "records": {
-        "CNAME": "alexgaming-dev.github.io"
+        "CNAME": "alexgaming-dev.github.io",
+        "MX": [
+            "mx1.improvmx.com.",
+            "mx2.improvmx.com."
+        ],
+        "TXT": [
+            "v=spf1 include:spf.improvmx.com ~all"
+        ]
     }
 }

--- a/domains/domains/_discord.alexgaming.is-a.dev.json
+++ b/domains/domains/_discord.alexgaming.is-a.dev.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "alexgamingstudio"
+    },
+    "records": {
+        "TXT": "dh=cb4a48593db803575ed8144ef73225deb67aa0ad"
+    }
+}

--- a/domains/domains/_gh-AlexGaming-dev-o.alexgaming.json
+++ b/domains/domains/_gh-AlexGaming-dev-o.alexgaming.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "alexgamingstudio",
+        "email": "team.alexgaming@icloud.com"
+    },
+    "description": "GitHub Organization Verification for AlexGaming-dev",
+    "records": {
+        "TXT": ["9f704a5c39"]
+    }
+}


### PR DESCRIPTION
### What's changed?
I am adding MX and TXT (SPF) records to my domain `alexgaming.is-a.dev` to enable email forwarding via ImprovMX.

### Checklist:
- [x] JSON format is valid
- [x] Records are correctly formatted for ImprovMX
- [x] No changes to the domain owner or CNAME