### PR TITLE
Add hooksniff.is-a.dev with Resend DNS records

### DIFF
--- a/domains/_resend._domainkey.hooksniff.json
+++ b/domains/_resend._domainkey.hooksniff.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "servetarslan02",
+    "email": "noreply@hooksniff.is-a.dev"
+  },
+  "records": {
+    "TXT": [
+      "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDa3wt33koYemEKLi0Fbf/xttHHbme0VaXjSG39D+TQoFuw5Tkap4eLmSP59CNB1DaZ16vI96tDhBi+ffZls7x3nQR4ap/byQm/bg9eTc4yg2PsCLpfcTzTTksK3/mv66Of3dDAZVPjk7sFPNS5ZHCyxCruUUFwMoGNeX4ZDVHuXwIDAQAB"
+    ]
+  }
+}

--- a/domains/hooksniff.json
+++ b/domains/hooksniff.json
@@ -1,0 +1,18 @@
+{
+  "owner": {
+    "username": "servetarslan02",
+    "email": "noreply@hooksniff.is-a.dev"
+  },
+  "records": {
+    "A": ["104.18.5.103", "104.18.4.103"],
+    "MX": [
+      {
+        "target": "feedback-smtp.us-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": [
+      "v=spf1 include:amazonses.com ~all"
+    ]
+  }
+}


### PR DESCRIPTION
## Adding hooksniff.is-a.dev

### Purpose
Adding Resend email DNS records for the HookSniff webhook delivery service.

### Changes
- Added `hooksniff.json` with A, MX, and TXT (SPF) records
- Added `_resend._domainkey.hooksniff.json` with DKIM TXT record

### DNS Records
| Type | Name | Value |
|------|------|-------|
| A | hooksniff | 104.18.5.103, 104.18.4.103 |
| MX | send.hooksniff | feedback-smtp.us-east-1.amazonses.com (priority: 10) |
| TXT | send.hooksniff | v=spf1 include:amazonses.com ~all |
| TXT | resend._domainkey.hooksniff | DKIM public key |