### PR TITLE
Register groundtruth.is-a.dev

### DIFF
--- a/domains/groundtruth.json
+++ b/domains/groundtruth.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "anish632",
+    "email": "anishdasmail@gmail.com"
+  },
+  "description": "Ground Truth MCP Server - AI agent fact-checking tool",
+  "record": {
+    "CNAME": "ground-truth-mcp.anishdasmail.workers.dev"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** groundtruth.is-a.dev
- **Record Type:** CNAME
- **Target:** ground-truth-mcp.anishdasmail.workers.dev

## Description

Ground Truth MCP Server — an MCP server that lets AI agents fact-check their own research in real time by probing endpoints, counting competitors, and testing hypotheses against live registries.

- GitHub: https://github.com/anish632/ground-truth-mcp
- MCP Registry: https://registry.modelcontextprotocol.io/servers/io.github.anish632/ground-truth