### PR TITLE
Create factoryeats.json

### DIFF
--- a/domains/factoryeats.json
+++ b/domains/factoryeats.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Lawson647",
+    "email": "contact@factoryeats.is-a.dev"
+  },
+  "record": {
+    "URL": "https://www.genspark.ai/agents?id=26175350-5df9-4d92-9012-32d4aa99c404"
+  }
+}


### PR DESCRIPTION
## Enregistrement du domaine Factory Eats

Cette PR enregistre le domaine **factoryeats.is-a.dev** pour la plateforme Factory Eats de coordination de restaurants virtuels.

## Critères respectés ✅
- [x] Le domaine respecte tous les critères d'is-a.dev
- [x] Conformité avec les Conditions d'Utilisation (https://is-a.dev/terms)
- [x] Fichier JSON valide dans le dossier domains/
- [x] Site non destiné à la vente commerciale directe (plateforme B2B virtuelle)
- [x] Informations de contact fournies via la clé 'owner' (Lawson647)
- [x] Aperçu du site fourni (agent GenSpark)

## À propos de Factory Eats

Factory Eats est une plateforme virtuelle de coordination de restaurants partenaires via un modèle proxy Uber Eats. L'agent GenSpark fournit la page d'accueil et les informations de service.

**URL du site :** https://www.genspark.ai/agents?id=26175350-5df9-4d92-9012-32d4aa99c404

**Propriétaire :** Lawson647  
**Email :** contact@factoryeats.is-a.dev