### PR TITLE
Add operava.is-a.dev

### DIFF
--- a/domains/operava.json
+++ b/domains/operava.json
@@ -1,0 +1,11 @@
+{
+  "description": "Operava website on Render",
+  "owner": {
+    "username": "mohamedemam0",
+    "email": "mohamedemam0@outlook.com"
+  },
+  "records": {
+    "CNAME": "operava.onrender.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Requesting operava.is-a.dev pointing to operava.onrender.com for the Operava website. Note: this is for a small software studio website, so maintainers should feel free to reject if it does not fit current commercial-use policy.