### PR TITLE
Register smidart.is-a.dev

### DIFF
--- a/domains/smidart.json
+++ b/domains/smidart.json
@@ -1,0 +1,11 @@
+{
+  "description": "Personal landing page — Artem Smidyuk, sales expert",
+  "repo": "smidart-eng/smidart-eng.github.io",
+  "owner": {
+    "username": "smidart-eng",
+    "email": ""
+  },
+  "record": {
+    "CNAME": "smidart-eng.github.io"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Domain:** smidart.is-a.dev
- **Record type:** CNAME → smidart-eng.github.io
- **Description:** Personal landing page for Artem Smidyuk, sales expert
- **GitHub Pages repo:** [smidart-eng.github.io](https://github.com/smidart-eng/smidart-eng.github.io)