### PR TITLE
Register venue-tracker.is-a.dev

### DIFF
--- a/domains/venue-tracker.json
+++ b/domains/venue-tracker.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "CyberWonder1",
+    "email": "logan.tiger65@gmail.com"
+  },
+  "record": {
+    "CNAME": "venue-tracker.logan-tiger65.workers.dev"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: venue-tracker.is-a.dev
- **Record Type**: CNAME
- **Target**: venue-tracker.logan-tiger65.workers.dev
- **Proxied**: Yes

FIFA World Cup 2026 venue tracking application hosted on Cloudflare Workers.