### PR TITLE
feat: add agent.baladengale.is-a.dev

### DIFF
--- a/domains/agent.baladengale.json
+++ b/domains/agent.baladengale.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "baladengale",
+    "email": "dengalebr@gmail.com"
+  },
+  "records": {
+    "CNAME": "baladengale.duckdns.org"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live site:** https://baladengale.duckdns.org

This is a nested subdomain of my portfolio domain `baladengale.is-a.dev` (PR #33531). It points to my personal AI agent project — an OpenClaw-based assistant running on a self-hosted VPS, which is part of my infrastructure/DevOps engineering work.

**Domain file:** `domains/agent.baladengale.json` — CNAME → `baladengale.duckdns.org`