### PR TITLE
Update forjex.is-a.dev: Point to GitHub Pages

### DIFF
--- a/domains/forjex.json
+++ b/domains/forjex.json
@@ -3,6 +3,6 @@
     "username": "hill-121"
   },
   "records": {
-    "CNAME": "forjex.netlify.app"
+    "CNAME": "hill-121.github.io"
   }
 }

--- a/domains/forjex.json
+++ b/domains/forjex.json
@@ -1,7 +1,6 @@
 {
   "owner": {
-    "username": "hill-121",
-    "email": "admin@forjex.dev"
+    "username": "hill-121"
   },
   "records": {
     "CNAME": "hill-121.github.io"

--- a/domains/forjex.json
+++ b/domains/forjex.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "hill-121"
+    "username": "hill-121",
+    "email": "admin@forjex.dev"
   },
   "records": {
     "CNAME": "hill-121.github.io"


### PR DESCRIPTION
## Update forjex.is-a.dev DNS

- Update CNAME record to point to GitHub Pages
- Target: hill-121.github.io
- Reason: Migrated from Netlify to GitHub Pages

cc @is-a-dev/maintainers

## Checklist
- [x] I confirm the subdomain is necessary and meets the [requirements](https://is-a.dev/help#what-is-allowed)
- [x] I agree to the [Terms of Service](https://is-a.dev/terms)
- [x] I confirm the website content is related to the application theme and publicly accessible