### PR TITLE
Register cronsafe, legalkit, and waitlistq subdomains

### DIFF
--- a/domains/_vercel.cronsafe.json
+++ b/domains/_vercel.cronsafe.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "maxwharris",
+    "email": "fuzegamingtv@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=cronsafe.is-a.dev,ff9e454006f7e21b15da"
+  }
+}

--- a/domains/_vercel.legalkit.json
+++ b/domains/_vercel.legalkit.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "maxwharris",
+    "email": "fuzegamingtv@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=legalkit.is-a.dev,d5e57ac9035e6fc4bacd"
+  }
+}

--- a/domains/_vercel.waitlistq.json
+++ b/domains/_vercel.waitlistq.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "maxwharris",
+    "email": "fuzegamingtv@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=waitlistq.is-a.dev,41424534fc747f5641f6"
+  }
+}

--- a/domains/cronsafe.json
+++ b/domains/cronsafe.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "maxwharris",
+    "email": "fuzegamingtv@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}

--- a/domains/legalkit.json
+++ b/domains/legalkit.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "maxwharris",
+    "email": "fuzegamingtv@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}

--- a/domains/waitlistq.json
+++ b/domains/waitlistq.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "maxwharris",
+    "email": "fuzegamingtv@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
## Subdomain Registration Request

Requesting three subdomains for developer tools built by Deep End Ventures:

### Domains
- **cronsafe.is-a.dev** — Cron job monitoring service (ping-based alerting)
- **legalkit.is-a.dev** — Privacy policy & terms of service generator
- **waitlistq.is-a.dev** — Embeddable waitlist widget with referral tracking

### Records
Each domain has:
- **A record** → 216.198.79.1 (Vercel)
- **TXT record** (\_vercel.\*) → Vercel domain verification

### Live Sites
- https://cronsafe-one.vercel.app
- https://legalkit.vercel.app
- https://waitlistq.vercel.app

All three are live production applications hosted on Vercel.