### PR TITLE
Add TXT record for Vercel domain verification for hammi.is-a.dev

### DIFF
--- a/domains/_vercel.hammi.json
+++ b/domains/_vercel.hammi.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "abouhoraira2006"
+  },
+  "records": {
+    "TXT": "_vercel=vc-domain-verify=hammi.is-a.dev,48488e3c6b623eb05529"
+  }
+}

--- a/domains/_vercel.hammi.json
+++ b/domains/_vercel.hammi.json
@@ -3,6 +3,6 @@
     "username": "abouhoraira2006"
   },
   "records": {
-    "TXT": "_vercel=vc-domain-verify=hammi.is-a.dev,48488e3c6b623eb05529"
+    "TXT": "vc-domain-verify=hammi.is-a.dev,48488e3c6b623eb05529"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Additional Information

This subdomain is being used to host my personal software development website.
The project is deployed on Vercel and is non-commercial.
A TXT record was added to verify domain ownership as required by Vercel.

GitHub username: **abouhoraira2006**

# Website Preview

<img width="1315" height="907" alt="brave_screenshot_hammi vercel app" src="https://github.com/user-attachments/assets/79a7f414-eedc-4c3d-a359-9b14fc9bfbd3" />
