### PR TITLE
Add mosyclara.is-a.dev domain

### DIFF
--- a/domains/mosyclara.json
+++ b/domains/mosyclara.json
@@ -1,0 +1,17 @@
+{
+  "description": "AI Assistant Domain",
+  "domain": "mosyclara",
+  "owner": "mosyclara",
+  "record": {
+    "A": [
+      "185.199.108.153"
+    ],
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  }
+}


### PR DESCRIPTION
Adding my domain for AI assistant service.

- **Domain**: mosyclara.is-a.dev
- **Owner**: mosyclara
- **Purpose**: AI assistant service