### PR TITLE
Add Vercel verification for ravikiran.is-a.dev

### DIFF
--- a/domains/_vercel.ravikiran.json
+++ b/domains/_vercel.ravikiran.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "padal1325454",
+    "email": "ravikiranpadalsagina@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=ravikiran.is-a.dev,1bee1de7bd7439574957"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://ravi-portfolio-lovat.vercel.app

![Portfolio Preview](https://opengraph.githubassets.com/00b7ee1551a31f3e237661e85dd93f46acee9ec2e0629d90533b5b34fd15991a/padal1325454/ravi-portfolio)

Adding `_vercel.ravikiran.json` for Vercel domain verification (separate file as per docs, not mixed with CNAME record).