### PR TITLE
add xan-collection.is-a.dev

### DIFF
--- a/domains/xan-collection.json
+++ b/domains/xan-collection.json
@@ -1,0 +1,9 @@
+{
+  "description": "XAN Collection - Kurdish fashion brand landing page",
+  "owner": {
+    "username": "Alandkf"
+  },
+  "records": {
+    "CNAME": "alandkf.github.io"
+  }
+}


### PR DESCRIPTION
## Description

Registering `xan-collection.is-a.dev` for a Kurdish fashion brand landing page hosted on GitHub Pages.

## Details

- **Domain:** `xan-collection.is-a.dev`
- **Owner:** [@Alandkf](https://github.com/Alandkf)
- **Target:** `alandkf.github.io` (GitHub Pages)
- **Site:** https://alandkf.github.io/xan-collection/