### PR TITLE
Register daffakaryudi.is-a.dev

### DIFF
--- a/domains/daffakaryudi.json
+++ b/domains/daffakaryudi.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "KeyCode17"
+  },
+  "records": {
+    "A": ["103.197.191.30"]
+  }
+}

--- a/domains/daffakaryudi.json
+++ b/domains/daffakaryudi.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "KeyCode17"
+    "username": "KeyCode17",
+    "email": "m.daffa.karyudi@gmail.com"
   },
   "records": {
     "A": ["103.197.191.30"]


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: daffakaryudi.is-a.dev
- **Record Type**: A
- **Target**: 103.197.191.30

### Checklist
- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

### Preview

Live site: http://103.197.191.30/
<img width="1920" height="1006" alt="image" src="https://github.com/user-attachments/assets/fb56f33a-4cb1-4c0d-a274-f797e7f00943" />
> Developer portfolio built with Rust + WebAssembly (Dioxus framework), hosted on NixOS VPS.