### PR TITLE
Register shulgin.is-a.dev

### DIFF
--- a/domains/shulgin.json
+++ b/domains/shulgin.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Sanexxxx777",
+        "email": "sanexxx777@gmail.com"
+    },
+    "records": {
+        "CNAME": "sanexxxx777.github.io"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live URL: https://sanexxxx777.github.io/

Screenshot:

![shulgin.is-a.dev preview](https://sanexxxx777.github.io/preview.png)

# Website Purpose

Personal developer portfolio of Aleksandr Shulgin (backend / Python / LLM / Web3). Single-page brutalist site presenting engineering principles, shipped projects, tech stack and contacts for potential employers and collaborators. Non-commercial: no paid offering, no ads, no revenue stream — strictly a CV / showcase.

Re-submission of the previous incomplete PR #37687 (closed for missing template). DNS record, file location and JSON schema are unchanged from the previous attempt where CI passed; this PR adds the required template, ToS agreement and a preview screenshot.
