### PR TITLE
Register windows-rectangle.is-a.dev

### DIFF
--- a/domains/windows-rectangle.json
+++ b/domains/windows-rectangle.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "yanmad27",
+    "email": "yanmad27@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Requirements
[x] I agree to the [Terms of Service](https://is-a.dev/terms).
[x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
[x] My website is reachable and completed.
[x] My website is software development related.
[x] My website is not for commercial use.
[x] I have provided contact information in the owner key.
[x] I have provided a preview of my website below.

Registering `windows-rectangle.is-a.dev` for the open-source project [windows-rectangle](https://github.com/yanmad27/windows-rectangle) — a free Windows tray app that resizes the active window with global hotkeys (Rust-based macOS Rectangle clone).

Site is hosted on Vercel; CNAME points to `cname.vercel-dns.com`.

- Owner: @yanmad27
- Project repo: https://github.com/yanmad27/windows-rectangle