### PR TITLE
[codex] add bishal domain

### DIFF
--- a/domains/bishal.json
+++ b/domains/bishal.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "ZenderGoD"
+  },
+  "records": {
+    "URL": "https://github.com/bishalbanerjee"
+  }
+}

--- a/domains/bishal.json
+++ b/domains/bishal.json
@@ -3,6 +3,6 @@
     "username": "ZenderGoD"
   },
   "records": {
-    "URL": "https://github.com/bishalbanerjee"
+    "URL": "https://github.com/ZenderGoD"
   }
 }


### PR DESCRIPTION
## Summary

This pull request registers `bishal.is-a.dev` in the is-a.dev domain registry.

The change adds a new `domains/bishal.json` record owned by `ZenderGoD` and configures the subdomain as an HTTP redirect to `https://github.com/bishalbanerjee`.

## Why this change is needed

Without a domain record in the registry, `bishal.is-a.dev` cannot be provisioned or published through the project workflow. Adding the record allows the maintainers to review and merge the requested subdomain so it can go live after DNS publish.

## Root cause

The subdomain did not exist in the registry, so there was no corresponding JSON record for the publishing pipeline to validate and deploy.

## Fix

This change adds the required domain registration file with the minimum valid schema for the project:

- `owner.username` is set to `ZenderGoD` so the PR author and file ownership rules match the repository CI checks.
- `records.URL` redirects the subdomain to `https://github.com/bishalbanerjee`.

## Validation

- Ran `npm test` successfully in the repository after adding the domain record.
