### PR TITLE
Register oscaralvarez.is-a.dev

### DIFF
--- a/domains/_vercel.oscaralvarez.json
+++ b/domains/_vercel.oscaralvarez.json
@@ -1,0 +1,11 @@
+{
+  "description": "Vercel domain ownership verification TXT for oscaralvarez.is-a.dev",
+  "repo": "https://github.com/oscar-rolando-alvarez/oscaralvarez-dev",
+  "owner": {
+    "username": "oscar-rolando-alvarez",
+    "email": "oralvarez@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=oscaralvarez.is-a.dev,82f1632aa0c4b5fa232e"
+  }
+}

--- a/domains/oscaralvarez.json
+++ b/domains/oscaralvarez.json
@@ -6,6 +6,6 @@
     "email": "oralvarez@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com."
+    "CNAME": "cname.vercel-dns.com"
   }
 }

--- a/domains/oscaralvarez.json
+++ b/domains/oscaralvarez.json
@@ -1,0 +1,11 @@
+{
+  "description": "Personal portfolio for Oscar Rolando Alvarez Cardenas — Principal AI Systems Architect, founder of Arkis Group. Built with Next.js 15, TypeScript, Tailwind, Framer Motion and next-intl. Bilingual (ES/EN), deployed on Vercel.",
+  "repo": "https://github.com/oscar-rolando-alvarez/oscaralvarez-dev",
+  "owner": {
+    "username": "oscar-rolando-alvarez",
+    "email": "oralvarez@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com."
+  }
+}


### PR DESCRIPTION
## Domain
`oscaralvarez.is-a.dev` → CNAME → `cname.vercel-dns.com`

## Purpose
Personal portfolio for Oscar Rolando Alvarez Cardenas — Principal AI Systems Architect, founder of Arkis Group.

## Source
- Public repo: https://github.com/oscar-rolando-alvarez/oscaralvarez-dev
- Stack: Next.js 15, TypeScript, Tailwind, Framer Motion, next-intl
- Bilingual (ES/EN), deployed on Vercel
- Currently live at: https://oscaralvarez-dev.vercel.app

## Checklist
- [x] Single domain JSON file added under `domains/`
- [x] Filename matches subdomain (lowercase, no special chars)
- [x] `owner.username` matches the GitHub user opening this PR
- [x] `owner.email` is a real address
- [x] `records.CNAME` points to a valid hosting target
- [x] No conflicting / pre-existing entry for this subdomain