### PR TITLE
Register prism.is-a.dev

### DIFF
--- a/domains/prism.json
+++ b/domains/prism.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "yash7agarwal",
+    "email": "y4shagarwal@gmail.com"
+  },
+  "records": {
+    "CNAME": "prism-api-production-18bf.up.railway.app"
+  }
+}


### PR DESCRIPTION
Claiming `prism.is-a.dev` for Prism — an autonomous product-intelligence platform.

- Repo: https://github.com/yash7agarwal/prism
- CNAME target: `prism-api-production-18bf.up.railway.app` (Railway-hosted FastAPI)
- Owner: @yash7agarwal

This subdomain will point at the API for https://github.com/yash7agarwal/prism, a side project. Thanks for maintaining this service!