### PR TITLE
Register eddiemacamo.is-a.dev

### DIFF
--- a/domains/eddiemacamo.json
+++ b/domains/eddiemacamo.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Eddie-Macamo",
+    "email": "edmundomacamo31@gmail.com"
+  },
+  "record": {
+    "A": ["76.76.21.21"],
+    "TXT": ["vc-domain-verify=eddiemacamo.is-a.dev,b4a67e070027b65486a6"]
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Domain:** eddiemacamo.is-a.dev
- **Record Type:** A + TXT
- **A Record:** 76.76.21.21 (Vercel)
- **TXT Record:** Vercel domain verification

### Purpose
Personal portfolio website hosted on Vercel.