### PR TITLE
Update natalia.is-a.dev DNS to A record

### DIFF
--- a/domains/natalia.json
+++ b/domains/natalia.json
@@ -4,7 +4,7 @@
                   "email": "nataliacuadradohidalgo@gmail.com"
         },
         "records": {
-                  "CNAME": "portfolio-natalia-psi.vercel.app"
+                  "A": ["216.198.79.1"]
         },
         "proxied": false
 }


### PR DESCRIPTION
## Update: Switch from CNAME to A record

This PR updates the DNS configuration for `natalia.is-a.dev` from a CNAME record to an A record, as recommended by Vercel for their new IP range.

**Change:** `CNAME: portfolio-natalia-psi.vercel.app` → `A: 216.198.79.1`

This follows the Vercel recommendation shown in the domain settings ("DNS Change Recommended").

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.