### PR TITLE
Register liscn.is-a.dev

### DIFF
--- a/domains/liscn.json
+++ b/domains/liscn.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../schemas/domain.schema.json",
+  "domain": "liscn.is-a.dev",
+  "subdomain": "liscn",
+  "owner": {
+    "email": "your-email@example.com",
+    "github": "46832632"
+  },
+  "record": {
+    "CNAME": "46832632.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering liscn.is-a.dev for my photography portfolio website.

The site is hosted on GitHub Pages: https://46832632.github.io/photo-portfolio

Content: Urban and architectural photography portfolio with a zen-inspired design.