### PR TITLE
Add solo-ai.is-a.dev

### DIFF
--- a/domains/solo-ai.json
+++ b/domains/solo-ai.json
@@ -1,6 +1,6 @@
 {
   "owner": {
-    "username": "chuzestranecS87-cloud"
+    "username": "chuzestranec587-cloud"
   },
   "records": {
     "CNAME": "solo-ai.duckdns.org"

--- a/domains/solo-ai.json
+++ b/domains/solo-ai.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "chuzestranec587-cloud"
+    "username": "chuzestranec587-cloud",
+    "email": "chuzestranec587@gmail.com"
   },
   "records": {
     "CNAME": "solo-ai.duckdns.org"

--- a/domains/solo-ai.json
+++ b/domains/solo-ai.json
@@ -5,5 +5,6 @@
   },
   "records": {
     "CNAME": "solo-ai.duckdns.org"
-  }
+  },
+  "proxied": true
 }

--- a/domains/solo-ai.json
+++ b/domains/solo-ai.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "chuzestranecS87-cloud"
+  },
+  "records": {
+    "CNAME": "solo-ai.duckdns.org"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Self-hosted Solo AI HTML — a developer-focused chat UI for local LLMs (LM Studio / Ollama / OpenAI-compatible backends), with sessions, projects, mindmap of chats, stats and more.

Live preview (CNAME currently points here, will resolve to `solo-ai.is-a.dev` after merge):
http://solo-ai.duckdns.org

<img width="1918" height="941" alt="image" src="https://github.com/user-attachments/assets/f7768cb6-ecb4-4b54-b957-77bbc9d9e757" />

# Website Purpose

Personal developer chat tool I built for myself and a few friends to use 24/7 with our self-hosted local language models. Source / further info on request via GitHub @chuzestranec587-cloud. Not for commercial use.