### PR TITLE
Register freestack.is-a.dev

### DIFF
--- a/domains/freestack.json
+++ b/domains/freestack.json
@@ -1,9 +1,9 @@
 {
   "owner": {
     "username": "Pratiyush",
-    "email": ""
+    "email": "pratiyush1@gmail.com"
   },
   "records": {
-    "CNAME": "Pratiyush.github.io"
+    "CNAME": "pratiyush.github.io"
   }
 }

--- a/domains/freestack.json
+++ b/domains/freestack.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Pratiyush",
+    "email": ""
+  },
+  "records": {
+    "CNAME": "Pratiyush.github.io"
+  }
+}


### PR DESCRIPTION
## Subdomain Registration

- **Subdomain:** freestack.is-a.dev
- **Record type:** CNAME → Pratiyush.github.io
- **Purpose:** GitHub Pages site for [free-stack](https://github.com/Pratiyush/free-stack) — a curated list of 323 verified free-tier services across 27 categories

The site is already built and deployed at `docs/index.html` in the repo. Just need the DNS pointing.