### PR TITLE
Register frecuenciaglobal.is-a.dev

### DIFF
--- a/domains/_vercel.frecuenciaglobal.json
+++ b/domains/_vercel.frecuenciaglobal.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "59gray",
+    "email": "frecuenciag@outlook.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=frecuenciaglobal.is-a.dev,f0cc958055d8faebfde4"
+    ]
+  }
+}

--- a/domains/frecuenciaglobal.json
+++ b/domains/frecuenciaglobal.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "59gray",
+    "email": "frecuenciag@outlook.com"
+  },
+  "description": "Frecuencia Global - International analysis media project",
+  "records": {
+    "A": [
+      "216.198.79.1"
+    ]
+  }
+}


### PR DESCRIPTION
## Register frecuenciaglobal.is-a.dev

**Frecuencia Global** — International analysis media project focused on geopolitical analysis.

- **Hosting:** Vercel
- **A record:** `216.198.79.1`
- **TXT verification:** included in `_vercel.frecuenciaglobal.json`

### Website Preview

Live preview: https://frecuenciaglobal.vercel.app
<img width="1919" height="1079" alt="Screenshot 2026-04-05 120509" src="https://github.com/user-attachments/assets/1f659657-803c-49c0-94cf-221a56f6c413" />
