### PR TITLE
feat: update apex A record for Vercel and add Clerk subdomains for jigarbhoye

### DIFF
--- a/domains/accounts.jigarbhoye.json
+++ b/domains/accounts.jigarbhoye.json
@@ -1,11 +1,9 @@
 {
   "owner": {
     "username": "jigarbhoye04",
-    "discord": "jigx.04",
     "email": "jigarbhoye04@gmail.com"
   },
   "records": {
-    "A": ["76.76.21.21"],
-    "CNAME": "jigarbhoye.vercel.app"
+    "CNAME": "accounts.clerk.services"
   }
 }

--- a/domains/clerk.jigarbhoye.json
+++ b/domains/clerk.jigarbhoye.json
@@ -1,11 +1,9 @@
 {
   "owner": {
     "username": "jigarbhoye04",
-    "discord": "jigx.04",
     "email": "jigarbhoye04@gmail.com"
   },
   "records": {
-    "A": ["76.76.21.21"],
-    "CNAME": "jigarbhoye.vercel.app"
+    "CNAME": "frontend-api.clerk.services"
   }
 }

--- a/domains/clk._domainkey.jigarbhoye.json
+++ b/domains/clk._domainkey.jigarbhoye.json
@@ -1,11 +1,9 @@
 {
   "owner": {
     "username": "jigarbhoye04",
-    "discord": "jigx.04",
     "email": "jigarbhoye04@gmail.com"
   },
   "records": {
-    "A": ["76.76.21.21"],
-    "CNAME": "jigarbhoye.vercel.app"
+    "CNAME": "dkim1.9p1t6mqbthrz.clerk.services"
   }
 }

--- a/domains/clk2._domainkey.jigarbhoye.json
+++ b/domains/clk2._domainkey.jigarbhoye.json
@@ -1,11 +1,9 @@
 {
   "owner": {
     "username": "jigarbhoye04",
-    "discord": "jigx.04",
     "email": "jigarbhoye04@gmail.com"
   },
   "records": {
-    "A": ["76.76.21.21"],
-    "CNAME": "jigarbhoye.vercel.app"
+    "CNAME": "dkim2.9p1t6mqbthrz.clerk.services"
   }
 }

--- a/domains/clkmail.jigarbhoye.json
+++ b/domains/clkmail.jigarbhoye.json
@@ -1,11 +1,9 @@
 {
   "owner": {
     "username": "jigarbhoye04",
-    "discord": "jigx.04",
     "email": "jigarbhoye04@gmail.com"
   },
   "records": {
-    "A": ["76.76.21.21"],
-    "CNAME": "jigarbhoye.vercel.app"
+    "CNAME": "mail.9p1t6mqbthrz.clerk.services"
   }
 }

--- a/domains/jigarbhoye.json
+++ b/domains/jigarbhoye.json
@@ -5,7 +5,6 @@
     "email": "jigarbhoye04@gmail.com"
   },
   "records": {
-    "A": ["76.76.21.21"],
-    "CNAME": "jigarbhoye.vercel.app"
+    "A": ["216.198.79.1"]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://jigarbhoye.is-a.dev

<img width="2278" height="1415" alt="image" src="https://github.com/user-attachments/assets/4c70a055-bd37-4686-8f58-6e70f9116efc" />

---

## Summary

This PR updates DNS records for `jigarbhoye.is-a.dev` to resolve a Vercel DNS warning and add Clerk authentication subdomains.

### Changes Made

#### 1. Updated `jigarbhoye.json` (Apex Domain)
- **Before:** CNAME → `jigarbhoye.vercel.app`
- **After:** A record → `216.198.79.1`
- **Reason:** Vercel recommends using an A record for apex domains (new recommended IP per their planned IP range expansion).

#### 2. Added 5 Clerk Authentication Subdomains

| File | Subdomain | Target |
|------|-----------|--------|
| `clerk.jigarbhoye.json` | `clerk.jigarbhoye.is-a.dev` | `frontend-api.clerk.services` |
| `accounts.jigarbhoye.json` | `accounts.jigarbhoye.is-a.dev` | `accounts.clerk.services` |
| `clkmail.jigarbhoye.json` | `clkmail.jigarbhoye.is-a.dev` | `mail.9p1t6mqbthrz.clerk.services` |
| `clk._domainkey.jigarbhoye.json` | `clk._domainkey.jigarbhoye.is-a.dev` | `dkim1.9p1t6mqbthrz.clerk.services` |
| `clk2._domainkey.jigarbhoye.json` | `clk2._domainkey.jigarbhoye.is-a.dev` | `dkim2.9p1t6mqbthrz.clerk.services` |

### Purpose
- **Vercel:** Apex domain compatibility improvement
- **Clerk:** Enable custom domain authentication with DKIM email verification for my portfolio site