### PR TITLE
Register jimbojankins.is-a.dev

### DIFF
--- a/domains/jimbojankins.json
+++ b/domains/jimbojankins.json
@@ -1,0 +1,14 @@
+{
+  "description": "Email forwarding domain for tooling",
+  "owner": {
+    "username": "doodaaatimmy-creator",
+    "email": "doodaaatimmy@gmail.com"
+  },
+  "records": {
+    "MX": ["mx1.forwardemail.net", "mx2.forwardemail.net"],
+    "TXT": [
+      "forward-email=doodaaatimmy@gmail.com",
+      "v=spf1 a include:spf.forwardemail.net -all"
+    ]
+  }
+}


### PR DESCRIPTION
### Domain Registration

**Subdomain:** jimbojankins.is-a.dev

**Purpose:** Email forwarding domain for development tooling

**Records:**
- MX: Forward Email (forwardemail.net) for catch-all email forwarding
- TXT: SPF record + forward-email configuration

**Owner:** doodaaatimmy-creator