### PR TITLE
Register maskpilot.is-a.dev

### DIFF
--- a/domains/maskpilot.json
+++ b/domains/maskpilot.json
@@ -1,0 +1,12 @@
+{
+  "description": "MaskPilot Pro - Faceless YouTube System for German-speaking creators",
+  "repo": "https://github.com/sahero7/maskpilot-website",
+  "owner": {
+    "username": "sahero7",
+    "email": "alienpcmichael@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Hi! Please register maskpilot.is-a.dev for the MaskPilot Pro project.

- **Project**: MaskPilot Pro - Faceless YouTube education platform (German market)
- **Repo**: https://github.com/sahero7/maskpilot-website
- **CNAME**: cname.vercel-dns.com (Vercel hosting)

Thanks for maintaining is-a.dev!