### PR TITLE
Add tesla-destination.is-a.dev

### DIFF
--- a/domains/tesla-destination.json
+++ b/domains/tesla-destination.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "junghwan-han",
+    "email": "sporthjh@gmail.com"
+  },
+  "record": {
+    "CNAME": "junghwan-han.github.io"
+  }
+}


### PR DESCRIPTION
Adding subdomain tesla-destination.is-a.dev pointing to junghwan-han.github.io (Tesla free destination charger list for South Korea)