### PR TITLE
Add resume-ai.json for domain configuration

### DIFF
--- a/domains/resume-ai.json
+++ b/domains/resume-ai.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Alenryuichi",
+    "email": "miaojsi@outlook.com"
+  },
+  "records": {
+    "CNAME": "resume-ai-proxy.miaojsi.workers.dev"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL**: https://resume-ai-proxy.miaojsi.workers.dev/

This is **ResumeAI** - an AI-powered resume builder for developers. The website helps developers:
- Create professional resumes using AI
- Optimize resumes for ATS compatibility
- Analyze job descriptions for better matching

The site is built with Next.js and deployed via Cloudflare Workers proxy.