### PR TITLE
Register milestrack.is-a.dev

### DIFF
--- a/domains/_dmarc.milestrack.json
+++ b/domains/_dmarc.milestrack.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "guimatheus92",
+    "email": "guilherme_matheus12@hotmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/milestrack.json
+++ b/domains/milestrack.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "guimatheus92",
+    "email": "guilherme_matheus12@hotmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/resend._domainkey.milestrack.json
+++ b/domains/resend._domainkey.milestrack.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "guimatheus92",
+    "email": "guilherme_matheus12@hotmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCnJZa/Q4QNxQb6gjf7WY9uqqAKPYnn5ErpI/GY3Sk9K4uN7naPhsblK7sS9XUtKjCyluv5uuG+86hp3F3jGQYOGQulgk7hGXngmzOAMVVIPC71cxRE6M6xTziMqSzcppIA+ya7HNN/MIf+LynO35kQnzCnxJ7Uz+Iopt87agRpNwIDAQAB"
+  }
+}

--- a/domains/send.milestrack.json
+++ b/domains/send.milestrack.json
@@ -1,0 +1,15 @@
+{
+  "owner": {
+    "username": "guimatheus92",
+    "email": "guilherme_matheus12@hotmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.sa-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
## Subdomain Registration

**Domain:** `milestrack.is-a.dev`

### Purpose
[MilesTrack](https://github.com/guimatheus92/MilesTrack) is an open-source platform for tracking airline miles/points market in Brazil. The subdomain will host the web application and support transactional email notifications via Resend.

### Files
- `milestrack.json` — CNAME to Vercel for web hosting
- `resend._domainkey.milestrack.json` — DKIM record for Resend email verification
- `send.milestrack.json` — MX + SPF records for Resend email sending
- `_dmarc.milestrack.json` — DMARC policy record

### Owner
- GitHub: [@guimatheus92](https://github.com/guimatheus92)