### PR TITLE
Register nvitlam.is-a.dev

### DIFF
--- a/domains/nvitlam.json
+++ b/domains/nvitlam.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+          "username": "NVitlam",
+          "email": "nadavvitlam@gmail.com"
+    },
+    "records": {
+          "A": ["151.145.94.171"]
+    }
+}


### PR DESCRIPTION
<!-- YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED! -->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This domain will host the ReaP Alliance Dashboard, a Flask web application for managing a gaming alliance. The site features Google OAuth login and displays alliance data from Google Sheets.

**Link:** http://151.145.94.171 (will be accessible at nvitlam.is-a.dev once DNS propagates)