### PR TITLE
Register ideony.is-a.dev

### DIFF
--- a/domains/ideony.json
+++ b/domains/ideony.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "aciDrums7",
+    "email": "ideony@zohomail.eu"
+  },
+  "records": {
+    "NS": ["joel.ns.cloudflare.com", "luciana.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview

Live page: **https://ideony-portfolio.pages.dev/**

![ideony.is-a.dev preview](https://image.thum.io/get/width/1280/crop/800/https://ideony-portfolio.pages.dev/)

# Website Purpose

This is a personal developer notebook — an open-source TypeScript repository I keep as a long-running playground for things I want to learn properly. The page indexed at the root of `ideony.is-a.dev` describes what I'm working on (DDD in NestJS, Expo Router, queue-driven background jobs, self-hosted CI tooling) and links to the GitHub repository. Static page, no tracking, no third-party scripts.

The DNS records under this subdomain delegate to Cloudflare nameservers because I'm self-hosting a small GitLab CE instance and a private container registry on a Hetzner box, and the GitLab Omnibus needs to issue TLS certificates for second-level subdomains (`gitlab.*`, `registry.*`) it owns. Adding individual A/CNAME records via separate PRs every time the internal layout changes wasn't practical for tooling that's purely behind-the-scenes for the project.

Not a deployed product, no users, nothing to log into.
