### PR TITLE
Register typeid.is-a.dev

### DIFF
--- a/domains/typeid.json
+++ b/domains/typeid.json
@@ -1,0 +1,12 @@
+{
+  "description": "TypeID — an 8-puzzle kerning game that reveals your typeface persona",
+  "repo": "https://github.com/raihanr1/typeid",
+  "owner": {
+    "username": "raihanr1",
+    "email": "raihanrobbani123@gmail.com"
+  },
+  "records": {
+    "CNAME": "typeid.pages.dev"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Register typeid.is-a.dev

Adding a subdomain for TypeID — a typography personality quiz inspired by kerntype.com. The project is deployed to Cloudflare Pages at typeid.pages.dev; this PR CNAMEs typeid.is-a.dev to that host.

- **Domain**: typeid.is-a.dev
- **Target**: typeid.pages.dev (Cloudflare Pages)
- **Repo**: https://github.com/raihanr1/typeid
- **Live preview**: https://typeid.pages.dev

Single CNAME record, non-proxied. Follows the schema described in the repo README.