### PR TITLE
add _vercel.raffi.json for Vercel ownership verification

### DIFF
--- a/domains/_vercel.raffi.json
+++ b/domains/_vercel.raffi.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "Wallens11",
+    "email": "raffiwindartobisnis@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=raffi.is-a.dev,cc15508fb3965aac2d8a",
+      "vc-domain-verify=www.raffi.is-a.dev,8c34240f0bf32307ad32"
+    ]
+  }
+}

--- a/domains/_vercel.raffi.json
+++ b/domains/_vercel.raffi.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "Wallens11",
-    "email": "raffiwindartobisnis@gmail.com"
+    "email": "muhammadraffiwindarto@gmail.com"
   },
   "records": {
     "TXT": [


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://portfolio-nu-seven-1xyfqw3iwx.vercel.app

![Portfolio preview](https://portfolio-nu-seven-1xyfqw3iwx.vercel.app/opengraph-image)

# Website Purpose

This PR adds the `_vercel.raffi.is-a.dev` TXT records required by Vercel to verify domain ownership when adding `raffi.is-a.dev` as a custom domain on a Vercel project. Vercel requires this TXT record because the domain is currently linked to another Vercel account (the is-a.dev team account). This is a follow-up to PR #37770 which registered `raffi.is-a.dev`.