### PR TITLE
add m4rkdown.is-a.dev

### DIFF
--- a/domains/m4rkdown.json
+++ b/domains/m4rkdown.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/is-a-dev/register/main/schemas/domain.schema.json",
+  "description": "M4rkdown — Fast, offline-first Markdown editor with real-time collab and typing arena",
+  "repo": "https://github.com/zhenxiao-yu/m4rkdown-editor",
+  "owner": {
+    "username": "zhenxiao-yu",
+    "email": "markyu0615@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Requesting m4rkdown.is-a.dev for M4rkdown — fast offline-first Markdown editor. Owner: @zhenxiao-yu. CNAME: cname.vercel-dns.com