### PR TITLE
add acmecorp.is-a.dev

### DIFF
--- a/domains/acmecorp.json
+++ b/domains/acmecorp.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "agentabcsystem"
+  },
+  "record": {
+    "CNAME": "agentabcsystem.github.io"
+  }
+}


### PR DESCRIPTION
Registering acmecorp.is-a.dev for Acme Corp team workspace (GitHub Pages CNAME).