### PR TITLE
Add scrimstracker.is-a.dev

### DIFF
--- a/domains/scrimstracker.json
+++ b/domains/scrimstracker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Swiftal13",
+    "email": "elyassepahi14@gmail.com"
+  },
+  "records": {
+    "CNAME": "swiftal13.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://swiftal13.github.io/scrims-tracker/

Minecraft server status tracker — shows live player count, online/offline status, and an hourly player count history graph for na.scrims.network.