### PR TITLE
Add dizaster.is-a.dev — self-hosted Headscale VPN control plane

### DIFF
--- a/domains/dizaster.json
+++ b/domains/dizaster.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jaguar999paw-droid",
+    "email": "jaguar999paw@gmail.com"
+  },
+  "records": {
+    "CNAME": "communication-bishop-ought-driving.trycloudflare.com"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. -->
**Live URL:** https://communication-bishop-ought-driving.trycloudflare.com/health

Self-hosted [Headscale](https://github.com/juanfont/headscale) VPN control plane — open-source Tailscale coordination server. Personal dev infrastructure project.

**Health check response:**
{"status":"pass"}

Stack: Headscale 0.28 · Cloudflare Tunnel · Caddy · Docker Compose · Ubuntu 22.04