### PR TITLE
Add ai-calisthenics-tutor.is-a.dev

### DIFF
--- a/domains/ai-calisthenics-tutor.json
+++ b/domains/ai-calisthenics-tutor.json
@@ -1,0 +1,12 @@
+{
+  "description": "AI-powered push-up form analyzer built at Yale",
+  "repo": "https://github.com/gerald512-beep/CalisthenicsTutorV0",
+  "owner": {
+    "username": "gerald512-beep",
+    "email": "Gerald512@gmail.com"
+  },
+  "record": {
+    "CNAME": "a08fd908-1502-41e8-9bfe-1973fc87fe6a.cfargotunnel.com"
+  },
+  "proxied": true
+}

--- a/domains/ai-calisthenics-tutor.json
+++ b/domains/ai-calisthenics-tutor.json
@@ -5,8 +5,7 @@
     "username": "gerald512-beep",
     "email": "Gerald512@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "a08fd908-1502-41e8-9bfe-1973fc87fe6a.cfargotunnel.com"
-  },
-  "proxied": true
+  }
 }


### PR DESCRIPTION
Registering ai-calisthenics-tutor.is-a.dev for an AI-powered push-up form analyzer built at Yale.