### PR TITLE
Add verity.is-a.dev domain

### DIFF
--- a/domains/verity.json
+++ b/domains/verity.json
@@ -1,0 +1,11 @@
+{
+  "description": "Verity — free verified news app",
+  "repo": "https://github.com/reshma-cassim-cell/verity",
+  "owner": {
+    "username": "reshma-cassim-cell",
+    "email": "reshma.cassim@gmail.com"
+  },
+  "record": {
+    "CNAME": "verity-sable.vercel.app"
+  }
+}


### PR DESCRIPTION
Registering verity.is-a.dev for Verity — a free, ad-free, trust-scored news app that helps users identify real vs fake news. Live at verity-sable.vercel.app