### PR TITLE
Register rawdnahealth.is-a.dev

### DIFF
--- a/domains/rawdnahealth.json
+++ b/domains/rawdnahealth.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "YuanisSalatne",
+    "email": "support@rawdnahealthanalyses.com"
+  },
+  "description": "Free, open-source DNA health analysis tool. Privacy-first genetic insights.",
+  "repo": "https://github.com/YuanisSalatne/Raw-DNA-Analyses",
+  "records": {
+    "CNAME": "genome-insight-1034326027184.us-central1.run.app"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** rawdnahealth.is-a.dev
- **Record type:** CNAME
- **Target:** genome-insight-1034326027184.us-central1.run.app

## About

Free, open-source DNA health analysis tool built with Flutter Web. Users can upload raw DNA files from 23andMe, AncestryDNA, MyHeritage, or FTDNA and get instant health insights across 200+ genetic markers. All processing happens client-side — no data leaves the browser.

## Preview

Live app: https://genome-insight-1034326027184.us-central1.run.app/

- **Repository:** https://github.com/YuanisSalatne/Raw-DNA-Analyses
- **License:** MIT