### PR TITLE
fix: new verification string for GH pages - achilleas-athanasiou-fragkoulis.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-achilleasatha.achilleas-athanasiou-fragkoulis.json
+++ b/domains/_github-pages-challenge-achilleasatha.achilleas-athanasiou-fragkoulis.json
@@ -4,6 +4,6 @@
     "email": "achilleasatha@gmail.com"
   },
   "records": {
-    "TXT": "20c668da95028931c97af7e8bfc7bf"
+    "TXT": "23088786e835de9c6eb58f471fece0"
   }
 }


### PR DESCRIPTION
3rd time's the charm, this time I'll get it right 😢 
- fix: update verification string for GH pages for achilleas-athanasiou-fragkoulis.is-a.dev

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
https://achilleas-athanasiou-fragkoulis.is-a.dev

<img width="876" height="1301" alt="Screenshot 2026-01-11 at 12 34 49" src="https://github.com/user-attachments/assets/c0a51f49-334b-4f5a-ae5f-56af2033520e" />

