### PR TITLE
Bring pragx home to is-a.dev

### DIFF
--- a/domains/_vercel.pragx.json
+++ b/domains/_vercel.pragx.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "PragneshNonghanvadra"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=pragx.is-a.dev,91f77a2e363e8813d65c"
+    }
+}

--- a/domains/pragx.json
+++ b/domains/pragx.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "PragneshNonghanvadra"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
# Requirements

  - [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
  - [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
  - [x] My website is **reachable** and **completed**.
  - [x] My website is **software development** related.
  - [x] My website is **not for commercial use**.
  - [x] I have provided contact information in the `owner` key.
  - [x] I have provided a preview of my website below.

  # Website Preview

  Live preview: https://pragx.vercel.app

  Screenshot:
  <img width="1206" height="888" alt="image" src="https://github.com/user-attachments/assets/c3f488e1-cd59-4e30-8577-73003cab6e7c" />

  
  # Website Purpose

  This is my personal developer portfolio website. It showcases my software development projects, technical skills, experience, and
  contact/profile links in one place. The website is non-commercial and is intended to represent my work as a developer.