### PR TITLE
Register aminshaikh.is-a.dev

### DIFF
--- a/domains/aminshaikh.json
+++ b/domains/aminshaikh.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "aizenshaikh",
+        "email": "amin58685@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Adding `aminshaikh.is-a.dev` for my personal portfolio site (Next.js).

Live site (currently on the default Vercel URL): https://portfolio-web-five-ebon.vercel.app/

The CNAME points to `cname.vercel-dns.com` so the new subdomain will be served by Vercel once approved. Thank you for running this service!