### PR TITLE
Register prompt-daily.is-a.dev

### DIFF
--- a/domains/prompt-daily.json
+++ b/domains/prompt-daily.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "gigaglobalstudio-lgtm",
+        "email": "gigaglobalstudio@gmail.com"
+    },
+    "description": "AI news site - Daily AI news updates in Korean",
+    "records": {
+        "CNAME": "gigaglobalstudio-lgtm.github.io"
+    }
+}


### PR DESCRIPTION
## Domain Registration Request

**Subdomain:** prompt-daily.is-a.dev

**Description:** AI news site - Daily AI news updates in Korean (Prompt Daily)

**Repository:** https://github.com/gigaglobalstudio-lgtm/prompt-daily

**Live site:** https://gigaglobalstudio-lgtm.github.io/prompt-daily/

### Checklist
- [x] I have read the documentation
- [x] My site has meaningful content
- [x] CNAME file is configured in my repository
- [x] This is for a legitimate project