### PR TITLE
Register juanvillegas.is-a.dev

### DIFF
--- a/domains/juanvillegas.json
+++ b/domains/juanvillegas.json
@@ -1,0 +1,12 @@
+{
+  "description": "Personal portfolio and homelab projects",
+  "domain": "juanvillegas.is-a.dev",
+  "owner": {
+    "username": "JuanVillegas95",
+    "email": "juanemail2001@gmail.com"
+  },
+  "records": {
+    "CNAME": "5033c705-5d3c-4bcf-b887-d3f334dc3cb5.cfargotunnel.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://death-server.tailc0a8ce.ts.net/

This is the temporary URL where the site is currently hosted via Tailscale Funnel. Once `juanvillegas.is-a.dev` is approved, the site will be served through the Cloudflare Tunnel CNAME already configured in the JSON file.

The first project hosted is `honecita-x-mas` — an interactive Three.js Christmas card project featuring 3D models (flowers, couple, scenes), background music, and animated transitions.

<img width="1512" height="908" alt="image" src="https://github.com/user-attachments/assets/dd4140d9-3deb-43ff-a500-c4914ba0b2d8" />


<img width="1512" height="908" alt="image" src="https://github.com/user-attachments/assets/0b2471b9-c4ee-49cd-9f1b-4acb061688b9" />

# Website Purpose

This domain will serve as my **personal portfolio hub**, where I plan to publish multiple software development projects, each under its own subdomain. The setup is hosted on my own Raspberry Pi 5 homelab and routed through a Cloudflare Tunnel for secure public exposure (no exposed router ports, no commercial CDN).

## Planned subdomain structure

Once `juanvillegas.is-a.dev` is approved, I will create dedicated subdomains for each personal project, all managed through Cloudflare DNS:

- `juanvillegas.is-a.dev` — main portfolio landing page
- `honecita.juanvillegas.is-a.dev` — Three.js Christmas card (current project)
- `portafolio.juanvillegas.is-a.dev` — main portfolio site
- Additional subdomains for future development projects (web apps, experiments, demos)

All subdomains will route through the same self-hosted infrastructure (Raspberry Pi 5 + Coolify + Cloudflare Tunnel), making this a fully self-hosted portfolio ecosystem under a single root domain.

## Why is-a.dev

I'm using is-a.dev because it provides a clean, dev-focused domain at no cost, perfect for showcasing personal software development projects without committing to a paid TLD. This setup is purely for personal/non-commercial use as a learning and portfolio platform.