### PR TITLE
Register tankobon.is-a.dev

### DIFF
--- a/domains/tankobon.json
+++ b/domains/tankobon.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "zachleiker-afk",
+    "email": ""
+  },
+  "record": {
+    "A": ["52.14.24.27"]
+  }
+}


### PR DESCRIPTION
## Domain Registration

**Domain:** `tankobon.is-a.dev`

**Description:** Tankobon is a social manga tracking app built with React Native/Expo and Express.js + PostgreSQL. Users can search manga, track reading progress, rate titles, and follow other readers.

**Repository:** https://github.com/zachleiker-afk/tankobon

**Record Type:** A record pointing to `52.14.24.27` (AWS EC2 instance)