### PR TITLE
Register jonathan.is-a.dev + email records + patina hosting

### DIFF
--- a/domains/_dmarc.jonathan.json
+++ b/domains/_dmarc.jonathan.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "jonathan-shemer"
+    },
+    "records": {
+        "TXT": "v=DMARC1; p=none;"
+    }
+}

--- a/domains/jonathan.json
+++ b/domains/jonathan.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "jonathan-shemer"
+    },
+    "records": {
+        "URL": "https://github.com/jonathan-shemer"
+    }
+}

--- a/domains/patina.jonathan.json
+++ b/domains/patina.jonathan.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "jonathan-shemer"
+    },
+    "records": {
+        "CNAME": "patina-4sc.pages.dev"
+    }
+}

--- a/domains/resend._domainkey.jonathan.json
+++ b/domains/resend._domainkey.jonathan.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "jonathan-shemer"
+    },
+    "records": {
+        "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCZz8KUOYew7lRK6IOt6o1seoyxwYFS12HI7lFrQti1CXpSsM7dyE6WR2/oEv0jl5fn5VpE64sAwswR/c2lANKUJVpfDBrZ8V4Cpf7fUyfuzqiF++YskAesNlxQud2J1FMNFzh4LXVTRQRVTFD4bwFFYke/oAaXqglDAlR/xm/+ZQIDAQAB"
+    }
+}

--- a/domains/send.jonathan.json
+++ b/domains/send.jonathan.json
@@ -1,0 +1,14 @@
+{
+    "owner": {
+        "username": "jonathan-shemer"
+    },
+    "records": {
+        "MX": [
+            {
+                "priority": 10,
+                "target": "feedback-smtp.us-east-1.amazonses.com"
+            }
+        ],
+        "TXT": "v=spf1 include:amazonses.com ~all"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the \`owner\` key.
- [x] I have provided a preview of my website below.

# Website Preview

### \`jonathan.is-a.dev\` (root subdomain)
Redirects to my GitHub profile: **https://github.com/jonathan-shemer**

A developer portfolio / project index — open-source work, side projects, and experiments. I work across Python, TypeScript, React and DX/tooling.

### \`patina.jonathan.is-a.dev\` (project subdomain)
Hosts a personal app.

Preview: https://patina-4sc.pages.dev/
Screenshot: 
<img width="383" height="839" alt="image" src="https://github.com/user-attachments/assets/261b137d-fd6d-4f86-b107-abf075e2677c" />

### Email
Three additional DNS-only files (`resend._domainkey.jonathan.json`, `send.jonathan.json`, `_dmarc.jonathan.json`) set up email sender verification for `jonathan.is-a.dev` emails. No web content — just TXT/MX records.