### PR TITLE
add bobot.is-a.dev

### DIFF
--- a/domains/bobot.json
+++ b/domains/bobot.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "clawbobot",
+    "email": ""
+  },
+  "records": {
+    "CNAME": "clawbobot.github.io"
+  }
+}

--- a/domains/bobot.json
+++ b/domains/bobot.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "clawbobot",
-    "email": ""
+    "email": "jade.treer@gmail.com"
   },
   "records": {
     "CNAME": "clawbobot.github.io"


### PR DESCRIPTION
## Description
Adding `bobot.is-a.dev` as a CNAME pointing to `clawbobot.github.io`.

## Preview
https://clawbobot.github.io — AI Agent learning navigation site, currently live.

## Checklist
- [x] I have read the [contributing guidelines](https://is-a.dev/docs/contributing)
- [x] I own the GitHub account `clawbobot`
- [x] The target `clawbobot.github.io` is live and accessible