### PR TITLE
feat(domain): add cycy.is-a.dev with dedicated Vercel verification

### DIFF
--- a/domains/_vercel.cycy.json
+++ b/domains/_vercel.cycy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CynthiaWahome",
+        "email": "hey@cycy.codes"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=cycy.is-a.dev,0668817934da0b4d265c"
+    }
+}

--- a/domains/cycy.json
+++ b/domains/cycy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CynthiaWahome",
+        "email": "hey@cycy.codes"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://atelier-kx2t.vercel.app

<img width="1416" height="813" alt="cycy-coverpage" src="https://github.com/user-attachments/assets/e78420c6-c566-44e4-85fa-07ca60965a5e" />


*Note: Fixed the Vercel verification by moving it to a dedicated `_vercel.cycy.json` file as requested by the maintainers in the previous closed PR. Updated the record to the recommended Vercel IP.*