### PR TITLE
Register umzugsvergleich.is-a.dev

### DIFF
--- a/domains/umzugsvergleich.json
+++ b/domains/umzugsvergleich.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "chukZ"
+  },
+  "records": {
+    "A": [
+      "217.154.224.102"
+    ]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Register subdomain `umzugsvergleich.is-a.dev` with A record pointing to `217.154.224.102`.