### PR TITLE
Register snr.is-a.dev

### DIFF
--- a/domains/snr.json
+++ b/domains/snr.json
@@ -2,7 +2,7 @@
   "owner": {
     "username": "Snrbeats"
   },
-  "record": {
+  "records": {
     "CNAME": "soundcraft-audio.vercel.app"
   }
 }

--- a/domains/snr.json
+++ b/domains/snr.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Snrbeats"
+  },
+  "record": {
+    "CNAME": "soundcraft-audio.vercel.app"
+  }
+}


### PR DESCRIPTION
## Domain Registration

**Subdomain:** snr.is-a.dev

**Record Type:** CNAME

**Target:** soundcraft-audio.vercel.app

---

Registering snr.is-a.dev for SNR Audio - professional audio services.