### PR TITLE
Add Vercel configuration for domain verification

### DIFF
--- a/domains/_vercel.shankumar.json
+++ b/domains/_vercel.shankumar.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "shankumar7",
+    "email": "Shankumarpitta714@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=shankumar.is-a.dev,1ca85280039f9c6f585a",
+      "vc-domain-verify=www.shankumar.is-a.dev,2ff080a1086fa4299c52"
+    ]
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://shankumar.vercel.app (Current deployment)
Domain: https://shankumar.is-a.dev

<!-- Note to Reviewer: I am adding a _vercel verification record to claim the domain in my Vercel project as requested by Vercel's security policy. -->

# Website Purpose
This is my personal portfolio website. It showcases my software development projects, technical skills, and experience to potential collaborators and employers.
