### PR TITLE
Register stcmail.is-a.dev

### DIFF
--- a/domains/stcmail.json
+++ b/domains/stcmail.json
@@ -1,0 +1,18 @@
+{
+  "owner": {
+    "username": "Stacy-yyy",
+    "email": "iangostacy@gmail.com"
+  },
+  "records": {
+    "A": "102.18.5.188",
+    "MX": [
+      {
+        "priority": 10,
+        "target": "stcmail.is-a.dev"
+      }
+    ],
+    "TXT": [
+      "v=spf1 a mx ~all"
+    ]
+  }
+}


### PR DESCRIPTION
Requesting stcmail.is-a.dev

- Usage: Personal email server test (Postfix/Dovecot in VM)
- Website: None yet (local testing)
- I agree to the Terms of Service: https://is-a.dev/terms
- File follows domain structure: https://docs.is-a.dev/domain-structure/