### PR TITLE
Register lit-pigeon.is-a.dev

### DIFF
--- a/domains/lit-pigeon.json
+++ b/domains/lit-pigeon.json
@@ -1,0 +1,11 @@
+{
+  "description": "Lit-based email editor web components",
+  "repo": "https://github.com/snxstudio/lit-pigeon",
+  "owner": {
+    "username": "mayurrawte",
+    "email": "rawte.mayur@gmail.com"
+  },
+  "record": {
+    "CNAME": "snxstudio.github.io"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: lit-pigeon.is-a.dev
- **Description**: Lit-based email editor web components
- **Repository**: https://github.com/snxstudio/lit-pigeon
- **Record Type**: CNAME -> snxstudio.github.io