### PR TITLE
Register rahib.is-a.dev

### DIFF
--- a/domains/rahib.json
+++ b/domains/rahib.json
@@ -1,0 +1,12 @@
+{
+    "description": "Rahib Noor — multi-theme portfolio showcasing systems, infra, and AI-agent work",
+    "repo": "https://github.com/Rahib9045/PRTFLIO",
+    "owner": {
+        "username": "Rahib9045",
+        "email": "rahib9045@gmail.com"
+    },
+    "record": {
+        "A": ["46.224.1.225"]
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Hi! registering rahib.is-a.dev for my personal portfolio site.

**What it is:** a multi-theme portfolio (dossier / brutalism / win98 / arcade / storybook / racing / boxing / interstellar) — already deployed on my Hetzner VPS at 46.224.1.225, nginx serving a Vite build.

**Source:** https://github.com/Rahib9045/PRTFLIO

**PR checklist**
- I read the docs at https://www.is-a.dev/docs/
- subdomain is 2-64 chars, lowercase ASCII
- only adds one file: domains/rahib.json (A record → my VPS)
- I own the VPS
- happy to add TXT records or adjust anything if reviewers ask