### PR TITLE
Add _vercel TXT record for Vercel verification (domain already approved)

### DIFF
--- a/domains/_vercel.victork.json
+++ b/domains/_vercel.victork.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "yVictorK",
+        "email": "dev.victork@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=victork.is-a.dev,41556d096081533b6ae1"
+    }
+}

--- a/domains/victork.json
+++ b/domains/victork.json
@@ -4,6 +4,9 @@
     "email": "dev.victork@gmail.com"
   },
   "records": {
-    "CNAME": "victorkossmann.vercel.app"
+    "CNAME": "victorkossmann.vercel.app",
+    "TXT": {
+      "_vercel": "vc-domain-verify=victork.is-a.dev,41556d096081533b6ae1"
+    }
   }
 }

--- a/domains/victork.json
+++ b/domains/victork.json
@@ -1,12 +1,9 @@
-{
-  "owner": {
-    "username": "yVictorK",
-    "email": "dev.victork@gmail.com"
-  },
-  "records": {
-    "CNAME": "victorkossmann.vercel.app",
-    "TXT": {
-      "_vercel": "vc-domain-verify=victork.is-a.dev,41556d096081533b6ae1"
-    }
-  }
+{ 
+   "owner": { 
+     "username": "yVictorK", 
+     "email": "dev.victork@gmail.com" 
+   }, 
+   "records": { 
+     "CNAME": "victorkossmann.vercel.app" 
+   } 
 }


### PR DESCRIPTION
The domain was already approved, but Vercel requires a TXT verification record.

This PR adds the "_vercel" TXT record required for domain ownership verification so the domain can be linked to my Vercel project.