### PR TITLE
ioc-sentinel.is-a.dev

### DIFF
--- a/domains/ioc-sentinel.json
+++ b/domains/ioc-sentinel.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Naeemk10",
+    "email": "Naeemkathawala07@outlook.com"
+  },
+  "record": {
+    "CNAME": "naeemk10.github.io"
+  }
+}


### PR DESCRIPTION
add ioc-sentinel.is-a.dev

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
**Live URL:** https://naeemk10.github.io/IOC-sentinel

**Description:** IOC Sentinel is a bulk threat intelligence scanner for security analysts. 
It checks IPs, domains, URLs and file hashes against VirusTotal, AbuseIPDB and 
AlienVault OTX APIs. Built for SOC teams to analyze multiple IOCs at once.

<img width="1242" height="1276" alt="image" src="https://github.com/user-attachments/assets/546aec1c-0d5e-41e1-b4fb-8f0d04add638" />

## Important checklist:
```
✅ All boxes changed from [ ] to [x]
✅ Live URL included
✅ Description explains it's security/dev tool
✅ Not commercial use ✅

