### PR TITLE
Applying NS in jyit.is-a.dev after Fundamental changes

### DIFF
--- a/domains/jyit.json
+++ b/domains/jyit.json
@@ -3,6 +3,6 @@
     "username": "leigit-dev"
   },
   "records": {
-    "NS":[raina.ns.cloudflare.com","terry.ns.cloudflare.com"]
+    "NS":["raina.ns.cloudflare.com","terry.ns.cloudflare.com"]
   }
 }

--- a/domains/jyit.json
+++ b/domains/jyit.json
@@ -3,6 +3,6 @@
     "username": "leigit-dev"
   },
   "records": {
-    "CNAME": "jyit.pages.dev"
+    "NS":"raina.ns.cloudflare.com,terry.ns.cloudflare.com"
   }
 }

--- a/domains/jyit.json
+++ b/domains/jyit.json
@@ -3,6 +3,6 @@
     "username": "leigit-dev"
   },
   "records": {
-    "NS":"raina.ns.cloudflare.com,terry.ns.cloudflare.com"
+    "NS":[raina.ns.cloudflare.com","terry.ns.cloudflare.com"]
   }
 }


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->


Request
Point the DNS of jyit.is-a.dev to Cloudflare via an NS record.

Background
This domain was created in PR #34384 and has been running normally for over a month. The project has now been upgraded from a static page to a dynamic backend application with login, storage, and other features, requiring deployment on an independent server.
After pr #36990 has failed,we have made some modifact to our site,which will be shown below.

## Reasons for requesting an NS record：I need to use cloudflare tunnel

1. Standard DNS records are not usable
      Due to the specific limitations of my local ISP network, I have tested A/AAAA records and direct IP connections on multiple platforms, all of which failed to provide stable access. Direct IP connection has been proven infeasible.
2. An NS record is the only feasible solution
      After testing, only Cloudflare Tunnel  works properly under this network environment. However, Cloudflare Tunnel requires the subdomain's DNS to be hosted by Cloudflare, which necessitates the use of an NS record. No other alternatives exist.
3. I understand and accept the constraints associated with NS records
      I am aware that is-a.dev has strict controls over NS records, including but not limited to: records cannot be arbitrarily added or removed, and I am responsible for compliance. I hereby commit that:
   · This NS record will be used solely for this project
   · It will not be used for wildcard resolution, bulk domains, commercial purposes, or any non‑development use
   · If this NS record is no longer needed in the future, I will proactively request its removal

Review request
Please let me know if any further information is needed. Thank you for your review.

# Website Purpose(Transformation from internal to open)
<!-- Please tell us the purpose or motive behind your website. For example, it is a portfolio website, etc. -->

Following the advice from the maintainer in PR #36990, we have made several adjustments to our website to better align with the open and public‑good nature of the `is-a.dev` community. These include:

1. **Removed internal‑only restriction** – The previous rule that "only team members can create projects" has been eliminated. This allows anyone who shares our needs to access and benefit from our resources.

2. **Enhanced collaboration features** – We have improved role‑based task management and project forums, while also relaxing file size/type restrictions to facilitate more efficient teamwork.

3. **Renamed the platform** – The website is now officially called the **"JY Information Open Source Collaboration Platform"** , which better reflects its open and inclusive mission.

With these changes, we believe the platform can serve both as an internal collaborative development environment for our team and as a public‑good resource offering free file hosting, multi‑user collaboration, and other services to developers worldwide.

# Website Preview
<!-- Provide a link AND screenshot of your website below. if not provided your PR will be closed with no questions asked. -->

**[ https://pensions-break-cycling-reaching.trycloudflare.com]( https://pensions-break-cycling-reaching.trycloudflare.com)**

Due to my academic schedule, I cannot keep this link available for a long time.
However, I have provided the complete code repository, where you can download the source code (Python Flask) or a pre-compiled EXE file to preview the site locally if the link is unaccessible.
[**Our responsitory : JYIT-Studio-Server-Code**](https://github.com/leigit-dev/JYIT-Studio-Server)

The admin user name in the local preview server is "admin1" and the password is "admin1pwd"


**And here are the screenshots of most of the pages of our website.**

**As you can see in the scteenshots,a guest user can now download,send forums and create projects freely.**

<img width="1080" height="1269" alt="Screenshot_20260502_142129_com huawei browser_edit_699873059784349" src="https://github.com/user-attachments/assets/7941c208-ae99-4414-83f7-6dc9f133ad41" />
<img width="1080" height="1011" alt="Screenshot_20260502_142156_com huawei browser_edit_699863061777580" src="https://github.com/user-attachments/assets/faec4070-b144-421d-bb49-907f840f63e3" />
<img width="1080" height="1360" alt="Screenshot_20260502_143005_com huawei browser_edit_700193580144717" src="https://github.com/user-attachments/assets/03aabb6a-f9a6-4d9f-b968-ab5b88ae0ef9" />
<img width="1080" height="747" alt="Screenshot_20260502_142724_com huawei browser_edit_700093154814524" src="https://github.com/user-attachments/assets/078e4701-06b9-44db-89de-5aded7e75406" />
<img width="1080" height="1268" alt="Screenshot_20260502_142657_com huawei browser_edit_700083493428067" src="https://github.com/user-attachments/assets/6680c586-0d56-427c-b2ae-40aa5fcf3caf" />
<img width="1080" height="1256" alt="Screenshot_20260502_142508" src="https://github.com/user-attachments/assets/bd103d03-5395-467b-9376-9bbde611faf8" />
