### PR TITLE
Register photobooth.is-a.dev and api.photobooth.is-a.dev

### DIFF
--- a/domains/_dmarc.photobooth.json
+++ b/domains/_dmarc.photobooth.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "viktoras-jego",
+    "email": "viktoras.jego@gmail.com"
+  },
+  "records": {
+    "TXT": ["v=DMARC1; p=none;"]
+  }
+}

--- a/domains/api.photobooth.json
+++ b/domains/api.photobooth.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "viktoras-jego",
+    "email": "viktoras.jego@gmail.com"
+  },
+  "records": {
+    "A": ["159.195.36.33"]
+  }
+}

--- a/domains/photobooth.json
+++ b/domains/photobooth.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "viktoras-jego",
+    "email": "viktoras.jego@gmail.com"
+  },
+  "records": {
+    "A": ["159.195.36.33"]
+  }
+}

--- a/domains/resend._domainkey.photobooth.json
+++ b/domains/resend._domainkey.photobooth.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "viktoras-jego",
+    "email": "viktoras.jego@gmail.com"
+  },
+  "records": {
+    "TXT": ["p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDyhP2ZcbVjUzueADJxGSS/NAN1dMEtTuci6V3Sy13S86lJvLrPrTIpeGAxX8fZ0BRdNU3XEBjhPB4+HeKSqgWfuJRm2CxkJKdfZB64qrYY7YI5f6EIykq+OMDeWgjK/g5dFsIvUv5M+v23IoGhXEzXlPwIFZmIXsf/sVmY8KcOsQIDAQAB"]
+  }
+}

--- a/domains/send.photobooth.json
+++ b/domains/send.photobooth.json
@@ -4,7 +4,7 @@
     "email": "viktoras.jego@gmail.com"
   },
   "records": {
-    "MX": ["10 feedback-smtp.eu-west-1.amazonses.com"],
+    "MX": ["feedback-smtp.eu-west-1.amazonses.com"],
     "TXT": ["v=spf1 include:amazonses.com ~all"]
   }
 }

--- a/domains/send.photobooth.json
+++ b/domains/send.photobooth.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "viktoras-jego",
+    "email": "viktoras.jego@gmail.com"
+  },
+  "records": {
+    "MX": ["10 feedback-smtp.eu-west-1.amazonses.com"],
+    "TXT": ["v=spf1 include:amazonses.com ~all"]
+  }
+}


### PR DESCRIPTION
## Subdomains

- **photobooth.is-a.dev** — Frontend (A record → `159.195.36.33`)
- **api.photobooth.is-a.dev** — Backend API (A record → `159.195.36.33`)

## Resend Email DNS

- **resend._domainkey.photobooth.is-a.dev** — DKIM verification (TXT)
- **send.photobooth.is-a.dev** — SPF + MX for email sending
- **_dmarc.photobooth.is-a.dev** — DMARC policy (TXT)

## Purpose

Photobooth fleet monitoring system — admin dashboard + API for managing photo booth devices with payment processing.