### PR TITLE
Register higomon.is-a.dev (NS delegation for home lab)

### DIFF
--- a/domains/higomon.json
+++ b/domains/higomon.json
@@ -1,0 +1,13 @@
+{
+    "description": "Personal home lab subdomain for self-hosted development infrastructure (Headscale control plane and Tailscale DERP relay)",
+    "owner": {
+        "username": "Higomon",
+        "email": "ohgi.mach@gmail.com"
+    },
+    "records": {
+        "NS": [
+            "graham.ns.cloudflare.com",
+            "nia.ns.cloudflare.com"
+        ]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This subdomain is requested as an **NS delegation** for self-hosted home lab infrastructure (no public-facing website at the apex). Equivalent to existing precedents such as [`homelab.is-a.dev`](https://github.com/is-a-dev/register/blob/main/domains/homelab.json) and [`lgstfn.is-a.dev`](https://github.com/is-a-dev/register/blob/main/domains/lgstfn.json).

Once delegated, the zone will host:
- `headscale.higomon.is-a.dev` — self-hosted Tailscale control plane (Headscale)
- `derp.higomon.is-a.dev` — self-hosted Tailscale DERP relay
- additional development services as needed

Public DNS verification of NS delegation post-merge:
```
dig +short higomon.is-a.dev NS
# expected: graham.ns.cloudflare.com / nia.ns.cloudflare.com
```

# Website Purpose

Personal software development infrastructure: a self-hosted Tailscale (Headscale + DERP) deployment for connecting personal development machines (Mac Studio, MacBook Air, GL.iNet routers, etc.) when behind restrictive networks where the public Tailscale control plane is blocked. Non-commercial, individual hobbyist use only.
