### PR TITLE
Add capb.json for CAPB Pages subdomain redirect

### DIFF
--- a/domains/capb.json
+++ b/domains/capb.json
@@ -1,0 +1,39 @@
+{
+  "owner": {
+    "name": "Aarham-Super",
+    "email": "aarhamameen17@gmail.com"
+  },
+  "name": "CAPB Pages",
+  "description": "CAPB Pages (Captcha Both) is a personal software development hub and project showcase platform, hosting nested developer projects, interactive demos, and tutorials.",
+  "url": "https://capb.pages.dev/",
+  "screenshot": "https://i.imgur.com/1VrTyfK.jpeg",
+  "domains": [
+    {
+      "subdomain": "capb",
+      "target": "https://capb.pages.dev/",
+      "records": [
+        {
+          "type": "CNAME",
+          "name": "capb",
+          "target": "capb.pages.dev",
+          "ttl": 3600
+        },
+        {
+          "type": "A",
+          "name": "capb",
+          "target": "192.0.2.1",
+          "ttl": 3600
+        },
+        {
+          "type": "TXT",
+          "name": "capb",
+          "target": "verification=capb-pages",
+          "ttl": 3600
+        }
+      ]
+    }
+  ],
+  "type": "personal",
+  "tags": ["software development", "web tools", "developer portfolio", "Cloudflare Pages"],
+  "commercial": false
+}


### PR DESCRIPTION
<I agree to the Terms of Service and Privacy Policy.>

My file is following the domain structure.  
My website is reachable and completed.  
My website is software development related.  
My website is not for commercial use.  
I have provided contact information in the owner key.  
I have provided a preview of my website below.  

CAPB Pages (capb.is-a.dev) is a subdomain that redirects users to my main software development site: https://capb.pages.dev/.  

CAPB stands for “Captcha Both”, reflecting the site’s focus on providing interactive, developer-focused projects including:  

- Web automation  
- CAPTCHA verification tools  
- Session auditing utilities  
- Cloudflare Workers & Pages demos  

This subdomain is purely functional and non-commercial. Its only purpose is to redirect users to the main CAPB Pages site, which contains nested subdomains for each project.  

Owner Email: aarhamameen17@gmail.com  

Target URL: https://capb.pages.dev/  

Screenshot:  
![CAPB Pages Screenshot](https://i.imgur.com/XT9o9Cl.jpeg)