### PR TITLE
feat(domain): add network-tools.is-a.dev

### DIFF
--- a/domains/network-tools.json
+++ b/domains/network-tools.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ksp1026-glitch",
+    "email": "ksp1026-glitch@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "ksp1026-glitch.github.io"
+  }
+}


### PR DESCRIPTION
## Domain: network-tools.is-a.dev

This subdomain points to my GitHub Pages site hosting a collection of web tools (URL encoder, QR code generator, password generator, etc.).

- **CNAME**: ksp1026-glitch.github.io
- **GitHub Pages**: https://ksp1026-glitch.github.io/network-tools

Thank you!