### PR TITLE
Register pricepulse.is-a.dev with Resend email DNS records

### DIFF
--- a/domains/_dmarc.pricepulse.json
+++ b/domains/_dmarc.pricepulse.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AmelioMansour",
+    "email": "ameliomansour612@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/pricepulse.json
+++ b/domains/pricepulse.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AmelioMansour",
+    "email": "ameliomansour612@gmail.com"
+  },
+  "records": {
+    "URL": "https://github.com/AmelioMansour/pricepulse"
+  }
+}

--- a/domains/resend._domainkey.pricepulse.json
+++ b/domains/resend._domainkey.pricepulse.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AmelioMansour",
+    "email": "ameliomansour612@gmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC67fRPmRH0Tup+PDBvpG/RC9oyVWBw85/RTGVPWuKeenUe14mAY8ZIwV+PRoIwovZ+2t6t0rR/2ZhKLc0tWzvHOe48L8iWna8uuSXJnFCTqeXCrI5wCLHsRqGofipwuBNRB4J5WuuLIlHaMoyuP74krRfiSGcI1JQllObF30Cg9QIDAQAB"
+  }
+}

--- a/domains/send.pricepulse.json
+++ b/domains/send.pricepulse.json
@@ -1,0 +1,15 @@
+{
+  "owner": {
+    "username": "AmelioMansour",
+    "email": "ameliomansour612@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.us-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Link:** https://github.com/AmelioMansour/pricepulse

PricePulse is a price tracking web app that monitors product prices across Amazon, Walmart, and Target. Built with React, Express, and PostgreSQL.

The root domain (`pricepulse.is-a.dev`) currently redirects to the GitHub repo. The subdomains (`resend._domainkey.pricepulse`, `send.pricepulse`, `_dmarc.pricepulse`) are for email delivery via Resend (DKIM, SPF, DMARC).

![PricePulse Screenshot](https://raw.githubusercontent.com/AmelioMansour/pricepulse/main/client/public/og-image.png)