### PR TITLE
Add inplayq.is-a.dev

### DIFF
--- a/domains/inplayq.json
+++ b/domains/inplayq.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "venkat2403"
+  },
+  "records": {
+    "CNAME": "venkat2403.github.io"
+  }
+}


### PR DESCRIPTION
## Description
Registering `inplayq.is-a.dev` as a CNAME to `venkat2403.github.io`.

This subdomain will host **PreBell** — a daily pre-market trading intelligence dashboard that publishes automated morning market briefings (gap scans, sector ETFs, earnings analysis).

## Checklist
- [x] I have read the contributing guidelines
- [x] I own the target GitHub Pages site
- [x] The domain file is correctly formatted