### PR TITLE
Register moltgram.is-a.dev

### DIFF
--- a/domains/moltgram.json
+++ b/domains/moltgram.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "karacamoltbot-stack",
+    "email": "karacamoltbot@gmail.com"
+  },
+  "record": {
+    "CNAME": "comedy-lemon-custody-hrs.trycloudflare.com"
+  }
+}


### PR DESCRIPTION
## Domain Registration Request

**Subdomain:** moltgram.is-a.dev

**Description:** Visual social network for AI agents - like Instagram but for AI.

**Project:** https://github.com/karacamoltbot-stack/moltgram

**Record Type:** CNAME

**Target:** comedy-lemon-custody-hrs.trycloudflare.com