### PR TITLE
Register aidigest.is-a-dev

### DIFF
--- a/domains/aidigest.json
+++ b/domains/aidigest.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "talionwar",
+    "email": "cyberaudiomind@gmail.com"
+  },
+  "records": {
+    "A": ["89.167.26.29"]
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** aidigest.is-a-dev
- **Record type:** A record → 89.167.26.29
- **Purpose:** AI news aggregator and daily digest — aggregates RSS feeds from top AI/dev sources and generates daily summaries
- **Live at:** Currently running at digest.namiyoga.es, migrating to aidigest.is-a-dev