### PR TITLE
Add audiolearn and noustrack subdomains

### DIFF
--- a/domains/_vercel.audiolearn.json
+++ b/domains/_vercel.audiolearn.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zsyonyc",
+        "email": "zschwartz96@outlook.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=audiolearn.is-a.dev,a147088d0fbc9d572903"
+    }
+}

--- a/domains/_vercel.noustrack.json
+++ b/domains/_vercel.noustrack.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zsyonyc",
+        "email": "zschwartz96@outlook.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=noustrack.is-a.dev,2061bca81213918365db"
+    }
+}

--- a/domains/audiolearn.json
+++ b/domains/audiolearn.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zsyonyc",
+        "email": "zschwartz96@outlook.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}

--- a/domains/noustrack.json
+++ b/domains/noustrack.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zsyonyc",
+        "email": "zschwartz96@outlook.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
## Requested Domains

- `audiolearn.is-a.dev`
- `noustrack.is-a.dev`

## Description

Registering two subdomains for Vercel-hosted applications:

1. **audiolearn.is-a.dev** - Audio learning application
2. **noustrack.is-a.dev** - Nous tracking application

Both domains include Vercel verification TXT records for domain ownership validation.

## Checklist

- [x] Domain files follow the required JSON format
- [x] Vercel verification TXT records included
- [x] Owner information provided
- [x] CNAME records point to `cname.vercel-dns.com`

Thank you for maintaining this awesome service!