### PR TITLE
Register republicai.is-a.dev

### DIFF
--- a/domains/republicai.json
+++ b/domains/republicai.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "eddgia",
+        "email": "eddgia@users.noreply.github.com"
+    },
+    "records": {
+        "CNAME": "eddgia.github.io"
+    }
+}


### PR DESCRIPTION
Register republicai.is-a.dev subdomain for RepublicAI blockchain explorer hosted on GitHub Pages (eddgia.github.io).