### PR TITLE
Register hkkgranking.is-a.dev

### DIFF
--- a/domains/hkkgranking.json
+++ b/domains/hkkgranking.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ChasingSuperiorReturns",
+        "email": "wan.martinn@gmail.com"
+    },
+    "records": {
+        "CNAME": "hkkgranking-web-63610341796.asia-east1.run.app"
+    }
+}


### PR DESCRIPTION
### Domain Registration
Subdomain: hkkgranking.is-a.dev
Record Type: CNAME
Target: hkkgranking-web-63610341796.asia-east1.run.app

This is for my Hong Kong Kindergarten Ranking website hosted on Google Cloud Run.