### PR TITLE
Add luminia-hub.is-a.dev

### DIFF
--- a/domains/luminia-hub.json
+++ b/domains/luminia-hub.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Moon-Havoc"
+  },
+  "records": {
+    "CNAME": "md8my5yf.up.railway.app"
+  }
+}


### PR DESCRIPTION
Adds luminia-hub.is-a.dev pointing to the Railway deployment for Luminia Hub.