### PR TITLE
Add A record and enable proxy for egemen.json

### DIFF
--- a/domains/egemen.json
+++ b/domains/egemen.json
@@ -4,6 +4,7 @@
     "email": "muhammedegemengeyik@gmail.com"
   },
   "records": {
-    "CNAME": "bore.pub"
-  }
+    "A": ["92.5.61.58"]
+  },
+  "proxied": true
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.
# Website Preview
> **Note:** DNS record has been updated from `CNAME: bore.pub` to `A: 92.5.61.58` to point directly to my Oracle Cloud server. Since the DNS change has not propagated yet, the live URL is currently unavailable. The site will be accessible at `https://egemen.is-a.dev` once propagation is complete.

**Screenshot:**
<img width="1685" height="977" alt="Screenshot 2026-04-12 at 19-47-06 Egemen Geyik — Portfolio" src="https://github.com/user-attachments/assets/989c0b22-19dd-4d66-b9a1-19e1dc28819e" />