### PR TITLE
Use ImprovMX for arpan.is-a.dev mail

### DIFF
--- a/domains/arpan.json
+++ b/domains/arpan.json
@@ -4,6 +4,11 @@
     "email": "arpannn543@gmail.com"
   },
   "records": {
-    "CNAME": "c371e2dabd92431b.vercel-dns-017.com"
+    "A": ["76.76.21.21"],
+    "MX": [
+      { "target": "mx1.improvmx.com", "priority": 10 },
+      { "target": "mx2.improvmx.com", "priority": 20 }
+    ],
+    "TXT": "v=spf1 include:spf.improvmx.com ~all"
   }
 }


### PR DESCRIPTION
Summary:
- replace the root CNAME for arpan.is-a.dev with a Vercel-compatible A record so mail records can coexist
- add ImprovMX MX records and SPF to the root host
- keep _vercel.arpan.json unchanged for Vercel verification

Notes:
- this keeps the site on Vercel while enabling ImprovMX forwarding on the same hostname
- no Zoho-specific records are included in this change