### PR TITLE
Add partnerai.is-a.dev

### DIFF
--- a/domains/partnerai.json
+++ b/domains/partnerai.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "jwchmodx"
+  },
+  "records": {
+    "A": ["127.0.0.1"]
+  }
+}


### PR DESCRIPTION
## Description

**partnerai.is-a.dev** — Partner AI Dashboard

A private dashboard for managing partner interviews, tasks, and meeting records for an AI co-founder assistant product.

## Domain

- Subdomain: `partnerai.is-a.dev`
- Owner: [@jwchmodx](https://github.com/jwchmodx)

## Records

```json
{
  "owner": {
    "username": "jwchmodx"
  },
  "records": {
    "A": ["127.0.0.1"]
  }
}
```

> DNS records will be updated to the production server once the domain is approved.