### PR TITLE
Register luisapr1.is-a.dev

### DIFF
--- a/domains/luisapr1.json
+++ b/domains/luisapr1.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "LuisAPR1"
+  },
+  "records": {
+    "CNAME": "luisapr1.netlify.app"
+  }
+}

--- a/domains/www.luisapr1.json
+++ b/domains/www.luisapr1.json
@@ -3,6 +3,6 @@
     "username": "LuisAPR1"
   },
   "records": {
-    "A": ["75.2.60.5"]
+    "CNAME": "luisapr1.netlify.app"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live preview:** https://luisapr1.netlify.app

(After merge and DNS propagation, the site will also resolve at https://luisapr1.is-a.dev.)

![Screenshot of luisapr1.netlify.app](https://image.thum.io/get/width/1280/crop/800/noanimate/https://luisapr1.netlify.app)

# Website Purpose

Personal developer portfolio website. I'm a Computer Science MSc student at Instituto Superior Técnico (Lisbon), and the site showcases:

- My CV / resume (full details + downloadable PDF and LaTeX source)
- A portfolio of personal and academic software projects, including: a permissioned blockchain with HotStuff BFT consensus, an end-to-end ETL/OLAP data warehouse, a from-scratch Java neural network for MNIST, a distributed key-value store (FastAPI / Redis / RabbitMQ / CockroachDB), and a 2D physics engine
- A technical blog with posts on distributed systems, machine learning, and full-stack development
- An About page and contact information

The site is built with Hugo, deployed on Netlify, fully open source at https://github.com/LuisAPR1/portfolio. No commercial use whatsoever — purely a personal/professional showcase.
