### PR TITLE
Register projectcyan.is-a.dev

### DIFF
--- a/domains/projectcyan.json
+++ b/domains/projectcyan.json
@@ -1,0 +1,11 @@
+{
+  "description": "Cyan.dev — Security tools, Minecraft launcher, terminal, and more by Cyan",
+  "repo": "https://github.com/sealanide-commits/cyan-website",
+  "owner": {
+    "username": "sealanide-commits",
+    "email": "sealanide@gmail.com"
+  },
+  "records": {
+    "A": ["5.189.188.231"]
+  }
+}


### PR DESCRIPTION
### Domain Registration

- **Subdomain:** projectcyan.is-a.dev
- **Record type:** A
- **Target:** 5.189.188.231

Portfolio site for Cyan — security tools, Minecraft launcher, themed terminal, and more.

**Preview:** https://sealanide-commits.github.io/cyan-website/