### PR TITLE
Register lobotskiy.is-a.dev

### DIFF
--- a/domains/lobotskiy.json
+++ b/domains/lobotskiy.json
@@ -1,0 +1,11 @@
+{
+  "description": "Personal bio page of Mikhail Lobotskiy",
+  "repo": "https://github.com/7758800-hash/7758800-hash.github.io",
+  "owner": {
+    "username": "7758800-hash",
+    "email": "7758800@gmail.com"
+  },
+  "record": {
+    "CNAME": "7758800-hash.github.io"
+  }
+}


### PR DESCRIPTION
### Domain Registration

- **Domain**: lobotskiy.is-a.dev
- **Record Type**: CNAME
- **Target**: 7758800-hash.github.io
- **Description**: Personal bio page of Mikhail Lobotskiy, CEO of Cloud.ru