### PR TITLE
Add abdullah-dev.is-a.dev (Revamped Website)

### DIFF
--- a/domains/abdullah-dev.json
+++ b/domains/abdullah-dev.json
@@ -1,0 +1,12 @@
+{
+    "description": "Abdullah Developer Portfolio",
+    "domain": "is-a.dev",
+    "subdomain": "abdullah-dev",
+    "owner": {
+        "repo": "https://github.com/bugbountysaburtilz1404test-blip/abdullah-dev",
+        "email": "bugbounty.sa.burtilz1404.test@gmail.com"
+    },
+    "record": {
+        "CNAME": "bugbountysaburtilz1404test-blip.github.io"
+    }
+}


### PR DESCRIPTION
Adding `abdullah-dev.is-a.dev`

- [x] I have read the guidelines
- [x] This is a personal/open-source project
- [x] Site preview: https://bugbountysaburtilz1404test-blip.github.io/abdullah-dev

Note: The website has been completely revamped to comply with the manual review requirement for a comprehensive personal portfolio.