### PR TITLE
Register educai.is-a.dev

### DIFF
--- a/domains/educai.json
+++ b/domains/educai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Prohar04",
+    "email": "Prohar04@users.noreply.github.com"
+  },
+  "record": {
+    "TXT": ["v=spf1 include:sendgrid.net ~all"]
+  }
+}


### PR DESCRIPTION
### Domain Registration

**Subdomain:** educai.is-a.dev
**Purpose:** Email sending (SendGrid TXT record for SPF)
**Owner:** @Prohar04

This registers the `educai.is-a.dev` subdomain with a TXT record for SendGrid email authentication (SPF).