### PR TITLE
feat: add Google verification TXT to workflow-builder.lunatiee.is-a.dev

### DIFF
--- a/domains/workflow-builder.lunatiee.json
+++ b/domains/workflow-builder.lunatiee.json
@@ -6,6 +6,7 @@
         "email": "lunatie@gmail.com"
     },
     "records": {
-        "CNAME": "workflow-builder-web-qtkckv6l3a-an.a.run.app"
+        "CNAME": "workflow-builder-web-qtkckv6l3a-an.a.run.app",
+        "TXT": ["google-site-verification=IvWiVgnwCebsWyWF0KRub6-zxOK15_bSpZKhpX4YaXE"]
     }
 }


### PR DESCRIPTION
## Update Domain Record

**Domain**: workflow-builder.lunatiee.is-a.dev

Adding Google Search Console verification TXT record to enable Cloud Run custom domain mapping.

### Changes
- Added `TXT` record: `google-site-verification=IvWiVgnwCebsWyWF0KRub6-zxOK15_bSpZKhpX4YaXE`