### PR TITLE
add geffhermenegildawedding.is-a.dev

### DIFF
--- a/domains/_vercel.geffhermenegildawedding.json
+++ b/domains/_vercel.geffhermenegildawedding.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Geliminatus",
+    "email": "geofreyeliminatus@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=geffhermenegildawedding.is-a.dev,918ef74ec64b0a368324"
+  }
+}

--- a/domains/geffhermenegildawedding.json
+++ b/domains/geffhermenegildawedding.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Geliminatus",
+    "email": "geofreyeliminatus@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Description
Registering the subdomain `geffhermenegildawedding.is-a.dev` for a wedding website.

## Details
- **Subdomain**: `geffhermenegildawedding.is-a.dev`
- **Owner**: Geliminatus
- **Target**: Vercel deployment (`cname.vercel-dns.com`)
- **Use**: Wedding website for Geffs & Hermenegilda — August 8, 2026

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md)
- [x] I have checked that the subdomain is not already taken
- [x] The JSON file is valid
- [x] My GitHub username is correct