### PR TITLE
add typhoon.is-a.dev

### DIFF
--- a/domains/typhoon.json
+++ b/domains/typhoon.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "typhoon1217",
+    "email": "jungwooshin.97@gmail.com"
+  },
+  "records": {
+    "CNAME": "typhoon-blog.pages.dev"
+  }
+}


### PR DESCRIPTION
## Register typhoon.is-a.dev

| Field | Value |
|-------|-------|
| Domain | `typhoon.is-a.dev` |
| Owner | [@typhoon1217](https://github.com/typhoon1217) |
| Record type | CNAME |
| Target | `typhoon-blog.pages.dev` |

Developer blog — backend, ML, infra.