### PR TITLE
Add chuzestranec587.is-a.dev for personal dev portfolio

### DIFF
--- a/domains/chuzestranec587.json
+++ b/domains/chuzestranec587.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "chuzestranec587-cloud",
+    "email": "chuzestranec587@gmail.com"
+  },
+  "description": "Personal portfolio site for chuzestranec587 — software developer building local-first AI tools and small self-hosted apps.",
+  "repo": "https://github.com/chuzestranec587-cloud/chuzestranec587-cloud.github.io",
+  "record": {
+    "CNAME": "chuzestranec587-cloud.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Requirements

- [x] I agree to the [Terms of Service](https://www.is-a.dev/docs/legal/terms-of-service).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure).
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for spam, phishing, illegal or NSFW content.

## Website Preview
https://chuzestranec587-cloud.github.io

## Website Purpose
This is my personal dev portfolio site. It's a static single-page bio
introducing me as a software developer, listing what I work on (local-first
AI tooling, self-hosted apps, personal automation), and linking to my
featured project.

The previous PR (#37119) was closed because I asked for a project subdomain
(`solo-ai.is-a.dev`) directly. I've restructured per the maintainer's
guidance:
  * `chuzestranec587.is-a.dev` (this PR) — my dev portfolio
  * `solo-ai.chuzestranec587.is-a.dev` (planned next PR, after this one is
    merged) — nested subdomain for one of my projects

Thanks!