### PR TITLE
Add TXT record for domain verification

### DIFF
--- a/domains/debbouz.json
+++ b/domains/debbouz.json
@@ -4,6 +4,9 @@
     "email": "debbouzamine@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "CNAME": "cname.vercel-dns.com",
+    "TXT": [
+      "vc-domain-verify=debbouz.is-a.dev,a684bc172ab158439433"
+    ]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.

## Website Preview

https://debbouz-amine.vercel.app/

This is an update to add a TXT verification record for Vercel domain ownership verification of debbouz.is-a.dev.