### PR TITLE
Register trading-signals.is-a.dev

### DIFF
--- a/domains/trading-signals.json
+++ b/domains/trading-signals.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "wayzeek",
+    "email": "wayzeek@users.noreply.github.com"
+  },
+  "description": "AI-optimized compound trading signals API via MPP (Machine Payments Protocol)",
+  "records": {
+    "A": ["144.217.82.158"]
+  }
+}


### PR DESCRIPTION
### Domain Registration

**Domain:** `trading-signals.is-a.dev`
**Record:** A -> 144.217.82.158

AI-powered trading signals API that accepts MPP payments on Tempo blockchain.