### PR TITLE
Register ideony.is-a.dev

### DIFF
--- a/domains/ideony.json
+++ b/domains/ideony.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "aciDrums7",
+    "email": "acidrumstudios@gmail.com"
+  },
+  "description": "Ideony — skilled-trades marketplace for Italy. Open-source dev project.",
+  "repo": "https://github.com/aciDrums7/ideony",
+  "records": {
+    "NS": ["joel.ns.cloudflare.com", "luciana.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
Registering `ideony.is-a.dev` for the Ideony open-source project — a skilled-trades marketplace for Italy built on Expo + NestJS.

**Repo:** https://github.com/aciDrums7/ideony
**Owner:** @aciDrums7

NS delegation to Cloudflare for DNS management + Quick Tunnel/named-tunnel routing. No proxying, no premium features — just free DNS.