### PR TITLE
add nourin.is-a.dev

### DIFF
--- a/domains/nourin.json
+++ b/domains/nourin.json
@@ -5,7 +5,7 @@
         "username": "nourinawadd",
         "email": "nourinawad@gmail.com"
     },
-    "record": {
+    "records": {
         "A": ["89.168.117.165"]
     }
 }

--- a/domains/nourin.json
+++ b/domains/nourin.json
@@ -1,0 +1,11 @@
+{
+    "description": "SSH portfolio",
+    "repo": "https://github.com/nourinawadd/ssh-portfolio",
+    "owner": {
+        "username": "nourinawadd",
+        "email": "nourinawad@gmail.com"
+    },
+    "record": {
+        "A": ["89.168.117.165"]
+    }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

`nourin.is-a.dev` serves a landing page (index.html) hosted on the same server that directs visitors to an interactive terminal portfolio accessible over SSH.

Currently reachable at: `http://89.168.117.165`  
SSH portfolio: `ssh 89.168.117.165 -p 2323`

<img width="1135" height="988" alt="image" src="https://github.com/user-attachments/assets/23fe5277-e981-46ad-8aad-7f0df9f025cf" />

![ssh-portfolio-demo](https://github.com/user-attachments/assets/d73d0a74-a603-414e-b8a3-68abcaa8e373)