### PR TITLE
Update kkshitij.is-a.dev — add Vercel TXT verification record

### DIFF
--- a/domains/kkshitij.json
+++ b/domains/kkshitij.json
@@ -5,6 +5,9 @@
     "email": "kjrlabs9@gmail.com"
   },
   "records": {
-    "CNAME": "kkshitij.vercel.app"
+    "CNAME": "kkshitij.vercel.app",
+    "TXT": [
+      "vc-domain-verify=kkshitij.is-a.dev,6cc558172170999e91d9"
+    ]
   }
 }


### PR DESCRIPTION
## Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

## Website Preview

**URL:** https://kkshitij.vercel.app

**About:** Adding Vercel TXT verification record to confirm domain ownership for kkshitij.is-a.dev. This is an update to the existing merged domain registration (PR #36251).