### PR TITLE
Register rororealtygroups.is-a.dev

### DIFF
--- a/domains/rororealtygroups.json
+++ b/domains/rororealtygroups.json
@@ -1,10 +1,10 @@
 {
+  "description": "RoRo Realty Groups - Real Estate Due Diligence Platform",
   "owner": {
     "username": "AkhilaK94",
     "email": "kancharana.akhila@gmail.com"
   },
-  "description": "RoRo Realty Groups - Real Estate Due Diligence Platform",
-  "record": {
+  "records": {
     "A": ["76.76.21.21"]
   }
 }

--- a/domains/rororealtygroups.json
+++ b/domains/rororealtygroups.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "AkhilaK94",
+    "email": "kancharana.akhila@gmail.com"
+  },
+  "description": "RoRo Realty Groups - Real Estate Due Diligence Platform",
+  "record": {
+    "A": ["76.76.21.21"]
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Domain**: rororealtygroups.is-a.dev
- **Purpose**: RoRo Realty Groups - Real Estate Due Diligence Platform
- **Record Type**: A record pointing to 76.76.21.21