### PR TITLE
fix: update harshith.is-a.dev CNAME to Netlify

### DIFF
--- a/domains/harshith.json
+++ b/domains/harshith.json
@@ -4,6 +4,6 @@
         "email": "harshithx@duck.org"
     },
     "records": {
-        "CNAME": "cname.vercel-dns.com"
+        "CNAME": "harshithbhosale.netlify.app"
     }
 }


### PR DESCRIPTION
## Changes
Updating CNAME from `cname.vercel-dns.com` to `harshithbhosale.netlify.app` — site is on Netlify, not Vercel.

## Checklist
- [x] I have read and understood the [Terms of Service](https://is-a.dev/terms)
- [x] I have checked that the domain I am registering is not already taken
- [x] I have the right to use the domain name I am registering
- [x] My website is live and accessible

**Website**: https://harshithbhosale.netlify.app
**Purpose**: Personal portfolio — Technology Consultant & Automation Engineer (correction PR: previous used wrong CNAME)