### PR TITLE
Add ff.is-a.dev

### DIFF
--- a/domains/ff-11.json
+++ b/domains/ff-11.json
@@ -1,5 +1,5 @@
 {
-  "description": "FF (Fast Files) is a lightweight image and file hosting service focused on speed and simplicity.",
+  "description": "FF-11 is a fast and minimal image hosting service focused on quick sharing.",
   "repo": "https://github.com/jngohel/image-hosting",
   "owner": {
     "username": "jngohel"

--- a/domains/ff.json
+++ b/domains/ff.json
@@ -1,5 +1,5 @@
 {
-  "description": "Fast and simple image hosting service",
+  "description": "FF (Fast Files) is a lightweight image and file hosting service focused on speed and simplicity.",
   "repo": "https://github.com/jngohel/image-hosting",
   "owner": {
     "username": "jngohel"

--- a/domains/ff.json
+++ b/domains/ff.json
@@ -1,0 +1,10 @@
+{
+  "description": "Fast and simple image hosting service",
+  "repo": "https://github.com/jngohel/image-hosting",
+  "owner": {
+    "username": "jngohel"
+  },
+  "record": {
+    "CNAME": "image-hosting-jngohel-32add1ac4263.herokuapp.com"
+  }
+}

--- a/domains/ffhost.json
+++ b/domains/ffhost.json
@@ -1,0 +1,10 @@
+{
+  "description": "FFHost is a fast and minimal image hosting service for quick file sharing.",
+  "repo": "https://github.com/jngohel/image-hosting",
+  "owner": {
+    "username": "jngohel"
+  },
+  "record": {
+    "CNAME": "image-hosting-jngohel-32add1ac4263.herokuapp.com"
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] The domain name is not already taken.
- [x] I own and control the GitHub account used.
- [x] The domain points to a valid service (Heroku).
- [x] This is a non-commercial project.

## Details

- **Subdomain**: ffhost.is-a.dev  
- **Purpose**: Image hosting service  
- **Target**: image-hosting-jngohel-32add1ac4263.herokuapp.com  
- **Repository**: https://github.com/jngohel/image-hosting
## Justification for short domain

The subdomain **ff** stands for **Fast Files**.  
This project is intentionally minimal and optimized for quick image/file uploads, where a short and memorable domain is important for usability and sharing.