### PR TITLE
Register bedrock.is-a.dev

### DIFF
--- a/domains/bedrock.json
+++ b/domains/bedrock.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "mrDevRussia",
+    "email": "kimoelshamy09@gmail.com"
+  },
+  "records": {
+    "CNAME": "mrDevRussia.github.io"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Hello, I would like to register bedrock.is-a.dev for my new programming language documentation hosted on gitHub pages