### PR TITLE
Add travelguide-app.is-a.dev

### DIFF
--- a/domains/travelguide-app.json
+++ b/domains/travelguide-app.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schemas/domain.schema.json",
+  "description": "A web portal for the TravelGuide project",
+  "repo": "https://github.com/hoangtri22/TravelGuide",
+  "owner": {
+    "username": "hoangtri22",
+    "email": "ngnhoangtri2206@gmail.com"
+  },
+  "records": {
+    "CNAME": "hoangtri22.github.io"
+  }
+}


### PR DESCRIPTION
A web portal for the TravelGuide project, where admins manage points of interest and users can download the latest Android APK via a stable QR code link.