### PR TITLE
Add swiftprosys.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-swiftprosyssfdev3-star.swiftprosys.json
+++ b/domains/_github-pages-challenge-swiftprosyssfdev3-star.swiftprosys.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "swiftprosyssfdev3-star"
+    },
+    "records": {
+        "TXT": "9abbbebbe1476bbe6ee7f9a87ed5f0"
+    }
+}

--- a/domains/swiftprosys.json
+++ b/domains/swiftprosys.json
@@ -1,0 +1,10 @@
+{
+    "description": "SwiftProsys Image Extraction Platform",
+    "owner": {
+        "username": "swiftprosyssfdev3-star"
+    },
+    "records": {
+        "CNAME": "swiftprosyssfdev3-star.github.io"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
## Description

Add domain `swiftprosys.is-a.dev` for the SwiftProsys Image Extraction Platform.

## Files Added

- `domains/swiftprosys.json` — CNAME record pointing to `swiftprosyssfdev3-star.github.io`
- `domains/_github-pages-challenge-swiftprosyssfdev3-star.swiftprosys.json` — GitHub Pages TXT verification

## Preview

The website will be available at https://swiftprosys.is-a.dev once the PR is merged and DNS propagates. The site is hosted on GitHub Pages at `swiftprosyssfdev3-star.github.io`.

## Checklist

- [x] File is in the `domains/` directory
- [x] File name matches subdomain (swiftprosys.json)
- [x] All required fields present (`owner.username`, `records`)
- [x] CNAME does not point to itself
- [x] Records are valid per the schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)