### PR TITLE
Add over.is-a.dev

### DIFF
--- a/domains/over.json
+++ b/domains/over.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Jeremy-Koder",
+    "email": "bezdarebanyblat@gmail.com"
+  },
+  "records": {
+    "CNAME": "jeremy-koder.github.io"
+  }
+}


### PR DESCRIPTION
Adds over.is-a.dev pointing to jeremy-koder.github.io for the OVER project site hosted on GitHub Pages.