### PR TITLE
Register gistgrowth.is-a.dev and wordsmith.is-a.dev

### DIFF
--- a/domains/gistgrowth.json
+++ b/domains/gistgrowth.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "bigzitod"
+  },
+  "records": {
+    "CNAME": "ghs.googlehosted.com"
+  }
+}

--- a/domains/wordsmith.json
+++ b/domains/wordsmith.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "bigzitod"
+  },
+  "records": {
+    "CNAME": "ghs.googlehosted.com"
+  }
+}


### PR DESCRIPTION
## Subdomain Registration

Registering two subdomains for development projects hosted on Google Cloud Run:

### gistgrowth.is-a.dev
- **Project:** Gist Growth — autonomous AI growth agent platform for SaaS products
- **CNAME:** `ghs.googlehosted.com` (Google Cloud Run)

### wordsmith.is-a.dev
- **Project:** WordSmith — AI-powered copy editor that suggests precise word replacements in context
- **CNAME:** `ghs.googlehosted.com` (Google Cloud Run)

Both are active development projects with deployed backends and frontends.