### PR TITLE
Add lorenzocaputo.is-a.dev

### DIFF
--- a/domains/lorenzocaputo.json
+++ b/domains/lorenzocaputo.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "lorenzocaputodev",
+    "email": "lorenzocaputo2002.lc@gmail.com"
+  },
+  "records": {
+    "CNAME": "lorenzocaputodev.github.io"
+  }
+}


### PR DESCRIPTION
Add lorenzocaputo.is-a.dev for my personal portfolio website hosted on GitHub Pages.

This is a non-commercial personal developer portfolio used to present my background, featured project, and work in a clean, modern, and professional way.

Current site preview:
https://lorenzocaputodev.github.io/lorenzo-caputo-portfolio/

Screenshot:
<img width="629" height="880" alt="Screenshot_portfolio_lorenzocaputo" src="https://github.com/user-attachments/assets/9858dd4d-f69a-41e4-bb00-178919cc954b" />
