### PR TITLE
Register storyforgesshorts.is-a.dev

### DIFF
--- a/domains/storyforgesshorts.json
+++ b/domains/storyforgesshorts.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "kkmat",
+        "email": "kkmat3@gmail.com"
+    },
+    "records": {
+        "CNAME": "kkmat.github.io"
+    }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: storyforgesshorts.is-a.dev
- **Service**: GitHub Pages
- **CNAME**: kkmat.github.io
- **Website**: https://kkmat.github.io/storyforgesshorts.com/

StoryForge Shorts is a content creator platform that publishes daily Reddit story videos across YouTube, TikTok, Instagram, and Facebook.