### PR TITLE
Add flagy.is-a.dev

### DIFF
--- a/domains/flagy.json
+++ b/domains/flagy.json
@@ -1,7 +1,6 @@
 {
   "$schema": "../schemas/domain.schema.json",
   "description": "homelab",
-  "domain": "flagy",
   "owner": {
     "username": "UsramFr"
   },

--- a/domains/flagy.json
+++ b/domains/flagy.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../schemas/domain.schema.json",
+  "description": "homelab",
+  "domain": "flagy",
+  "owner": {
+    "username": "UsramFr"
+  },
+  "record": {
+    "NS": [
+      "aria.ns.cloudflare.com",
+      "remy.ns.cloudflare.com"
+    ]
+  }
+}

--- a/domains/flagy.json
+++ b/domains/flagy.json
@@ -1,11 +1,11 @@
 {
   "$schema": "../schemas/domain.schema.json",
-  "description": "Homelab self-hosted infrastructure (Home Assistant, Portainer, NPM reverse proxy)",
+  "description": "Homelab self-hosted infrastructure (Home Assistant, Portainer, Cloudflare Tunnel)",
   "owner": {
     "username": "UsramFr",
     "email": "christophe@trillot.fr"
   },
   "records": {
-    "A": ["82.64.132.26"]
+    "CNAME": "6aa6d478-6e30-4426-a3c0-eae103b0487a.cfargotunnel.com"
   }
 }

--- a/domains/flagy.json
+++ b/domains/flagy.json
@@ -5,7 +5,7 @@
   "owner": {
     "username": "UsramFr"
   },
-  "record": {
+  "records": {
     "NS": [
       "aria.ns.cloudflare.com",
       "remy.ns.cloudflare.com"

--- a/domains/flagy.json
+++ b/domains/flagy.json
@@ -1,13 +1,11 @@
 {
   "$schema": "../schemas/domain.schema.json",
-  "description": "homelab",
+  "description": "Homelab self-hosted infrastructure (Home Assistant, Portainer, Cloudflare Tunnel)",
   "owner": {
-    "username": "UsramFr"
+    "username": "UsramFr",
+    "email": "christophe@trillot.fr"
   },
   "records": {
-    "NS": [
-      "aria.ns.cloudflare.com",
-      "remy.ns.cloudflare.com"
-    ]
+    "CNAME": "ced0f50b-ec7d-4a7b-8431-8a14fa0f2685.cfargotunnel.com"
   }
 }

--- a/domains/flagy.json
+++ b/domains/flagy.json
@@ -1,11 +1,11 @@
 {
   "$schema": "../schemas/domain.schema.json",
-  "description": "Homelab self-hosted infrastructure (Home Assistant, Portainer, Cloudflare Tunnel)",
+  "description": "Homelab self-hosted infrastructure (Home Assistant, Portainer, NPM reverse proxy)",
   "owner": {
     "username": "UsramFr",
     "email": "christophe@trillot.fr"
   },
   "records": {
-    "CNAME": "ced0f50b-ec7d-4a7b-8431-8a14fa0f2685.cfargotunnel.com"
+    "A": ["82.64.132.26"]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This subdomain points to my homelab self-hosted infrastructure via an A record (`82.64.132.26`) behind an Nginx Proxy Manager reverse proxy (Home Assistant mainly)

![Preview](https://flagy.is-a.dev)
<img width="684" height="656" alt="image" src="https://github.com/user-attachments/assets/64319a1e-8656-4353-abdd-9da252d3b32c" />


Contact: GitHub [@UsramFr](https://github.com/UsramFr) | Email: christophe@trillot.fr