### PR TITLE
Register mule0.is-a.dev

### DIFF
--- a/domains/mule0.json
+++ b/domains/mule0.json
@@ -1,0 +1,17 @@
+{
+  "owner": {
+    "username": "wuweiwangzheye",
+    "email": "wuweiwangzheye@outlook.com"
+  },
+  "records": {
+    "A": ["104.21.80.121", "172.67.181.11"],
+    "MX": [
+      { "target": "mx1.improvmx.com", "priority": 10 },
+      { "target": "mx2.improvmx.com", "priority": 20 }
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** mule0.is-a.dev
- **Records:** A (Cloudflare Pages) + MX (ImprovMX email) + TXT (SPF)
- **Purpose:** Developer project landing page with email forwarding for notifications

## Records

| Type | Value | Purpose |
|------|-------|---------|
| A | 104.21.80.121, 172.67.181.11 | Web hosting (Cloudflare Pages) |
| MX | mx1.improvmx.com (pri 10), mx2.improvmx.com (pri 20) | Email forwarding via ImprovMX |
| TXT | v=spf1 include:spf.improvmx.com ~all | SPF record for email |