### PR TITLE
Add carlsir.is-a.dev

### DIFF
--- a/domains/carlsir.json
+++ b/domains/carlsir.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Carlsir"
+  },
+  "records": {
+    "CNAME": "zhishichang-250236-6-1406375049.sh.run.tcloudbase.com"
+  }
+}

--- a/domains/zhishichang.json
+++ b/domains/zhishichang.json
@@ -1,8 +1,0 @@
-{
-  "owner": {
-    "username": "Carlsir"
-  },
-  "records": {
-    "CNAME": "zhishichang-250236-6-1406375049.sh.run.tcloudbase.com"
-  }
-}

--- a/domains/zhishichang.json
+++ b/domains/zhishichang.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Carlsir"
+  },
+  "records": {
+    "CNAME": "zhishichang-250236-6-1406375049.sh.run.tcloudbase.com"
+  }
+}


### PR DESCRIPTION
Add carlsir.is-a.dev for the live CloudBase deployment.

Live site: https://zhishichang-250236-6-1406375049.sh.run.tcloudbase.com/
Health: https://zhishichang-250236-6-1406375049.sh.run.tcloudbase.com/api/health

This keeps the label short while still including the Carlsir name.