### PR TITLE
Add kaosmp.json for domain configuration

### DIFF
--- a/domains/kaosmp.json
+++ b/domains/kaosmp.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "NotKao"
+  },
+  "record": {
+    "CNAME": "silver-thinks.gl.joinmc.link"
+  }
+}


### PR DESCRIPTION
Requesting domain: kaosmp.is-a.dev

CNAME → silver-thinks.gl.joinmc.link

This will be used for my Minecraft server.