### PR TITLE
add mathdrill.is-a.dev

### DIFF
--- a/domains/mathdrill.json
+++ b/domains/mathdrill.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "yure-py",
+    "email": "yuking08@hotmail.com"
+  },
+  "records": {
+    "A": ["129.153.156.50"]
+  }
+}


### PR DESCRIPTION
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**URL:** https://mathdrill-frontend.vercel.app/

MathDrill is a timed mental math training web app built with Angular 21 (frontend) and Spring Boot 3.5 (backend). It features three game modes: full multiplication table conquest, single table training, and infinite shuffle mode with mixed operations. The app tracks results and session history via a REST API backed by PostgreSQL.

![MathDrill screenshot](https://i.imgur.com/MebQNPm.png)