### PR TITLE
Register andresrojoburgos.is-a.dev

### DIFF
--- a/domains/andresrojoburgos.json
+++ b/domains/andresrojoburgos.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Sendery"
+  },
+  "records": {
+    "URL": "https://www.red-labs.es"
+  }
+}


### PR DESCRIPTION
### Domain Registration

- **Subdomain**: andresrojoburgos.is-a.dev
- **Record type**: URL redirect
- **Target**: https://www.red-labs.es

Owner: @Sendery