### PR TITLE
Add parkease.json for domain configuration

### DIFF
--- a/domains/parkease.json
+++ b/domains/parkease.json
@@ -4,13 +4,25 @@
     "email": "laxmansawant1210@gmail.com"
   },
   "record": {
-    "TXT": {
-      "@": "brevo-code:e04c1e59144809174b246d71f03327b0",
-      "_dmarc": "v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com"
-    },
-    "CNAME": {
-      "brevo1._domainkey": "b1.parkease-is-a-dev.dkim.brevo.com",
-      "brevo2._domainkey": "b2.parkease-is-a-dev.dkim.brevo.com"
-    }
+    "TXT": [
+      {
+        "name": "@",
+        "value": "brevo-code:e04c1e59144809174b246d71f03327b0"
+      },
+      {
+        "name": "_dmarc",
+        "value": "v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com"
+      }
+    ],
+    "CNAME": [
+      {
+        "name": "brevo1._domainkey",
+        "value": "b1.parkease-is-a-dev.dkim.brevo.com"
+      },
+      {
+        "name": "brevo2._domainkey",
+        "value": "b2.parkease-is-a-dev.dkim.brevo.com"
+      }
+    ]
   }
 }

--- a/domains/parkease.json
+++ b/domains/parkease.json
@@ -1,0 +1,21 @@
+{
+  "owner": {
+    "username": "laxmansawant1210"
+  },
+  "record": {
+    "TXT": [
+      "brevo-code:e04c1e59144809174b246d71f03327b0",
+      "v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com"
+    ],
+    "CNAME": [
+      {
+        "name": "brevo1._domainkey",
+        "value": "b1.parkease-is-a-dev.dkim.brevo.com"
+      },
+      {
+        "name": "brevo2._domainkey",
+        "value": "b2.parkease-is-a-dev.dkim.brevo.com"
+      }
+    ]
+  }
+}

--- a/domains/parkease.json
+++ b/domains/parkease.json
@@ -1,21 +1,16 @@
 {
   "owner": {
-    "username": "laxmansawant1210"
+    "username": "laxmansawant1210",
+    "email": "laxmansawant1210@gmail.com"
   },
   "record": {
-    "TXT": [
-      "brevo-code:e04c1e59144809174b246d71f03327b0",
-      "v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com"
-    ],
-    "CNAME": [
-      {
-        "name": "brevo1._domainkey",
-        "value": "b1.parkease-is-a-dev.dkim.brevo.com"
-      },
-      {
-        "name": "brevo2._domainkey",
-        "value": "b2.parkease-is-a-dev.dkim.brevo.com"
-      }
-    ]
+    "TXT": {
+      "@": "brevo-code:e04c1e59144809174b246d71f03327b0",
+      "_dmarc": "v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com"
+    },
+    "CNAME": {
+      "brevo1._domainkey": "b1.parkease-is-a-dev.dkim.brevo.com",
+      "brevo2._domainkey": "b2.parkease-is-a-dev.dkim.brevo.com"
+    }
   }
 }


### PR DESCRIPTION
Add parkease.is-a.dev domain

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the 'owner' key.
- [x] I have provided a preview of my website below.

## Website Preview
Currently the domain is used for email (Brevo) only – the website will be built at `parkease.is-a.dev` later. For now, the subdomain is required to send password reset emails for my parking finder app.

## Website Purpose
This subdomain is used as a sender domain for transactional emails (password reset) for my parking finder application (internship project). No commercial use.