### PR TITLE
Register dashbench.is-a.dev

### DIFF
--- a/domains/dashbench.json
+++ b/domains/dashbench.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "taktam",
+    "email": "tamastakacs408@gmail.com"
+  },
+  "records": {
+    "CNAME": "dashbench.github.io"
+  },
+  "description": "Linux desktop toolkit for processing dashcam recordings (DashBenchApp)."
+}


### PR DESCRIPTION
Hello!

Registering `dashbench.is-a.dev` for the **DashBenchApp** project — a Linux desktop toolkit for processing dashcam recordings.

- Project landing page (already live): https://dashbench.github.io/
- Source code: https://github.com/dashbench/dashbench (currently private; v1.0.0 will be the first public release)
- License: MIT

The CNAME points to the GitHub Pages site `dashbench.github.io`.

Thank you for maintaining this service!