### PR TITLE
Add Vercel configuration for domain verification

### DIFF
--- a/domains/_vercel.jaiminkumar.json
+++ b/domains/_vercel.jaiminkumar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "techjaik",
+        "email": "techjaik@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=jaiminkumar.is-a.dev,54f0faf2c3e0c16a238d"
+    }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
<img width="1919" height="985" alt="image" src="https://github.com/user-attachments/assets/5a97aae0-41b7-4342-9698-b2189bb29524" />


**Live site:** https://jaiminkumar-pawar.vercel.app/

# Website Purpose
This is my personal developer portfolio website. I want to use jaiminkumar.is-a.dev as my main domain to make it look more professional.