### PR TITLE
Register muly.is-a.dev

### DIFF
--- a/domains/_vercel.muly.json
+++ b/domains/_vercel.muly.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mulyoved",
+        "email": "dev@core8.co"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=muly.is-a.dev,7bee213c26c9219cc57b"
+    }
+}

--- a/domains/muly.json
+++ b/domains/muly.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mulyoved",
+        "email": "dev@core8.co"
+    },
+    "records": {
+        "A": ["216.198.79.1", "64.29.17.1"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live URL: https://mulyoved.vercel.app

(Screenshot will be added as a comment / inline below.)

# Website Purpose

Personal portfolio site for Muly Oved, a software engineer / founder. The site lists current and past software development work (Core8 commission-plan parsing platform, Autopilot rate engine, Smapy, testRTC), open-source side projects, and contact info. Non-commercial — it's a developer profile / portfolio, not a sales page.

# Hosting

Hosted on Vercel. Two records added:
- `muly.json` — A records `216.198.79.1`, `64.29.17.1` (Vercel's current recommended IPs)
- `_vercel.muly.json` — TXT verification record required by Vercel