### PR TITLE
feat: add _vercel.debbouz.json for Vercel TXT domain verification

### DIFF
--- a/domains/_vercel.debbouz.json
+++ b/domains/_vercel.debbouz.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "brutalpanda1990-oss",
+    "email": "debbouzamine@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=debbouz.is-a.dev,a684bc172ab158439433"
+  }
+}

--- a/domains/debbouz.json
+++ b/domains/debbouz.json
@@ -4,6 +4,9 @@
     "email": "debbouzamine@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "CNAME": "cname.vercel-dns.com",
+    "TXT": [
+      "vc-domain-verify=debbouz.is-a.dev,a684bc172ab158439433"
+    ]
   }
 }

--- a/domains/debbouz.json
+++ b/domains/debbouz.json
@@ -4,9 +4,6 @@
     "email": "debbouzamine@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com",
-    "TXT": [
-      "vc-domain-verify=debbouz.is-a.dev,a684bc172ab158439433"
-    ]
+    "CNAME": "cname.vercel-dns.com"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.

## Website Preview

https://debbouz-amine.vercel.app/

This PR adds the `_vercel.debbouz.json` file as instructed by maintainer STICKnoLOGIC (PR #34859), to properly handle Vercel TXT domain ownership verification for `debbouz.is-a.dev`. Also reverts `debbouz.json` to CNAME only.