### PR TITLE
Add f15.is-a.dev (Revamped Website)

### DIFF
--- a/domains/f15.json
+++ b/domains/f15.json
@@ -1,0 +1,12 @@
+{
+    "description": "F15 Projects",
+    "domain": "is-a.dev",
+    "subdomain": "f15",
+    "owner": {
+        "repo": "https://github.com/bugbountysaburtilz1404test-blip/f15",
+        "email": "bugbounty.sa.burtilz1404.test@gmail.com"
+    },
+    "record": {
+        "CNAME": "bugbountysaburtilz1404test-blip.github.io"
+    }
+}


### PR DESCRIPTION
Adding `f15.is-a.dev`

- [x] I have read the guidelines
- [x] This is a personal/open-source project
- [x] Site preview: https://bugbountysaburtilz1404test-blip.github.io/f15

Note: The website has been completely revamped to comply with the manual review requirement for a comprehensive personal portfolio.