### PR TITLE
Register getson.is-a.dev

### DIFF
--- a/domains/getson.json
+++ b/domains/getson.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "abdussamet032",
+    "email": "abdussamet032@gmail.com"
+  },
+  "description": "son — Project switcher CLI & terminal workspace launcher",
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
### Domain Registration

**Subdomain:** getson.is-a.dev

**Record type:** CNAME
**Record value:** cname.vercel-dns.com

### Description

Landing page for [son](https://github.com/abdussamet032/son) — a project switcher CLI that opens recent repos in tmux, WezTerm, or iTerm2 terminal workspaces.

### Preview

Live site: https://website-vert-five-63.vercel.app

![son landing page preview](https://website-vert-five-63.vercel.app)

**Features:**
- Project discovery with frecency sorting
- Fuzzy search with fzf
- Multi-terminal support (iTerm2, tmux, WezTerm)
- Split-pane layouts, editor integration, startup hooks

### Checklist
- [x] File is in `domains/` directory
- [x] File is valid JSON (validated with jsonlint)
- [x] Records are correct (CNAME to Vercel)
- [x] I own the repository linked