### PR TITLE
Register nihongovs.is-a.dev

### DIFF
--- a/domains/nihongovs.json
+++ b/domains/nihongovs.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "HumanCronAdmin"
+    },
+    "records": {
+        "CNAME": "humancronadmin.github.io"
+    }
+}

--- a/domains/nihongovs.json
+++ b/domains/nihongovs.json
@@ -1,6 +1,7 @@
 {
     "owner": {
-        "username": "HumanCronAdmin"
+        "username": "HumanCronAdmin",
+        "twitter": "petitedevlog"
     },
     "records": {
         "CNAME": "humancronadmin.github.io"


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live site:** https://humancronadmin.github.io/nihongo-vs/

NihongoVS is a free, open-source Japanese grammar comparison tool for language learners. It provides side-by-side grammar comparisons sorted by JLPT level, built with Astro.

**Repository:** https://github.com/HumanCronAdmin/nihongo-vs

![NihongoVS Preview](https://humancronadmin.github.io/nihongo-vs/og.png)