### PR TITLE
Add hooksniff.is-a.dev and api.hooksniff.is-a.dev

### DIFF
--- a/domains/api.hooksniff.json
+++ b/domains/api.hooksniff.json
@@ -4,6 +4,6 @@
     "email": "servetarslan02@github.com"
   },
   "records": {
-    "CNAME": "api.hooksniff.is-a.dev.cdn.cloudflare.net"
+    "CNAME": "hooksniff-api-sdjufmaqka-ew.a.run.app"
   }
 }

--- a/domains/api.hooksniff.json
+++ b/domains/api.hooksniff.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "servetarslan02",
+    "email": "servetarslan02@github.com"
+  },
+  "records": {
+    "CNAME": "api.hooksniff.is-a.dev.cdn.cloudflare.net"
+  }
+}

--- a/domains/hooksniff.json
+++ b/domains/hooksniff.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "servetarslan02",
+    "email": "servetarslan02@github.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Adding hooksniff domains

- **hooksniff.is-a.dev** → Vercel Dashboard (cname.vercel-dns.com)
- **api.hooksniff.is-a.dev** → Cloudflare CDN (api.hooksniff.is-a.dev.cdn.cloudflare.net)

### Purpose
HookSniff is a webhook delivery service for developers. These domains will serve:
- Main dashboard (hooksniff.is-a.dev)
- API endpoint (api.hooksniff.is-a.dev)