### PR TITLE
Register yang-tracker.is-a.dev

### DIFF
--- a/domains/yang-tracker.json
+++ b/domains/yang-tracker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "diddytpq",
+    "email": "yoseph97@may-i.io"
+  },
+  "record": {
+    "CNAME": "e62c9622-84c6-480a-bfab-66aa0b596baf.cfargotunnel.com"
+  }
+}

--- a/domains/yang-tracker.json
+++ b/domains/yang-tracker.json
@@ -3,7 +3,7 @@
     "username": "diddytpq",
     "email": "yoseph97@may-i.io"
   },
-  "record": {
+  "records": {
     "CNAME": "e62c9622-84c6-480a-bfab-66aa0b596baf.cfargotunnel.com"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

The site is a self-hosted full-stack web app routed through a Cloudflare Named Tunnel. It will resolve at `https://yang-tracker.is-a.dev` immediately upon merge (the CNAME target `e62c9622-84c6-480a-bfab-66aa0b596baf.cfargotunnel.com` is already configured and the tunnel is live).

Stack & implementation details:
- Backend: FastAPI + SQLAlchemy + SQLite, JWT auth
- Frontend: React + TypeScript + Vite + TanStack Query, PWA-installable
- Tunnel: Cloudflare locally-managed tunnel via `config.yml` ingress

The app requires login (single-user, personal). A reviewer can confirm the tunnel is reachable by sending an HTTP request directly to the cfargotunnel target; the FastAPI server returns a login page (HTTP 200, `text/html`).

# Website Purpose

Personal software-engineering project — a FastAPI + React full-stack app I built from scratch to track and visualize my own brokerage account holdings (KOSPI / NASDAQ tickers, KRW/USD valuation, daily snapshots, market-index dashboard). It is a non-commercial personal tool. The implementation itself (auth, OCR pipeline for image-based holding updates, scheduled snapshots, mobile-responsive UI, Cloudflare-Tunnel-based self-hosting) is the primary motivation — the domain hosts the live deployment of that engineering work.
