### PR TITLE
Register rahib.is-a.dev

### DIFF
--- a/domains/rahib.json
+++ b/domains/rahib.json
@@ -1,0 +1,14 @@
+{
+    "description": "Rahib Noor — multi-theme portfolio showcasing systems, infra, and AI-agent work",
+    "repo": "https://github.com/Rahib9045/PRTFLIO",
+    "owner": {
+        "username": "Rahib9045",
+        "email": "rahib9045@gmail.com"
+    },
+    "record": {
+        "A": [
+            "46.224.1.225"
+        ]
+    },
+    "proxied": false
+}

--- a/domains/rahib.json
+++ b/domains/rahib.json
@@ -1,5 +1,5 @@
 {
-    "description": "Rahib Noor — multi-theme portfolio showcasing systems, infra, and AI-agent work",
+    "description": "Rahib Noor - multi-theme portfolio showcasing systems, infra, and AI-agent work",
     "repo": "https://github.com/Rahib9045/PRTFLIO",
     "owner": {
         "username": "Rahib9045",

--- a/domains/rahib.json
+++ b/domains/rahib.json
@@ -5,7 +5,7 @@
         "username": "Rahib9045",
         "email": "rahib9045@gmail.com"
     },
-    "record": {
+    "records": {
         "A": [
             "46.224.1.225"
         ]


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview: http://46.224.1.225 (the subdomain will resolve to this once merged)

Screenshot of the theme-picker landing screen:

![Theme selector](https://raw.githubusercontent.com/Rahib9045/register/preview-assets/preview/theme-selector-v2.png)

# Website Purpose

A personal multi-theme developer portfolio. The site features 8 distinct visual themes (Dossier, Brutalism, Win98, Arcade, Storybook, Racing, Boxing, Interstellar) the visitor can switch between, each reimagining the same content in a different aesthetic. Built with React + Vite + Tailwind, hosted on a self-managed Hetzner VPS. The hero is a theme-picker that previews each theme's environment on hover.

The "fix social links" change requested on the previous PR (#36982) has been applied — `bio.linkedin` now points to https://www.linkedin.com/in/rahib-noor-85048b206/ across all themes, and the placeholder `href="#"` in the contact section is fixed. Site rebuilt and redeployed.
