### PR TITLE
Register ai-efficiency.is-a.dev

### DIFF
--- a/domains/ai-efficiency.json
+++ b/domains/ai-efficiency.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "xiaoxiong20260206",
+        "email": "xhan2008@163.com"
+    },
+    "records": {
+        "CNAME": "xiaoxiong20260206.github.io"
+    }
+}


### PR DESCRIPTION
Subdomain: ai-efficiency.is-a.dev pointing to xiaoxiong20260206.github.io for hosting AI DevOps research report.