### PR TITLE
rr.is-a.dev request

### DIFF
--- a/domains/rr.json
+++ b/domains/rr.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ruhanirabin",
+        "twitter": "ruhanirabin"
+    },
+    "records": {
+       "A": ["75.2.60.5"]
+    }
+}

--- a/domains/www.rr.json
+++ b/domains/www.rr.json
@@ -1,0 +1,10 @@
+
+{
+    "owner": {
+        "username": "ruhanirabin",
+        "twitter": "ruhanirabin"
+    },
+    "records": {
+        "CNAME": "rabin-blog-astro.netlify.app"
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. -->

live URL https://rabin.blog (since 2019)

Rabin.blog is a personal technology journal on various topics, including WP, Home Assistant, Code Snippets and more. Built with Astro+WordPress(backend) - This website framework is open-source (can be found at my GitHub profile).

## Screenshots: 

### Main view
<img width="1223" height="990" alt="2026-03-05-(1223x990)-02287" src="https://github.com/user-attachments/assets/83727bf7-c820-480e-b756-aec7357c2953" />

### Archive view
<img width="1267" height="1000" alt="2026-03-05-(1267x1000)-02289" src="https://github.com/user-attachments/assets/755a342d-8212-48b4-81ea-8c85fed3f684" />

