### PR TITLE
Register bond-checker.is-a.dev

### DIFF
--- a/domains/bond-checker.json
+++ b/domains/bond-checker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "zulqar-abbas",
+    "email": "zulqarnainabbas001@gmail.com"
+  },
+  "record": {
+    "CNAME": "d271v5ocgmudsj.cloudfront.net"
+  }
+}

--- a/domains/bond-checker.json
+++ b/domains/bond-checker.json
@@ -3,7 +3,7 @@
     "username": "zulqar-abbas",
     "email": "zulqarnainabbas001@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "d271v5ocgmudsj.cloudfront.net"
   }
 }


### PR DESCRIPTION
## Subdomain Registration

**Subdomain:** bond-checker.is-a.dev

**Record:** CNAME → d271v5ocgmudsj.cloudfront.net (AWS CloudFront)

**Purpose:** Prize Bond Checker — a web app for checking Pakistani prize bonds against the National Savings website.

**Repository:** https://github.com/zulqar-abbas/bond-checker