### PR TITLE
Add MX records for email forwarding (frecuenciaglobal.is-a.dev)

### DIFF
--- a/domains/_vercel.frecuenciaglobal.json
+++ b/domains/_vercel.frecuenciaglobal.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "59gray",
+    "email": "frecuenciag@outlook.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=frecuenciaglobal.is-a.dev,f0cc958055d8faebfde4"
+    ]
+  }
+}

--- a/domains/frecuenciaglobal.json
+++ b/domains/frecuenciaglobal.json
@@ -1,0 +1,25 @@
+{
+  "owner": {
+    "username": "59gray",
+    "email": "frecuenciag@outlook.com"
+  },
+  "description": "Frecuencia Global - Developer portfolio and international analysis project",
+  "records": {
+    "A": [
+      "216.198.79.1"
+    ],
+    "MX": [
+      {
+        "target": "mx1.forwardemail.net",
+        "priority": 10
+      },
+      {
+        "target": "mx2.forwardemail.net",
+        "priority": 20
+      }
+    ],
+    "TXT": [
+      "forward-email=contact:frecuenciag@outlook.com"
+    ]
+  }
+}


### PR DESCRIPTION
Add MX and TXT records for ForwardEmail.net email forwarding on frecuenciaglobal.is-a.dev.

- MX: mx1.forwardemail.net (priority 10)
- MX: mx2.forwardemail.net (priority 10)
- TXT: forward-email-site-verification-1na0P2KRja

Website preview: https://frecuenciaglobal.is-a.dev

![Website Preview](https://private-user-images.githubusercontent.com/268832868/573938085-555a234d-fa40-4f29-b2d1-6f3e7cf61c73.png)