### PR TITLE
Add grp-archive.is-a.dev

### DIFF
--- a/domains/grp-archive.json
+++ b/domains/grp-archive.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "FytikProdd"
+  },
+  "records": {
+    "CNAME": "grp-archive.borov2530-gleb-bot.workers.dev"
+  }
+}


### PR DESCRIPTION
## Description
Adds \grp-archive.is-a.dev\ and points it to the deployed Cloudflare Workers site.

## DNS
- CNAME: \grp-archive.borov2530-gleb-bot.workers.dev\

## Live site
- https://grp-archive.borov2530-gleb-bot.workers.dev
