### PR TITLE
Register jonathan.is-a.dev + email records + patina hosting

### DIFF
--- a/domains/_dmarc.jonathan.json
+++ b/domains/_dmarc.jonathan.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "jonathan-shemer",
+        "email": "shemer.yonatan.mail@gmail.com"
+    },
+    "records": {
+        "TXT": "v=DMARC1; p=none;"
+    }
+}

--- a/domains/jonathan.json
+++ b/domains/jonathan.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "jonathan-shemer",
+        "email": "shemer.yonatan.mail@gmail.com"
+    },
+    "records": {
+        "URL": "https://github.com/jonathan-shemer"
+    }
+}

--- a/domains/patina.jonathan.json
+++ b/domains/patina.jonathan.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "jonathan-shemer",
+        "email": "shemer.yonatan.mail@gmail.com"
+    },
+    "records": {
+        "CNAME": "patina-4sc.pages.dev"
+    }
+}

--- a/domains/resend._domainkey.jonathan.json
+++ b/domains/resend._domainkey.jonathan.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "jonathan-shemer",
+        "email": "shemer.yonatan.mail@gmail.com"
+    },
+    "records": {
+        "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCZz8KUOYew7lRK6IOt6o1seoyxwYFS12HI7lFrQti1CXpSsM7dyE6WR2/oEv0jl5fn5VpE64sAwswR/c2lANKUJVpfDBrZ8V4Cpf7fUyfuzqiF++YskAesNlxQud2J1FMNFzh4LXVTRQRVTFD4bwFFYke/oAaXqglDAlR/xm/+ZQIDAQAB"
+    }
+}

--- a/domains/send.jonathan.json
+++ b/domains/send.jonathan.json
@@ -1,0 +1,15 @@
+{
+    "owner": {
+        "username": "jonathan-shemer",
+        "email": "shemer.yonatan.mail@gmail.com"
+    },
+    "records": {
+        "MX": [
+            {
+                "priority": 10,
+                "target": "feedback-smtp.us-east-1.amazonses.com"
+            }
+        ],
+        "TXT": "v=spf1 include:amazonses.com ~all"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the \`owner\` key.
- [x] I have provided a preview of my website below.

# Website Preview

### \`jonathan.is-a.dev\` (root subdomain)
Redirects to my GitHub profile: **https://github.com/jonathan-shemer**

A developer portfolio / project index — open-source work, side projects, and experiments. I work across TypeScript, React, Cloudflare Workers, and DX/tooling.

### \`patina.jonathan.is-a.dev\` (project subdomain)
Hosts the **Patina** PWA, a personal portfolio-tracking app for patient investors. Already deployed and live at the CNAME target:

**Live preview:** https://patina-4sc.pages.dev

Patina is a side project built on Cloudflare Pages + Workers + D1, using TanStack Router, Hono, Drizzle, and shadcn/ui. It is **not commercial** — it's used by me and a small group of friends/family to track DCA strategies across multi-asset portfolios. No ads, no paid tiers, no revenue.

Source: (public repo coming soon)

# DNS-only subdomains (email infrastructure)

Three additional files are included for setting up transactional email via [Resend](https://resend.com) on \`jonathan.is-a.dev\`:

- \`resend._domainkey.jonathan.json\` — DKIM TXT record (Resend / Amazon SES)
- \`send.jonathan.json\` — MX + SPF for bounce/feedback handling
- \`_dmarc.jonathan.json\` — DMARC policy (\`p=none\` monitoring mode)

These are DNS-only; they don't host web content. They enable \`Patina\` to send OTP sign-in codes to invited users.

# Test results

\`\`\`
13 tests passed
\`\`\`

All tests in \`tests/\` pass locally against the updated repo.