### PR TITLE
Add pageroast.is-a.dev

### DIFF
--- a/domains/pageroast.json
+++ b/domains/pageroast.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "johnalister11011-stack",
+    "email": "john.alister11011@gmail.com"
+  },
+  "records": {
+    "CNAME": "pageroast-plum.vercel.app"
+  }
+}


### PR DESCRIPTION
## Summary
- Register `pageroast.is-a.dev` subdomain
- CNAME pointing to `pageroast-plum.vercel.app`

## About
PageRoast is an AI-powered landing page conversion analysis tool that scores and critiques websites across headline, value proposition, CTAs, trust signals, and copy quality.

## Owner
- GitHub: @johnalister11011-stack
- Email: john.alister11011@gmail.com