### PR TITLE
Register serialplotter.is-a.dev

### DIFF
--- a/domains/serialplotter.json
+++ b/domains/serialplotter.json
@@ -1,0 +1,11 @@
+{
+  "description": "Web Serial Plotter - Real-time serial data visualization",
+  "repo": "https://github.com/rizkyandito/serial-plotter",
+  "owner": {
+    "username": "rizkyandito",
+    "email": ""
+  },
+  "record": {
+    "CNAME": "rizkyandito.github.io"
+  }
+}


### PR DESCRIPTION
### Domain Registration

- **Subdomain:** serialplotter.is-a.dev
- **Record Type:** CNAME
- **Target:** rizkyandito.github.io
- **Repository:** https://github.com/rizkyandito/serial-plotter
- **Description:** Web Serial Plotter — Real-time serial data visualization tool for Arduino/microcontroller projects, built with vanilla HTML/JS and Plotly.js.