### PR TITLE
fix(workflow-builder.lunatiee): change CNAME to A records

### DIFF
--- a/domains/workflow-builder.lunatiee.json
+++ b/domains/workflow-builder.lunatiee.json
@@ -6,8 +6,7 @@
         "email": "lunatie@gmail.com"
     },
     "records": {
-        "CNAME": "workflow-builder-web-qtkckv6l3a-an.a.run.app",
+        "A": ["216.239.32.21", "216.239.34.21", "216.239.36.21", "216.239.38.21"],
         "TXT": ["google-site-verification=IvWiVgnwCebsWyWF0KRub6-zxOK15_bSpZKhpX4YaXE"]
-    },
-    "proxied": true
+    }
 }


### PR DESCRIPTION
Change DNS records from CNAME+proxied to A records for Google Cloud Run SSL certificate provisioning.

- Remove CNAME record and proxied flag
- Add A records pointing to Google Cloud Run IPs (216.239.32.21, 216.239.34.21, 216.239.36.21, 216.239.38.21)
- Keep TXT record for domain verification