### PR TITLE
fix: add Vercel TXT verification record for adedesfrianto.is-a.dev

### DIFF
--- a/domains/adedesfrianto.json
+++ b/domains/adedesfrianto.json
@@ -6,6 +6,7 @@
     "email": "adedesfrianto@gmail.com"
   },
   "records": {
-    "CNAME": "portfolio-hub-ashy.vercel.app"
+    "A": ["216.198.79.1"],
+    "TXT": ["vc-domain-verify=adedesfrianto.is-a.dev,d0e1660b98ebabed0f07"]
   }
 }


### PR DESCRIPTION
Added A record (216.198.79.1) and TXT record for Vercel domain verification.

Previously only had CNAME pointing to old Vercel deployment. Updated to support domain verification on new Vercel account.

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. -->
<img width="1366" height="720" alt="570967829-0269438c-7d29-48ab-ad85-15e301cdb404" src="https://github.com/user-attachments/assets/c22484a2-14e3-4503-b351-64859d704169" />