### PR TITLE
new(0x24): register 0x24.is-a.dev

### DIFF
--- a/domains/0x24.json
+++ b/domains/0x24.json
@@ -1,0 +1,12 @@
+{
+  "description": "0x24 — a five-minute daily tech briefing, read in 10+ languages, delivered in English.",
+  "repo": "https://github.com/OmniCoreAlpha-lgtm/0x24",
+  "owner": {
+    "username": "OmniCoreAlpha-lgtm",
+    "email": "omnicorealpha@icloud.com"
+  },
+  "record": {
+    "CNAME": "cheery-liger-96072d.netlify.app"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering `0x24.is-a.dev` for **0x24** — a daily English tech briefing
that reads tech press in 10+ languages (English, Chinese, Japanese, German,
Korean, French, Russian, Hebrew, Portuguese BR, Hindi) and delivers the
signal in one five-minute digest.

**Live preview:** <https://cheery-liger-96072d.netlify.app>
**Target:** CNAME → `cheery-liger-96072d.netlify.app` (hosted on Netlify)

Static site, open-source, no tracking. Thanks!