### PR TITLE
Add _vercel.malavgajera.is-a.dev TXT record

### DIFF
--- a/domains/_vercel.malavgajera.json
+++ b/domains/_vercel.malavgajera.json
@@ -1,0 +1,11 @@
+{
+  "description": "Vercel domain ownership verification for malavgajera.is-a.dev",
+  "repo": "https://github.com/malav-250/portfolio",
+  "owner": {
+    "username": "malav-250",
+    "email": "gajera.ma@northeastern.edu"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=malavgajera.is-a.dev,c4551a9af19c58334bf6"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This PR adds a TXT-only verification record for the parent domain `malavgajera.is-a.dev` (already merged in #37145). The verification record is required by Vercel to issue an SSL certificate and route traffic to my project.

**Live URL of parent domain (currently served via portfolio-pearl-two-32.vercel.app):**
https://portfolio-pearl-two-32.vercel.app

**Screenshot:**

![Portfolio screenshot](https://image.thum.io/get/width/1200/https://portfolio-pearl-two-32.vercel.app/)

**Once this PR merges and Vercel verifies the TXT record:** the domain `malavgajera.is-a.dev` will resolve to the same site over HTTPS.

# Website Purpose

This is a nested subdomain (`_vercel.malavgajera.is-a.dev`) used solely for Vercel's domain ownership verification. The parent subdomain `malavgajera.is-a.dev` (PR #37145, already merged) hosts my personal portfolio — a backend/cloud engineering portfolio for a Northeastern University Master's student.

The TXT record value `vc-domain-verify=malavgajera.is-a.dev,c4551a9af19c58334bf6` was generated by Vercel and proves I control this subdomain on their platform. Without this record, Vercel won't route traffic or issue an SSL certificate to the parent domain.

Owner is the same `malav-250` as the parent record, satisfying the nested-subdomain ownership rule.

Portfolio repo: https://github.com/malav-250/portfolio