### PR TITLE
new(0x24): register 0x24.is-a.dev

### DIFF
--- a/domains/0x24.json
+++ b/domains/0x24.json
@@ -1,0 +1,12 @@
+{
+  "description": "0x24 — a five-minute daily tech briefing, read in 10+ languages, delivered in English.",
+  "repo": "https://github.com/OmniCoreAlpha-lgtm/0x24",
+  "owner": {
+    "username": "OmniCoreAlpha-lgtm",
+    "email": "omnicorealpha@icloud.com"
+  },
+  "record": {
+    "CNAME": "cheery-liger-96072d.netlify.app"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live preview:** https://cheery-liger-96072d.netlify.app/

![0x24 preview](https://raw.githubusercontent.com/OmniCoreAlpha-lgtm/register/media-0x24/.github/preview/0x24.png)

## About 0x24

**0x24** is an open-source daily tech briefing focused on AI, hardware, security, and policy. What makes it different: it reads primary tech press in **10+ languages** (English, Chinese, Japanese, German, Korean, French, Russian, Hebrew, Portuguese-BR, Hindi) and delivers the signal in a single five-minute English digest. Cross-language stories — things that break in Chinese or Japanese press before they hit English outlets — get a "first in EN" badge.

- Static site, dark-first, reading-optimized (no ads, no tracking cookies)
- Privacy-first analytics (GoatCounter, no cookies)
- Fully open-source at https://github.com/OmniCoreAlpha-lgtm/0x24
- Non-commercial, personal project
- Target: developers, AI engineers, researchers

## Record

CNAME → `cheery-liger-96072d.netlify.app` (hosted on Netlify with free HTTPS).

Thanks for the volunteer time maintaining this registry!