### PR TITLE
Add egemen.json for domain configuration

### DIFF
--- a/domains/egemen.json
+++ b/domains/egemen.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "egemngyk",
+    "email": "muhammedegemengeyik@gmail.com"
+  },
+  "records": {
+    "CNAME": "bore.pub"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** http://bore.pub:2000/

> **Note:** The production URL will be `https://egemen.is-a.dev:2000`. This subdomain is served via the backend at `bore.pub:2000`, so it has been configured directly with this address. Once the CNAME record is approved and propagated, the site will be accessible through this domain.

**Screenshot:**
<img width="1685" height="977" alt="Screenshot 2026-04-12 at 19-47-06 Egemen Geyik — Portfolio" src="https://github.com/user-attachments/assets/989c0b22-19dd-4d66-b9a1-19e1dc28819e" />