### PR TITLE
Update: Added A record and Vercel verification for hichem.is-a.dev

### DIFF
--- a/domains/_vercel.hichem.json
+++ b/domains/_vercel.hichem.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hiche-m",
+        "email": "hichem1029@live.fr"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=hichem.is-a.dev,e1636dddbf9532723d2a"
+    }
+}

--- a/domains/hichem.json
+++ b/domains/hichem.json
@@ -4,6 +4,6 @@
         "email": "hichem1029@live.fr"
     },
     "records": {
-        "CNAME": "portfolio-lyart-omega-vxsp6sawer.vercel.app"
+        "A": ["216.198.79.1"]
     }
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Changes
- Updated `hichem.json` to use the correct Vercel A Record.
- Added `_vercel.hichem.json` to provide the TXT verification record required by Vercel for SSL.

# Website Preview
Link: [portfolio-lyart-omega-vxsp6sawer.vercel.app](https://portfolio-lyart-omega-vxsp6sawer.vercel.app/)

Portfolio Screenshots:
![preview_pages-to-jpg-0001](https://github.com/user-attachments/assets/46a3f6dc-aec5-4f57-97f1-3d8f41705fc0)
![preview_pages-to-jpg-0002](https://github.com/user-attachments/assets/3130aec3-9ebd-4ea2-bd66-db21f57088ae)
![preview_pages-to-jpg-0003](https://github.com/user-attachments/assets/83964561-3281-4400-ac94-961f695f7788)
![preview_pages-to-jpg-0004](https://github.com/user-attachments/assets/34cf34a7-9c4c-4cf0-a47d-b03122e74fab)
