### PR TITLE
#35128. Create anji.json for portfolio details

### DIFF
--- a/domains/anji.json
+++ b/domains/anji.json
@@ -1,0 +1,12 @@
+{
+    "description": "Portfolio of Anji",
+    "repo": "https://github.com/ianjiteshan/anji.github.io",
+    "owner": {
+        "username": "ianjiteshan",
+        "email": "anjitesh1976@gmail.com"
+    },
+    "record": {
+        "CNAME": "ianjiteshan.github.io",
+        "TXT": ["0e67fef7c1d11e100c41c63f081423"]
+    }
+}


### PR DESCRIPTION
Add JSON configuration for Anji portfolio (Reclaiming Hijacked Domain #35128)

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). 
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). 
- [x] My website is **reachable** and **completed**. 
- [x] My website is **software development** related. 
- [x] My website is **not for commercial use**. 
- [x] I have provided contact information in the `owner` key. 
- [x] I have provided a preview of my website below. 


# Website Preview
<!-- Provide a link AND screenshot of your website below. -->

**Link:** https://ianjiteshan.github.io/anji.github.io/
<img width="1680" height="1050" alt="Screenshot 2026-03-26 at 12 33 44 PM" src="https://github.com/user-attachments/assets/6bc30041-a2b6-431e-af47-44de3e59df40" />

**Note to maintainers:** I am the original owner of `anji.is-a.dev`. My domain suffered a GitHub Pages Subdomain Takeover and was erroneously serving gambling content (which was reported and taken down in issue #35128). I have now locked the domain down securely by adding the GitHub Pages TXT verification record to this PR configuration so it can never be hijacked again. Please approve so I can restore my portfolio URL. Thank you!

