### PR TITLE
Register steam-wishlist.is-a.dev

### DIFF
--- a/domains/_dnsauth.steam-wishlist.json
+++ b/domains/_dnsauth.steam-wishlist.json
@@ -1,0 +1,10 @@
+{
+  "description": "Azure Static Web Apps domain validation for steam-wishlist.is-a.dev",
+  "repo": "https://github.com/d-b-c-e/steam-wishlist-demos",
+  "owner": {
+    "username": "d-b-c-e"
+  },
+  "records": {
+    "TXT": ["_cjvnc26qxnqa8a2tt55kum65ixjrot0"]
+  }
+}

--- a/domains/steam-wishlist.json
+++ b/domains/steam-wishlist.json
@@ -1,0 +1,10 @@
+{
+  "description": "Steam Wishlist Demo Filter — filter your Steam wishlist by playable demos",
+  "repo": "https://github.com/d-b-c-e/steam-wishlist-demos",
+  "owner": {
+    "username": "d-b-c-e"
+  },
+  "records": {
+    "CNAME": "jolly-dune-0a7f17d0f.4.azurestaticapps.net"
+  }
+}


### PR DESCRIPTION
## Domain Registration

**Subdomain:** `steam-wishlist.is-a.dev`

**Project:** [Steam Wishlist Demo Filter](https://github.com/d-b-c-e/steam-wishlist-demos) — A web app that lets Steam users filter their wishlist by games with playable demos. Sign in with Steam, see which games have demos, filter by genre, sort by price/rating/popularity.

**Records:**
- `CNAME` → `jolly-dune-0a7f17d0f.4.azurestaticapps.net` (Azure Static Web Apps)
- `_dnsauth.steam-wishlist` TXT → Azure domain validation token

**Hosting:** Azure Static Web Apps (free tier)

**Files added:**
- `domains/steam-wishlist.json` — CNAME to Azure SWA
- `domains/_dnsauth.steam-wishlist.json` — TXT for SSL/domain validation