### PR TITLE
Add _vercel.bogdangalai.is-a.dev (TXT verification for Vercel)

### DIFF
--- a/domains/_vercel.bogdangalai.json
+++ b/domains/_vercel.bogdangalai.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "bobtattvamasi",
+    "email": "bogdan.galaxy@gmail.com"
+  },
+  "record": {
+    "TXT": [
+      "vc-domain-verify=bogdangalai.is-a.dev,c07df251941d9b8954a0"
+    ]
+  }
+}


### PR DESCRIPTION
Adding TXT record for Vercel domain verification.
This is required to link bogdangalai.is-a.dev to my Vercel project.

Related: PR #32667 (already merged)

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live URL: https://bogdan-portfolio-website.vercel.app

Description: TXT record addition for Vercel domain verification. Main domain PR #32667 already merged. Website is a personal developer portfolio with interactive terminal interface.
