### PR TITLE
Register taqueriacalifornia.is-a.dev

### DIFF
--- a/domains/taqueriacalifornia.json
+++ b/domains/taqueriacalifornia.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "vxlume-s",
+    "email": "vxlume@proton.me"
+  },
+  "record": {
+    "CNAME": "vxlume-s.github.io"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Domain:** taqueriacalifornia.is-a.dev
- **Record type:** CNAME
- **Target:** vxlume-s.github.io
- **Purpose:** Landing page for Taqueria California food truck in Tulsa, OK