### PR TITLE
Register iappem.is-a.dev

### DIFF
--- a/domains/iappem.json
+++ b/domains/iappem.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "radz-z",
+        "email": ""
+    },
+    "records": {
+        "CNAME": "radz-z.github.io"
+    }
+}


### PR DESCRIPTION
## Subdomain Registration

- **Subdomain:** iappem.is-a.dev
- **Record Type:** CNAME
- **Target:** radz-z.github.io

### Website Preview
The website is live at: https://radz-z.github.io/iappem-website/

It is a static website for the IAP Chapter on Pediatric Emergency Medicine (IAP PEM) - an Indian medical organization focused on improving pediatric emergency care.

Made with [Cursor](https://cursor.com)