### PR TITLE
Add egemen.json with owner and records information

### DIFF
--- a/domains/egemen.json
+++ b/domains/egemen.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "egemngyk",
+    "email": "muhammedegemengeyik@gmail.com"
+  },
+  "records": {
+    "CNAME": "5a1ac757-ffdd-43ee-b85f-8cd7a5af68f4.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** http://bore.pub:1024/

> **Note:** The production URL will be `https://egemen.is-a.dev`. This subdomain uses a Cloudflare Tunnel as its backend, so the final domain cannot be previewed until the CNAME record is approved and propagated. The screenshot below shows the actual site content served through the tunnel's temporary URL.

**Screenshot:**
<img width="1685" height="977" alt="Screenshot 2026-04-12 at 19-47-06 Egemen Geyik — Portfolio" src="https://github.com/user-attachments/assets/989c0b22-19dd-4d66-b9a1-19e1dc28819e" />