### PR TITLE
Add fastapi-learn.is-a.dev

### DIFF
--- a/domains/asuid.fastapi-learn.json
+++ b/domains/asuid.fastapi-learn.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "davidsantana1",
+    "email": "davidsantanar01@gmail.com"
+  },
+  "records": {
+    "TXT": ["2748D14D6078D426C1C997E54DB298A9840EB32C18A349125E76001697751857"]
+  }
+}

--- a/domains/fastapi-learn.json
+++ b/domains/fastapi-learn.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "davidsantana1",
+    "email": "davidsantanar01@gmail.com"
+  },
+  "records": {
+    "CNAME": "fastapi-learn.politesky-af322db0.eastus.azurecontainerapps.io"
+  }
+}


### PR DESCRIPTION
Registering `fastapi-learn.is-a.dev` pointing to Azure Container Apps deployment. Also adding `asuid.fastapi-learn.is-a.dev` TXT record for Azure custom domain verification.