### PR TITLE
Register digestbot.is-a.dev

### DIFF
--- a/domains/digestbot.json
+++ b/domains/digestbot.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "baklaki52",
+        "email": "baklaki52@proton.me"
+    },
+    "records": {
+        "A": ["94.103.188.125"]
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview (until DNS propagates and the vhost moves to the new domain): https://telescope.cv/miniapp/

After DNS propagation the same content will live at https://digestbot.is-a.dev/miniapp/.

![Дайджест-бот landing](https://raw.githubusercontent.com/baklaki52/register/preview-assets/digestbot-preview.png)

# Website Purpose

`digestbot.is-a.dev` will host the landing page and Mini App for **Дайджест-бот** — a small Telegram Mini App that produces daily thematic digests from public sources for a small invite-only group of developers and analysts.

Five tracks:

- **World Радар** — geopolitics from 40+ TG channels, RSS, Twitter, GDELT, Polymarket
- **Tech & AI** — models, research, GitHub trends, Hacker News, ArXiv
- **Ближний Восток** — OSINT analytics
- **РКН & VPN** — anti-censorship tooling, DPI, open-source releases
- **Аналитик** — weekly cross-domain synthesis over the archive

The site is **non-commercial**: invite-only, no ads, no paid tiers, no monetisation. It is a developer tool for keeping up with networking / security / AI research. Visitors outside Telegram see the landing page (shown above); inside Telegram the Mini App opens through `@AIDigest007_bot`.
