### PR TITLE
add dltrf.is-a.dev

### DIFF
--- a/domains/dltrf.json
+++ b/domains/dltrf.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Bhavesh473",
+        "email": "bhavesht22ecs@student.mes.ac.in"
+    },
+    "record": {
+        "A": ["20.212.82.99"]
+    }
+}

--- a/domains/dltrf.json
+++ b/domains/dltrf.json
@@ -3,7 +3,7 @@
         "username": "Bhavesh473",
         "email": "bhavesht22ecs@student.mes.ac.in"
     },
-    "record": {
+    "records": {
         "A": ["20.212.82.99"]
     }
 }


### PR DESCRIPTION
Registering dltrf.is-a.dev for DLTRF (Deterministic Log Test Replay Framework) - a BTech final year academic project. This domain will point to our Azure VM hosting the framework for deterministic idempotent traffic replay and the App State DB.

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). 
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). 
- [x] My website is **reachable** and **completed**. 
- [x] My website is **software development** related. 
- [x] My website is **not for commercial use**. 
- [x] I have provided contact information in the `owner` key. 
- [x] I have provided a preview of my website below. 

# Website Preview
Link: http://20.212.82.99

<img width="1600" height="800" alt="image (1)" src="https://github.com/user-attachments/assets/1265be51-db39-46e8-a898-ce018da79582" />
