### PR TITLE
Register xmum-flea.is-a.dev (FYP project at XMUM, Resend email)

### DIFF
--- a/domains/_dmarc.xmum-flea.json
+++ b/domains/_dmarc.xmum-flea.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "URneiU1",
+        "email": "1046470063@qq.com"
+    },
+    "description": "DMARC policy for xmum-flea.is-a.dev",
+    "records": {
+        "TXT": [
+            "v=DMARC1; p=none;"
+        ]
+    }
+}

--- a/domains/resend._domainkey.xmum-flea.json
+++ b/domains/resend._domainkey.xmum-flea.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "URneiU1",
+        "email": "1046470063@qq.com"
+    },
+    "description": "Resend DKIM key for xmum-flea.is-a.dev",
+    "records": {
+        "TXT": [
+            "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDY+V/fbmSWxI7crY7XevsrUfK8F9ba7WHh4tRwL/Io63F4OcyYDM+XsaAbJkym39ep9bWTbHTLGyEvQfZAmskXGFeGsbm/2Y0jmeHJFffy6cuuhxHTC588l+vjqrd/DLHcLBcDYnRb9FP7JiwL5HZ82RNHKQmJ5ZWHuFr1e8colQIDAQAB"
+        ]
+    }
+}

--- a/domains/send.xmum-flea.json
+++ b/domains/send.xmum-flea.json
@@ -1,0 +1,15 @@
+{
+    "owner": {
+        "username": "URneiU1",
+        "email": "1046470063@qq.com"
+    },
+    "description": "Resend transactional email return-path + SPF for xmum-flea.is-a.dev",
+    "records": {
+        "MX": [
+            { "target": "feedback-smtp.ap-northeast-1.amazonses.com", "priority": 10 }
+        ],
+        "TXT": [
+            "v=spf1 include:amazonses.com ~all"
+        ]
+    }
+}

--- a/domains/xmum-flea.json
+++ b/domains/xmum-flea.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "URneiU1",
+        "email": "1046470063@qq.com"
+    },
+    "description": "Final-year project at Xiamen University Malaysia: a campus second-hand trading web application (Spring Boot + Vue 3). Sources: https://github.com/URneiU1/xmum-flea",
+    "records": {
+        "URL": "https://xmum-flea.pages.dev"
+    }
+}


### PR DESCRIPTION
> Re-submission of #37206 with the email validation fix (no `users.noreply.github.com`).

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

- Live URL: https://xmum-flea.pages.dev
- Source code: https://github.com/URneiU1/xmum-flea

The site is a campus second-hand trading platform built as a final-year project (FYP) at Xiamen University Malaysia (XMUM). The frontend is a Vue 3 + TypeScript SPA on Cloudflare Pages, the backend is a Spring Boot 3.5 (Java 21) API on Fly.io with a self-managed MySQL 8 sidecar, and real-time chat is implemented over STOMP/SockJS. The repo contains the full implementation, Flyway migrations, k6 performance scripts, JaCoCo coverage, and a thesis draft.

# Website Purpose

Final-year academic project. The site is **non-commercial** — no listings can be promoted, there is no payment integration, and access is gated behind verified `.edu.my` student emails. The project's evaluation chapter (System Usability Scale) is conducted in-person with XMUM students.

The companion subdomains (`send.xmum-flea`, `resend._domainkey.xmum-flea`, `_dmarc.xmum-flea`) provision Resend transactional email so the OTP login can deliver from a project-owned domain rather than the developer's personal Gmail. This was chosen specifically to follow good privacy practice for the user-study phase.

# Files added

- `domains/xmum-flea.json` — apex, redirects to the live Cloudflare Pages site
- `domains/send.xmum-flea.json` — Resend return-path MX + SPF
- `domains/resend._domainkey.xmum-flea.json` — Resend DKIM
- `domains/_dmarc.xmum-flea.json` — DMARC `p=none;`

Thanks for maintaining is-a.dev — it's the cleanest free option I found for adding a verified custom domain to a student project. ⭐️
