### PR TITLE
Register locallyuncensored.is-a.dev

### DIFF
--- a/domains/locallyuncensored.json
+++ b/domains/locallyuncensored.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "PurpleDoubleD",
+    "email": "purpai@agentmail.to"
+  },
+  "record": {
+    "CNAME": "purpledoubled.github.io"
+  }
+}


### PR DESCRIPTION
Registering locallyuncensored.is-a.dev for the open-source project Locally Uncensored.

- **GitHub:** https://github.com/PurpleDoubleD/locally-uncensored
- **Record type:** CNAME -> purpledoubled.github.io
- **Description:** All-in-one local AI app for uncensored chat, image generation, and video generation