### PR TITLE
Register json-to-ts.is-a.dev

### DIFF
--- a/domains/json-to-ts.json
+++ b/domains/json-to-ts.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "west0nG",
+    "email": "agent+is-a-dev@west0n.top"
+  },
+  "records": {
+    "CNAME": "json-to-ts-app.netlify.app"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://json-to-ts-app.netlify.app/

Preview image (Open Graph card):

![json-to-ts preview](https://json-to-ts-app.netlify.app/og-image.png)

# Website Purpose

`json-to-ts` is a free, open-source, browser-based developer utility that converts a JSON sample into a TypeScript `interface` / `type`, a [Zod](https://zod.dev) schema, or a [Valibot](https://valibot.dev) schema. The conversion runs entirely client-side — pasted JSON never leaves the browser tab.

It is a personal hobby project: MIT-licensed, no signup, no ads, no payments, no analytics beyond a tiny privacy-friendly hit counter. Source is public at https://github.com/SolvoHQ/json-to-ts.

The `is-a.dev` subdomain would be used as a friendlier, more memorable hostname for the same content already served at `*.netlify.app`. The canonical URL across all pages is preserved as `https://json-to-ts-app.netlify.app/...` (per the existing `<link rel="canonical">` on every page) so this is purely a parallel hostname, not a redirect target.

# Notes

- CNAME points at the existing Netlify deploy: `json-to-ts-app.netlify.app`.
- Owner is registered to my individual GitHub account (`west0nG`), per TOS section 2.
