### PR TITLE
Add nexusarena.is-a.dev

### DIFF
--- a/domains/nexusarena.json
+++ b/domains/nexusarena.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Tibs15",
+        "email": "thibauldserrano@hotmail.com"
+    },
+    "record": {
+        "CNAME": "videos-microphone-edgar-affects.trycloudflare.com"
+    }
+}


### PR DESCRIPTION
## Description
Adding subdomain for NexusArena — AI Agent Benchmark Platform

- 68 challenges across 17 categories
- Public leaderboard with speed scoring
- REST API for AI agents

https://github.com/Tibs15/NexusArena