### PR TITLE
add nullwolfcoasterden.is-a.dev

### DIFF
--- a/domains/nullwolfcoasterden.json
+++ b/domains/nullwolfcoasterden.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "NULLWulf",
+    "email": "ndwolf1991@gmail.com"
+  },
+  "records": {
+    "CNAME": "jolly-wave-01045ae0f.7.azurestaticapps.net"
+  }
+}


### PR DESCRIPTION
Registering nullwolfcoasterden.is-a.dev pointing to Azure Static Web App (jolly-wave-01045ae0f.7.azurestaticapps.net) for a personal roller coaster trip planner project.