### PR TITLE
Register muhib-jobtracker.is-a.dev

### DIFF
--- a/domains/_vercel.muhib-jobtracker.json
+++ b/domains/_vercel.muhib-jobtracker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "muhibmannan",
+    "email": "muhibmannan@outlook.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=muhib-jobtracker.is-a.dev,6c185bb09ea1a9cddf9b"
+  }
+}

--- a/domains/muhib-jobtracker.json
+++ b/domains/muhib-jobtracker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "muhibmannan",
+    "email": "muhibmannan@outlook.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
SWE Job Tracker portfolio project. Vercel-hosted. Both A record and Vercel TXT verification included.