### PR TITLE
add pienoh.is-a.dev

### DIFF
--- a/domains/pienoh.json
+++ b/domains/pienoh.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "YarinCardillo",
+    "email": "yarin.cardillo@icloud.com"
+  },
+  "records": {
+    "A": ["46.62.195.228"]
+  }
+}


### PR DESCRIPTION
## Domain Request

**Domain:** `pienoh.is-a.dev`  
**Owner:** @YarinCardillo  
**Record type:** A  
**IP:** `46.62.195.228`

This domain will host [Pienoh](https://github.com/YarinCardillo/pienoh-app), a mobile-first web app showing the cheapest fuel stations in Italy using MIMIT open data.