### PR TITLE
Register saytoit.is-a.dev

### DIFF
--- a/domains/saytoit.json
+++ b/domains/saytoit.json
@@ -1,0 +1,11 @@
+{
+  "description": "SayToIt — open-source macOS voice transcription app for developers",
+  "repo": "https://github.com/rameshreddy-adutla/saytoit",
+  "owner": {
+    "username": "rameshreddy-adutla",
+    "email": "rameshreddy.adutla@mnscorp.net"
+  },
+  "records": {
+    "CNAME": "rameshreddy-adutla.github.io"
+  }
+}


### PR DESCRIPTION
Register `saytoit.is-a.dev` subdomain for [SayToIt](https://github.com/rameshreddy-adutla/saytoit) — an open-source macOS voice transcription app for developers.

- **Repo**: https://github.com/rameshreddy-adutla/saytoit
- **Target**: `rameshreddy-adutla.github.io` (GitHub Pages)
- **Record type**: CNAME