### PR TITLE
add agentlab.is-a.dev

### DIFF
--- a/domains/agentlab.json
+++ b/domains/agentlab.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "SoftwareValete",
+    "email": "mdrezden@gmail.com"
+  },
+  "records": {
+    "A": ["34.10.210.160"]
+  }
+}


### PR DESCRIPTION
## Description
Registering `agentlab.is-a.dev` for a Fetch.ai AI agents API platform — three specialized developer tools (code context analysis, context compression, AI chat teleportation) available via REST API, Python SDK, and Claude MCP.

## Preview
**Live website:** https://agentslab.duckdns.org (same server, same content — final domain will be agentlab.is-a.dev)

## Checklist
- [x] I have read and agree to the [terms of service](https://is-a.dev/terms)
- [x] I have read the [contributing guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md)
- [x] My domain is being used for a **development** project
- [x] My subdomain JSON is valid

## Details
- **Owner:** SoftwareValete
- **Domain:** agentlab.is-a.dev  
- **Record:** A → 34.10.210.160 (GCP VM, always-free tier)
- **Use case:** Developer tools API — code context slimming, LLM context compression, AI chat history teleportation
