### PR TITLE
feat: add subdomains (www, support) and GitHub domain verification

### DIFF
--- a/domains/alexgaming.json
+++ b/domains/alexgaming.json
@@ -14,6 +14,17 @@
         "TXT": [
             "v=spf1 include:spf.improvmx.com include:spf.brevo.com ~all",
             "brevo-code:48785c909fd9b5599c12767fc992db3e"
-        ]
+        ],
+        "subdomains": {
+            "www": {
+                "CNAME": "alexgaming-dev.github.io"
+            },
+            "support": {
+                "CNAME": "alexgaming-dev.github.io"
+            },
+            "_gh-AlexGaming-dev-o": {
+                "TXT": "4eca742694"
+            }
+        }
     }
 }

--- a/domains/alexgaming.json
+++ b/domains/alexgaming.json
@@ -14,17 +14,17 @@
         "TXT": [
             "v=spf1 include:spf.improvmx.com include:spf.brevo.com ~all",
             "brevo-code:48785c909fd9b5599c12767fc992db3e"
-        ],
-        "subdomains": {
-            "www": {
-                "CNAME": "alexgaming-dev.github.io"
-            },
-            "support": {
-                "CNAME": "alexgaming-dev.github.io"
-            },
-            "_gh-AlexGaming-dev-o": {
-                "TXT": "4eca742694"
-            }
+        ]
+    },
+    "subdomains": {
+        "www": {
+            "CNAME": "alexgaming-dev.github.io"
+        },
+        "support": {
+            "CNAME": "alexgaming-dev.github.io"
+        },
+        "_gh-AlexGaming-dev-o": {
+            "TXT": "4eca742694"
         }
     }
 }


### PR DESCRIPTION
# Update: Subdomains & GitHub Verification

## PR Title
`feat: add subdomains (www, support) and GitHub domain verification`

---

## Description
This update modifies the DNS configuration for `alexgaming.is-a.dev`. The primary goal is to expand the reachability of the portfolio and verify domain ownership within GitHub.

## Changes

### 1. New Subdomains
I have implemented the following subdomains using the recommended `is-a.dev` structure:
* **www.alexgaming.is-a.dev**: Added as a CNAME pointing to the GitHub Pages host.
* **support.alexgaming.is-a.dev**: Added as a CNAME to provide a dedicated entry point for support-related queries.

### 2. Domain Verification
* Added a `TXT` record for `_gh-AlexGaming-dev-o.alexgaming.is-a.dev`.
* **Value:** `4eca742694`
* **Purpose:** Required for GitHub Organization/Account verification.

### 3. Record Overview
| Subdomain | Type | Target/Value |
| :--- | :--- | :--- |
| `www` | CNAME | `alexgaming-dev.github.io` |
| `support` | CNAME | `alexgaming-dev.github.io` |
| `_gh-AlexGaming-dev-o` | TXT | `4eca742694` |

---

## Technical Note
* **Cloudflare Proxy:** The `proxied: true` setting is maintained to benefit from Cloudflare's security features.
* **Email Configuration:** No changes were made to the existing `MX` or `SPF` (TXT) records to ensure uninterrupted email forwarding via ImprovMX and Brevo.

---

## JSON Implementation
The changes are consolidated within the `subdomains` object inside `alexgaming.json` to maintain a clean repository structure.