### PR TITLE
Fix: pmolinav.json - Update TXT record for Vercel domain verification

### DIFF
--- a/domains/_vercel.pmolinav.json
+++ b/domains/_vercel.pmolinav.json
@@ -4,6 +4,6 @@
         "email": "trastornillo@gmail.com"
     },
     "records": {
-        "TXT": "vc-domain-verify=is-a.dev,45b1318da514baee0de2"
+        "TXT": "vc-domain-verify=pmolinav.is-a.dev,7a1225b68b009a37af02"
     }
 }


### PR DESCRIPTION
Sorry for the inconvenience. 
I put a wrong argument previously for Vercel domain.
This is related to already merged PR:
https://github.com/is-a-dev/register/pull/34120

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. -->
https://pmolinav-portfolio.vercel.app/
<img width="1800" height="779" alt="image" src="https://github.com/user-attachments/assets/93fc8b0b-6297-400e-a029-57656d7c78e0" />
