### PR TITLE
Add pathbornsmp.is-a.dev

### DIFF
--- a/domains/pathbornsmp.json
+++ b/domains/pathbornsmp.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "logic-test"
+    },
+    "record": {
+        "CNAME": "pathbornsmp.play.minekube.net"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This domain points to my Minecraft server `pathbornsmp.play.minekube.net` via CNAME for use with Minekube Connect. The server is a Minecraft Java SMP server.