### PR TITLE
Fix mosyclara.is-a.dev domain registration

### DIFF
--- a/domains/mosyclara.json
+++ b/domains/mosyclara.json
@@ -1,8 +1,8 @@
 {
-  "description": "AI Assistant Domain",
-  "domain": "mosyclara",
-  "owner": "mosyclara",
-  "record": {
+  "owner": {
+    "username": "mosyclara"
+  },
+  "records": {
     "A": [
       "185.199.108.153"
     ],
@@ -13,5 +13,6 @@
     "TXT": [
       "v=spf1 include:spf.improvmx.com ~all"
     ]
-  }
+  },
+  "proxied": true
 }

--- a/domains/mosyclara.json
+++ b/domains/mosyclara.json
@@ -1,0 +1,17 @@
+{
+  "description": "AI Assistant Domain",
+  "domain": "mosyclara",
+  "owner": "mosyclara",
+  "record": {
+    "A": [
+      "185.199.108.153"
+    ],
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Fixing the domain file to match the current is-a.dev schema.

## Changes
- use required `owner.username` object
- use required `records` field instead of deprecated `record`
- remove invalid custom fields
- keep GitHub Pages A record and email records

## Preview
Planned usage: personal AI assistant / API gateway domain.