### PR TITLE
Register vazdeng.is-a.dev

### DIFF
--- a/domains/vazdeng.json
+++ b/domains/vazdeng.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "thaiscvaz",
+    "email": "tvazdataengineer@gmail.com"
+  },
+  "description": "Personal blog of Thais Vaz, Brazilian senior data engineer writing about production data engineering, AI research, and a crypto AI agent built in public.",
+  "repo": "https://github.com/thaiscvaz/vazdeng-blog",
+  "records": {
+    "CNAME": "thaiscvaz.github.io."
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Description of changes
Requesting the subdomain `vazdeng.is-a.dev` for my personal blog.

- **Owner:** [@thaiscvaz](https://github.com/thaiscvaz)
- **Blog repo:** https://github.com/thaiscvaz/vazdeng-blog
- **Current URL:** https://thaiscvaz.github.io/vazdeng-blog/
- **Purpose:** Personal technical blog about production data engineering, AI research (UFPR master's), and a crypto AI agent being built in public. Published in Portuguese and English.

## Checklist
- [x] I have read and agree to the [Terms of Service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md)
- [x] My domain file is in \`domains/\` folder and has correct JSON schema
- [x] The subdomain points to my GitHub Pages site via CNAME record
- [x] My website is live and ready to receive the custom domain