### PR TITLE
Register replyaid.is-a.dev

### DIFF
--- a/domains/replyaid.json
+++ b/domains/replyaid.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "akrawingame-jpg",
+    "email": "akrawingame@gmail.com"
+  },
+  "records": {
+    "A": ["178.104.18.168"]
+  }
+}


### PR DESCRIPTION
### Domain
replyaid.is-a.dev

### Description
Replyaid is a small AI assistant SaaS for Thai SMB shops using LINE OA. The subdomain will host the webhook endpoint that LINE servers POST to when shop customers send messages.

### Project links
- Landing page (live): https://replyai-landing-theta.vercel.app
- Source code (this repo): https://github.com/akrawingame-jpg/replyai-landing

### Why is-a.dev
Project is at early Beta — recruiting first 50 small business shops in Thailand. A clean subdomain helps shop owners trust and verify the integration. Full custom domain will follow once paid customers are onboarded.

### Use case
- A record points to a Hetzner VPS (178.104.18.168)
- nginx + Let's Encrypt + bot listening on /webhook
- Used solely for LINE Messaging API webhook delivery

### Compliance
- I have read and agree to the [Terms of Service](https://www.is-a.dev/docs/legal/terms-of-service)
- I have read and agree to the [Privacy Policy](https://www.is-a.dev/docs/legal/privacy-policy)