### PR TITLE
Register malavgajera.is-a.dev

### DIFF
--- a/domains/malavgajera.json
+++ b/domains/malavgajera.json
@@ -1,0 +1,11 @@
+{
+  "description": "Personal portfolio — Backend & Cloud Engineer",
+  "repo": "https://github.com/malav-250/portfolio",
+  "owner": {
+    "username": "malav-250",
+    "email": "gajera.ma@northeastern.edu"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://portfolio-pearl-two-32.vercel.app

**Screenshot:**

![Portfolio screenshot](https://image.thum.io/get/width/1200/https://portfolio-pearl-two-32.vercel.app/)

# Website Purpose

Personal portfolio for Malav Gajera — a Master's student at Northeastern University specializing in **backend and cloud engineering**. The site showcases:

- Engineering projects (distributed task queue with Celery/RabbitMQ, AWS infrastructure with Terraform, Spring Boot microservices)
- Internship experience (Crewasis, Tatvasoft)
- Technical skills (Python, Java, AWS, PostgreSQL, Docker, etc.)
- A custom-built visitor analytics system (open-source code in the linked repo)

The portfolio repo itself is also open source: https://github.com/malav-250/portfolio

This is a non-commercial, software-development-related personal site used for job search and engineering blog content.