### PR TITLE
add simulador-bds.is-a.dev

### DIFF
--- a/domains/domains/simulador-bds.json
+++ b/domains/domains/simulador-bds.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "JhonyVargas",
-    "email": "johnnyvargasluque@gmail.com"
-  },
-  "record": {
-    "CNAME": "jhonyvargas.github.io"
-  }
-}

--- a/domains/domains/simulador-bds.json
+++ b/domains/domains/simulador-bds.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "JhonyVargas",
+    "email": "johnnyvargasluque@gmail.com"
+  },
+  "record": {
+    "CNAME": "jhonyvargas.github.io"
+  }
+}

--- a/domains/simulador-bds.json
+++ b/domains/simulador-bds.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "JhonyVargas",
+    "email": "johnnyvargasluque@gmail.com"
+  },
+  "records": {
+    "CNAME": "jhonyvargas.github.io"
+  }
+}


### PR DESCRIPTION
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://jhonyvargas.github.io/simulador-bds/

# Website Purpose
Educational tool to practice SQL and NoSQL queries on 7 database engines (SQL Server, MySQL, PostgreSQL, SQLite, Oracle, MongoDB, Redis) without installing servers.
