### PR TITLE
Register hyunsu.is-a.dev

### DIFF
--- a/domains/_vercel.hyunsu.json
+++ b/domains/_vercel.hyunsu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ehs208",
+        "email": "ehs208@naver.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=hyunsu.is-a.dev,ce6fd4f04bdc3d3236a4"
+    }
+}

--- a/domains/hyunsu.json
+++ b/domains/hyunsu.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ehs208",
+        "email": "ehs208@naver.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
### Domain Registration

- **Subdomain**: hyunsu.is-a.dev
- **Record Type**: CNAME → `cname.vercel-dns.com`
- **Verification**: `_vercel.hyunsu.json` (TXT record for Vercel domain verification)
- **Purpose**: Personal portfolio site hosted on Vercel