### PR TITLE
Register pressstart.is-a.dev

### DIFF
--- a/domains/pressstart.json
+++ b/domains/pressstart.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "wawadiwah-star",
+    "email": "wawadiwah@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** pressstart.is-a.dev
- **Record type:** CNAME → cname.vercel-dns.com
- **Purpose:** PlayStation repair & jailbreak service website (Aix-en-Provence, France)
- **Hosted on:** Vercel (Next.js static site)