### PR TITLE
Add startupforge.is-a.dev

### DIFF
--- a/domains/startupforge.json
+++ b/domains/startupforge.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Azemblage",
+    "email": "martin.agno@outlook.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Hi, I'd like to register `startupforge.is-a.dev` for my digital agency website.

**Domain:** `startupforge.is-a.dev`
**Record:** `CNAME → cname.vercel-dns.com` (Vercel)
**Owner:** @Azemblage

The site is a professional web design & AI automation agency for UK local businesses, hosted on Vercel.