### PR TITLE
Register mrinal.is-a.dev

### DIFF
--- a/domains/_vercel.mrinal.json
+++ b/domains/_vercel.mrinal.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "thepigdestroyer"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=is-a.dev,9832888dad2c15eabf5a"
+  }
+}

--- a/domains/_vercel.mrinal.json
+++ b/domains/_vercel.mrinal.json
@@ -4,6 +4,6 @@
     "email": "mrinaljoshi27@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=is-a.dev,9832888dad2c15eabf5a"
+    "TXT": "vc-domain-verify=mrinal.is-a.dev,3bd0a4301d97ea5eda48"
   }
 }

--- a/domains/_vercel.mrinal.json
+++ b/domains/_vercel.mrinal.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "thepigdestroyer"
+    "username": "thepigdestroyer",
+    "email": "mrinaljoshi27@gmail.com"
   },
   "records": {
     "TXT": "vc-domain-verify=is-a.dev,9832888dad2c15eabf5a"

--- a/domains/mrinal.json
+++ b/domains/mrinal.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "thepigdestroyer"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}

--- a/domains/mrinal.json
+++ b/domains/mrinal.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "thepigdestroyer"
+    "username": "thepigdestroyer",
+    "email": "mrinaljoshi27@gmail.com"
   },
   "records": {
     "A": ["216.198.79.1"]


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://portfolio-opal-xi-55.vercel.app

![Portfolio preview](https://image.thum.io/get/width/1280/crop/900/https://portfolio-opal-xi-55.vercel.app)

# Website Purpose

Personal portfolio for Mrinal Joshi — a PhD researcher at Imperial College London / UK Dementia Research Institute studying transcriptional regulation in microglia, and a developer building agentic AI tools.

The site showcases six active software/research projects spanning bioinformatics pipelines (PRIDICT 2.0 pegRNA design on Imperial HPC), agentic developer tools (a bioinformatics-native AI agent skill library, an agentic London rentals pipeline, an AI-supervised CFD trading bot), and experiments in agentic coding (TIC-TAC). Each project links back to its GitHub repository.

The site is hosted on Vercel; this PR adds the A record for the apex along with the `_vercel` TXT record required for domain verification.