### PR TITLE
Register novahq.is-a.dev

### DIFF
--- a/domains/novahq.json
+++ b/domains/novahq.json
@@ -1,0 +1,11 @@
+{
+  "description": "Nova HQ - AI Agent Dashboard",
+  "repo": "https://github.com/98kiran",
+  "owner": {
+    "username": "98kiran",
+    "email": "98kirans@gmail.com"
+  },
+  "records": {
+    "A": ["45.76.56.139"]
+  }
+}


### PR DESCRIPTION
### Domain Registration

**Subdomain:** novahq.is-a.dev
**Description:** Nova HQ - AI Agent Dashboard
**Record Type:** A
**Target:** 45.76.56.139

This domain will be used for a personal AI agent management dashboard.