### PR TITLE
Add thyroxeia.is-a.dev

### DIFF
--- a/domains/thyroxeia.json
+++ b/domains/thyroxeia.json
@@ -1,0 +1,11 @@
+{
+  "description": "Thyroxeia AI - Study Smarter with Gemini AI",
+  "repo": "https://github.com/gabron920-sudo/thyroxeia-deploy",
+  "owner": {
+    "username": "gabron920-sudo",
+    "email": "gabron920@gmail.com"
+  },
+  "record": {
+    "CNAME": "thyroxeia-ai.fancy-sky-31cf.workers.dev"
+  }
+}


### PR DESCRIPTION
Hi! I would like to register `thyroxeia.is-a.dev` for my Thyroxeia AI study platform.

- **Domain:** `thyroxeia.is-a.dev`
- **Target:** `thyroxeia-ai.fancy-sky-31cf.workers.dev` (Cloudflare Worker)
- **Project:** AI-powered flashcard and study platform
- **Repo:** https://github.com/gabron920-sudo/thyroxeia-deploy