### PR TITLE
Register dari.is-a.dev

### DIFF
--- a/domains/dari.json
+++ b/domains/dari.json
@@ -8,12 +8,11 @@
   "records": {
     "A": ["168.107.54.158"],
     "MX": [
-      {"target": "mx.zoho.com", "priority": 10},
-      {"target": "mx2.zoho.com", "priority": 20},
-      {"target": "mx3.zoho.com", "priority": 50}
+      {"target": "mx1.improvmx.com", "priority": 10},
+      {"target": "mx2.improvmx.com", "priority": 20}
     ],
     "TXT": [
-      "v=spf1 include:zoho.com ~all"
+      "v=spf1 include:spf.improvmx.com ~all"
     ]
   }
 }

--- a/domains/dari.json
+++ b/domains/dari.json
@@ -1,0 +1,11 @@
+{
+  "description": "DaRi — EN↔KO Technical Translation API",
+  "repo": "",
+  "owner": {
+    "username": "daily2translate",
+    "email": "dogdoh1338@icloud.com"
+  },
+  "record": {
+    "A": ["168.107.54.158"]
+  }
+}

--- a/domains/dari.json
+++ b/domains/dari.json
@@ -6,6 +6,14 @@
     "email": "dogdoh1338@icloud.com"
   },
   "records": {
-    "A": ["168.107.54.158"]
+    "A": ["168.107.54.158"],
+    "MX": [
+      {"target": "mx.zoho.com", "priority": 10},
+      {"target": "mx2.zoho.com", "priority": 20},
+      {"target": "mx3.zoho.com", "priority": 50}
+    ],
+    "TXT": [
+      "v=spf1 include:zoho.com ~all"
+    ]
   }
 }

--- a/domains/dari.json
+++ b/domains/dari.json
@@ -1,11 +1,11 @@
 {
   "description": "DaRi — EN↔KO Technical Translation API",
-  "repo": "",
+  "repo": "https://github.com/daily2translate/register",
   "owner": {
     "username": "daily2translate",
     "email": "dogdoh1338@icloud.com"
   },
-  "record": {
+  "records": {
     "A": ["168.107.54.158"]
   }
 }

--- a/domains/dari.json
+++ b/domains/dari.json
@@ -1,5 +1,5 @@
 {
-  "description": "DaRi — EN↔KO Technical Translation API",
+  "description": "Dari — EN↔KO Technical Translation API",
   "repo": "https://github.com/daily2translate/register",
   "owner": {
     "username": "daily2translate",


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: dari.is-a.dev
- **Description**: DaRi (다리) — EN↔KO Technical Translation API
- **Record Type**: A → 168.107.54.158 (OCI VM)

### About
DaRi is a technical translation API service powered by 63M EN↔KO parallel corpus, providing Translation Memory search, glossary lookup, and quality assessment for patent, medical, IT, and legal domains.

- Live API: http://168.107.54.158:8000/docs
- Demo: https://dogdoh-dari.hf.space