### PR TITLE
Add alhrbi.is-a.dev (Revamped Website)

### DIFF
--- a/domains/alhrbi.json
+++ b/domains/alhrbi.json
@@ -1,0 +1,12 @@
+{
+    "description": "Alhrbi Portfolio",
+    "domain": "is-a.dev",
+    "subdomain": "alhrbi",
+    "owner": {
+        "repo": "https://github.com/bugbountysaburtilz1404test-blip/alhrbi",
+        "email": "bugbounty.sa.burtilz1404.test@gmail.com"
+    },
+    "record": {
+        "CNAME": "bugbountysaburtilz1404test-blip.github.io"
+    }
+}


### PR DESCRIPTION
Adding `alhrbi.is-a.dev`

- [x] I have read the guidelines
- [x] This is a personal/open-source project
- [x] Site preview: https://bugbountysaburtilz1404test-blip.github.io/alhrbi

Note: The website has been completely revamped to comply with the manual review requirement for a comprehensive personal portfolio.