### PR TITLE
Add prebell.is-a.dev

### DIFF
--- a/domains/prebell.json
+++ b/domains/prebell.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "venkat2403"
+  },
+  "records": {
+    "CNAME": "venkat2403.github.io"
+  }
+}


### PR DESCRIPTION
## Description
Registering `prebell.is-a.dev` as a CNAME to `venkat2403.github.io`.

This subdomain hosts **PreBell** — a daily pre-market trading intelligence dashboard that publishes automated morning market briefings by 8:20 AM CST (gap scans, sector ETFs, AH movers, earnings analysis).

## Checklist
- [x] I have read the contributing guidelines
- [x] I own the target GitHub Pages site
- [x] The domain file is correctly formatted