### PR TITLE
Register maale-amos.is-a.dev

### DIFF
--- a/domains/maale-amos.json
+++ b/domains/maale-amos.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "yossi6742853",
+    "email": "6742853@gmail.com"
+  },
+  "record": {
+    "CNAME": "yossi6742853.github.io"
+  }
+}

--- a/domains/maale-amos.json
+++ b/domains/maale-amos.json
@@ -3,7 +3,7 @@
     "username": "yossi6742853",
     "email": "6742853@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "yossi6742853.github.io"
   }
 }


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** maale-amos.is-a.dev
- **Record type:** CNAME
- **Target:** yossi6742853.github.io
- **Purpose:** Community website for Ma'ale Amos settlement (Gush Etzion, Israel)
- **GitHub Pages repo:** https://github.com/yossi6742853/maale-amos