### PR TITLE
add raffi.is-a.dev

### DIFF
--- a/domains/raffi.json
+++ b/domains/raffi.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Wallens11",
+    "email": "raffi@funtoco.jp"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain Registration

**Domain:** `raffi.is-a.dev`

**Record:**
```json
{
  "CNAME": "cname.vercel-dns.com"
}
```

**Description:** Personal portfolio for Raffi Windarto — software engineer (Osaka / Remote). Site is hosted on Vercel.

**GitHub:** https://github.com/Wallens11
**Site (temporary URL):** https://portfolio-nu-seven-1xyfqw3iwx.vercel.app