### PR TITLE
Register postmortem.is-a.dev

### DIFF
--- a/domains/postmortem.json
+++ b/domains/postmortem.json
@@ -3,9 +3,7 @@
     "username": "ryana79",
     "email": "rma167@scarletmail.rutgers.edu"
   },
-  "record": {
+  "records": {
     "CNAME": "yellow-water-069414910.2.azurestaticapps.net"
-  },
-  "proxied": false
+  }
 }
-

--- a/domains/postmortem.json
+++ b/domains/postmortem.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "ryana79",
+    "email": "rma167@scarletmail.rutgers.edu"
+  },
+  "record": {
+    "CNAME": "yellow-water-069414910.2.azurestaticapps.net"
+  },
+  "proxied": false
+}
+


### PR DESCRIPTION
## Domain Registration Request

**Subdomain:** postmortem.is-a.dev

**Record Type:** CNAME

**Target:** yellow-water-069414910.2.azurestaticapps.net

**Purpose:** Incident Postmortem Manager - A web application for managing incident postmortems built with Azure Static Web Apps, Azure Functions, and Cosmos DB.

**GitHub Repo:** https://github.com/ryana79/incident-postmortem-manager

Thank you!