### PR TITLE
Register steamviewer.is-a.dev

### DIFF
--- a/domains/steamviewer.json
+++ b/domains/steamviewer.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Paelsmoessan",
+    "email": "forstenius@hotmail.com"
+  },
+  "records": {
+    "CNAME": "paelsmoessan.github.io"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** steamviewer.is-a.dev
- **Record type:** CNAME
- **Target:** paelsmoessan.github.io
- **Purpose:** Landing page for SteamViewer, a free remote desktop application for Windows