### PR TITLE
feat: register loze.is-a.dev

### DIFF
--- a/domains/loze.json
+++ b/domains/loze.json
@@ -1,0 +1,11 @@
+{
+  "description": "Personal blog focused on AI and tech topics. Built with Next.js 15 + MDX, deployed on Vercel.",
+  "repo": "https://github.com/lozehq/ai-blog",
+  "owner": {
+    "username": "lozehq",
+    "email": "lozehqlozehq@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## What
Register `loze.is-a.dev` for a personal blog deployed on Vercel.

## Project
- Repository: https://github.com/lozehq/ai-blog
- Personal blog focused on AI and tech topics
- Stack: Next.js 15 + MDX, deployed on Vercel
- Live preview (Vercel default URL): https://ai-blog-1940231594qqcom.vercel.app

## DNS records
- `CNAME` → `cname.vercel-dns.com` (Vercel-managed routing)

## Checklist
- [x] I have read the documentation
- [x] My subdomain name is appropriate (a short personal identifier matching my GitHub handle root)
- [x] DNS records are valid
- [x] Owner info is accurate