### PR TITLE
Register cooked.is-a.dev

### DIFF
--- a/domains/cooked.json
+++ b/domains/cooked.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "0xyrn",
+    "email": "noreply@github.com"
+  },
+  "record": {
+    "CNAME": "cooked-meter-six.vercel.app"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: cooked.is-a.dev
- **Record type**: CNAME
- **Target**: cooked-meter-six.vercel.app

Simple static site hosted on Vercel.