### PR TITLE
Register ins-translator.is-a.dev

### DIFF
--- a/domains/ins-translator.json
+++ b/domains/ins-translator.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "vibecodingengine"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
### Domain Registration

- **Subdomain:** ins-translator.is-a.dev
- **Record type:** CNAME → cname.vercel-dns.com
- **Purpose:** API backend for the Instagram Translator Chrome extension