### PR TITLE
add _vercel.mujthaba.json for Vercel domain ownership verification

### DIFF
--- a/domains/_vercel.mujthaba.json
+++ b/domains/_vercel.mujthaba.json
@@ -4,6 +4,6 @@
         "email": "mujthabamkdev@gmail.com"
     },
     "records": {
-        "TXT": "vc-domain-verify=mujthaba.is-a.dev,ff0973a566218f58b1f0"
+        "TXT": "vc-domain-verify=mujthaba.is-a.dev,4d0c1ec08ee6c93ab0e7"
     }
 }

--- a/domains/_vercel.mujthaba.json
+++ b/domains/_vercel.mujthaba.json
@@ -4,8 +4,6 @@
         "email": "mujthabamkdev@gmail.com"
     },
     "records": {
-        "A": [
-            "76.76.21.21"
-        ]
+        "TXT": "vc-domain-verify=mujthaba.is-a.dev,ff0973a566218f58b1f0"
     }
 }

--- a/domains/mujthaba.json
+++ b/domains/mujthaba.json
@@ -4,8 +4,6 @@
         "email": "mujthabamkdev@gmail.com"
     },
     "records": {
-        "A": [
-            "76.76.21.21"
-        ]
+        "A": ["216.198.79.1"]
     }
 }


### PR DESCRIPTION
## _vercel.mujthaba.is-a.dev — Vercel TXT verification

**Context:** `mujthaba.is-a.dev` was previously registered to a different Vercel account. Since I do not have access to that account, Vercel requires a TXT record at `_vercel.mujthaba.is-a.dev` to prove ownership and transfer the domain to my project. This is Vercel's official process — see [Vercel docs](https://vercel.com/docs/projects/domains/troubleshooting#domain-linked-to-another-vercel-account).

### Changes
- `domains/mujthaba.json` — `CNAME` replaced with `A: 216.198.79.1` (Vercel's required IP for apex domains)
- `domains/_vercel.mujthaba.json` — **NEW FILE** with TXT record at `_vercel.mujthaba.is-a.dev` for Vercel ownership verification

### Website Preview (current live Vercel deploy)
https://mj-portfolio-rouge.vercel.app

---
- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://is-a.dev/docs).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not** for commercial use.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.