### PR TITLE
Add modcoderpack.is-a.dev

### DIFF
--- a/domains/modcoderpack.json
+++ b/domains/modcoderpack.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "pmgdev64",
+        "email": "tranhoang2009vqht@gmail.com"
+    },
+    "record": {
+        "CNAME": "modcoderpack.vercel.app"
+    }
+}


### PR DESCRIPTION
Registering a subdomain for my open-source project modcoderpack-redevelop hosted on Vercel.