### PR TITLE
Add alam.is-a.dev (Zoho + redirect) and www.alam.is-a.dev (GitHub Pages)

### DIFF
--- a/domains/_dmarc.alam.json
+++ b/domains/_dmarc.alam.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Muhammad-Nur-Alamsyah-Anwar",
+    "email": "alam.is.a.dev@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none; rua=mailto:alam.is.a.dev@gmail.com"
+  }
+}

--- a/domains/alam.json
+++ b/domains/alam.json
@@ -1,0 +1,20 @@
+{
+  "owner": {
+    "username": "Muhammad-Nur-Alamsyah-Anwar",
+    "email": "alam.is.a.dev@gmail.com"
+  },
+  "records": {
+    "URL": "https://www.alam.is-a.dev",
+
+    "TXT": [
+      "zoho-verification=zb85604523.zmverify.zoho.com",
+      "v=spf1 include:zohomail.com ~all"
+    ],
+
+    "MX": [
+      { "target": "mx.zoho.com", "priority": 10 },
+      { "target": "mx2.zoho.com", "priority": 20 },
+      { "target": "mx3.zoho.com", "priority": 50 }
+    ]
+  }
+}

--- a/domains/www.alam.json
+++ b/domains/www.alam.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Muhammad-Nur-Alamsyah-Anwar",
+    "email": "alam.is.a.dev@gmail.com"
+  },
+  "records": {
+    "CNAME": "muhammad-nur-alamsyah-anwar.github.io"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Preview link:** https://muhammad-nur-alamsyah-anwar.github.io/alam-minidocs/

**Screenshot (hero):**
![Alam Mini Docs hero](https://files.catbox.moe/70n3cw.png)


## Notes (optional)

- `alam.is-a.dev` is configured for Zoho Mail (verification TXT, SPF, MX) and redirects to `https://www.alam.is-a.dev`.
- `www.alam.is-a.dev` points to GitHub Pages (`muhammad-nur-alamsyah-anwar.github.io`) where the mini docs site is hosted.
