### PR TITLE
feat: add sarangwe.is-a.dev

### DIFF
--- a/domains/sarangwe.json
+++ b/domains/sarangwe.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "sarangwe64-debug",
+    "email": "sarangwe64@gmail.com"
+  },
+  "records": {
+    "CNAME": "mk9l7t72.up.railway.app"
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds the subdomain `sarangwe.is-a.dev` pointing to a Railway-hosted web application (Meta Ads Intelligence Dashboard).

## Domain file

`domains/sarangwe.json` — CNAME pointing to Railway: `mk9l7t72.up.railway.app`

## Website Preview


The site is a Meta Ads scraping and batch job management tool running on Railway.

## Checklist
- [x] I have read the contributing guidelines
- [x] I have checked that the domain is not already taken
- [x] The CNAME points to a valid service