### PR TITLE
Add misitio.json with domain owner and records

### DIFF
--- a/domains/misitio.json
+++ b/domains/misitio.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "jose-grito"
+  },
+  "records": {
+    "CNAME": "castle-mixture-federation-expires.trycloudflare.com"
+  }
+}


### PR DESCRIPTION

Agrego mi dominio `mision.is-a.dev` para usar con XAMPP y Cloudflare Tunnel.

Mi servidor local está corriendo y accesible públicamente.