### PR TITLE
Register turing-ris.is-a.dev

### DIFF
--- a/domains/turing-ris.json
+++ b/domains/turing-ris.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "StudUserRIS",
+        "email": "ignovokreshchenov@edu.hse.ru"
+    },
+    "records": {
+        "CNAME": "StudUserRIS.github.io"
+    }
+}


### PR DESCRIPTION
## Description

I'm registering `turing-ris.is-a.dev` for a non-commercial educational software project — a Turing Machine Interpreter, which is my coursework as a student of group RIS-24-2.

## Project details

- **Name:** Интерпретатор машины Тьюринга (Turing Machine Interpreter)
- **Type:** Non-commercial educational / coursework project
- **Description:** A client-server educational system for designing and step-by-step execution of algorithms on an abstract Turing Machine. The project consists of a WinForms desktop client (.NET Framework 4.8, C#) and an ASP.NET Core 8 backend with PostgreSQL and SignalR. It implements a role-based model (Admin / Teacher / Student), full course and assignment management, real-time notifications, and grading workflows.
- **Technologies:** C#, .NET Framework 4.8, ASP.NET Core 8, PostgreSQL, Dapper, SignalR, WinForms, BCrypt
- **Hosting:** GitHub Pages (static landing page describing the project)
- **Live preview:** https://StudUserRIS.github.io/turing-ris/

## Checklist

- [x] My website is software-development related
- [x] My website is non-commercial
- [x] My website is complete and contains real content (not blank or placeholder)
- [x] I have read and agree to the [Terms of Service](https://is-a.dev/terms)
- [x] The JSON file is valid and follows the required format
- [x] The filename matches the requested subdomain (`turing-ris.json`)
- [x] My GitHub username in the JSON matches the account submitting this PR
