### PR TITLE
fix: switch to A records for MX support and add GitHub org verification

### DIFF
--- a/domains/_gh-AlexGaming-dev-o.alexgaming.json
+++ b/domains/_gh-AlexGaming-dev-o.alexgaming.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "alexgamingstudio",
+        "email": "team.alexgaming@icloud.com"
+    },
+    "records": {
+        "TXT": ["9f704a5c39"]
+    }
+}


### PR DESCRIPTION
### What's changed?
1. **DNS Change**: Switched from `CNAME` to `A` records (GitHub Pages IPs) to allow `MX` records (CNAME and MX cannot coexist).
2. **Email**: Added ImprovMX records for email forwarding.
3. **Verification**: Added a new file for GitHub Organization verification (`_gh-AlexGaming-dev-o`).

### Records added:
- **A Records**: 185.199.108.153, 185.199.109.153, 185.199.110.153, 185.199.111.153
- **MX Records**: mx1.improvmx.com, mx2.improvmx.com
- **TXT Record**: SPF for ImprovMX and GitHub verification code