### PR TITLE
feat: add otium-tram.is-a.dev

### DIFF
--- a/domains/otium-tram.json
+++ b/domains/otium-tram.json
@@ -3,7 +3,7 @@
     "username": "SebJulien-071334",
     "email": "sebastienjulien@gmx.fr"
   },
-  "record": {
+  "records": {
     "CNAME": "otium-viatis.vercel.app"
   }
 }

--- a/domains/otium-tram.json
+++ b/domains/otium-tram.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "SebJulien-071334",
+    "email": "sebastienjulien@gmx.fr"
+  },
+  "record": {
+    "CNAME": "otium-viatis.vercel.app"
+  }
+}


### PR DESCRIPTION
## Description

Registering `otium-tram.is-a.dev` for a PWA tram schedule app for Montpellier (France).

## Record

CNAME → `otium-viatis.vercel.app`

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md)
- [x] I have followed the [record format](https://github.com/is-a-dev/register/blob/main/RECORD_FORMAT.md)
- [x] My domain file is named correctly (`otium-tram.json`)
- [x] I own the GitHub account mentioned in the `owner.username` field