### PR TITLE
feat: add portal-hub.is-a.dev

### DIFF
--- a/domains/portal-hub.json
+++ b/domains/portal-hub.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "taemire",
+    "email": "msjang@inca.co.kr"
+  },
+  "record": {
+    "A": ["192.0.2.1"]
+  },
+  "description": "TSGroup Portal Hub - Operations portal for technical support and issue management"
+}


### PR DESCRIPTION
## Description
Adding `portal-hub.is-a.dev` for TSGroup Portal Hub project.

## Record
- **Type**: A record (placeholder `192.0.2.1` — will update with OCI instance IP once provisioned)

## Ownership
- GitHub: [@taemire](https://github.com/taemire)