### PR TITLE
feat: register baladengale.is-a.dev portfolio with nested subdomains

### DIFF
--- a/domains/agent.baladengale.json
+++ b/domains/agent.baladengale.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "baladengale",
+    "email": "dengalebr@gmail.com"
+  },
+  "records": {
+    "CNAME": "baladengale.duckdns.org"
+  }
+}

--- a/domains/baladengale.json
+++ b/domains/baladengale.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "baladengale",
+    "email": "dengalebr@gmail.com"
+  },
+  "records": {
+    "A": "185.199.111.153"
+  }
+}

--- a/domains/baladengale.json
+++ b/domains/baladengale.json
@@ -4,6 +4,6 @@
     "email": "dengalebr@gmail.com"
   },
   "records": {
-    "A": "185.199.111.153"
+    "A": ["185.199.111.153"]
   }
 }

--- a/domains/projects.baladengale.json
+++ b/domains/projects.baladengale.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "baladengale",
+    "email": "dengalebr@gmail.com"
+  },
+  "records": {
+    "CNAME": "baladengale.github.io"
+  }
+}


### PR DESCRIPTION
## Register baladengale.is-a.dev

### Portfolio Structure
- **baladengale.is-a.dev** → GitHub Pages portfolio (A record)
- **agent.baladengale.is-a.dev** → AI agent webchat (CNAME)
- **projects.baladengale.is-a.dev** → GitHub projects (CNAME)

### Purpose
Personal portfolio website with nested subdomains for dev projects and services.