### PR TITLE
chore: add mining.is-a-dev

### DIFF
--- a/domains/mining.json
+++ b/domains/mining.json
@@ -1,6 +1,6 @@
 {
   "owner": {
-    "username": "kutaelee",
+    "username": "kutaelee0127-cell",
     "email": "kutaelee0@gmail.com"
   },
   "records": {

--- a/domains/mining.json
+++ b/domains/mining.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "kutaelee",
+    "email": "kutaelee0@gmail.com"
+  },
+  "records": {
+    "CNAME": "kutaelee.iptime.org"
+  }
+}


### PR DESCRIPTION
- [x] Domain file is in the correct location and format
- [x] JSON is valid
- [x] The PR only contains the domain file for my project
- [x] DNS target is set to a publicly reachable URL
- [x] Email is valid and matches account intent

### Domain(s)
- `mining.is-a.dev`

### DNS Record(s)
```json
{"CNAME":"kutaelee.iptime.org"}
```

### Record owner
- `owner.username`: `kutaelee0127-cell`
- `owner.email`: `kutaelee0@gmail.com`

### Additional context
- Recreated PR after previous rejection due username mismatch.
- Runtime service runs on port `31234` and is accessed via CNAME target `kutaelee.iptime.org`.
