### PR TITLE
fix: Correct is-a.dev domain registration format for CodeShield

### DIFF
--- a/domains/codeshield.json
+++ b/domains/codeshield.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "H-sharma63",
+    "email": "627harshit@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "description": "The main Next.js frontend for the CodeShield IDE, hosted on Vercel."
+}

--- a/domains/engine.codeshield.json
+++ b/domains/engine.codeshield.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "H-sharma63",
+    "email": "627harshit@gmail.com"
+  },
+  "records": {
+    "A": "136.111.99.43"
+  },
+  "description": "The GCP VM running the persistent terminal backend for CodeShield."
+}


### PR DESCRIPTION
This pull request corrects the domain registration format for codeshield.is-a.dev and engine.codeshield.is-a.dev as per the is-a.dev documentation, with separate JSON files for each subdomain.