### PR TITLE
Register junglewaves.is-a.dev

### DIFF
--- a/domains/junglewaves.json
+++ b/domains/junglewaves.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jocsanzu",
+    "email": "zunigakaled942@gmail.com"
+  },
+  "record": {
+    "CNAME": "jocsanzu.github.io"
+  }
+}


### PR DESCRIPTION
## Register junglewaves.is-a.dev

### Domain
junglewaves.is-a.dev

### Record Type
CNAME → jocsanzu.github.io

### Description
Landscaping and pool maintenance business website hosted on GitHub Pages.