### PR TITLE
Register ai-pdf-toolkit.is-a.dev

### DIFF
--- a/domains/_vercel.ai-pdf-toolkit.json
+++ b/domains/_vercel.ai-pdf-toolkit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vkristof1995",
+        "email": "v.kristof1995@gmail.com"
+    },
+    "records": {
+        "TXT": ["vc-domain-verify=ai-pdf-toolkit.is-a.dev,3b9f5a906549f809a8fd"]
+    }
+}

--- a/domains/ai-pdf-toolkit.json
+++ b/domains/ai-pdf-toolkit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vkristof1995",
+        "email": "v.kristof1995@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
## Domain Registration

**Subdomain:** ai-pdf-toolkit.is-a.dev

**Purpose:** AI-powered PDF toolkit - summarize, chat with, and extract data from PDFs.

**Website:** Currently live at https://ai-pdf-toolkit-ten.vercel.app

**Records:**
- A record pointing to Vercel (216.198.79.1)
- TXT verification record for Vercel domain ownership