### PR TITLE
Register ogff.is-a.dev

### DIFF
--- a/domains/ogff.json
+++ b/domains/ogff.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "origamigriffin",
+        "email": "Origami.griffin@icloud.com"
+    },
+    "records": {
+        "NS": [
+            "celine.ns.cloudflare.com",
+            "fonzie.ns.cloudflare.com"
+        ]
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

A working preview of the portal (currently exposed via a temporary `*.trycloudflare.com` quick tunnel; will move to `ogff.is-a.dev` if this PR is approved):

**URL:** https://file-books-andy-aspects.trycloudflare.com
**Access code:** `0512`

The portal is gated behind a 4-digit access code — without it you only see the login screen. The code above is shared so reviewers can verify the site is real and complete.

The portal is a self-hosted FastAPI + Jinja2 app. Source code at https://github.com/origamigriffin/griffin-build-bundle (private; happy to share read-only access on request).

# Website Purpose

`ogff.is-a.dev` will host a **personal coordination portal** for an open-source-style smart-home build I'm doing (Home Assistant, Frigate, Zigbee2MQTT, WLED, Ubiquiti). The portal is built in Python (FastAPI + Jinja2 + SSE) and serves as:

1. A live reference for device hostnames, IPs, MACs, port assignments, and service URLs (rendered from CSV manifests in the repo)
2. A web UI for running deployment scripts (e.g. `unifi/push-config.sh`, `ha/push-config.sh`) with risk-graded confirmation flow + real-time log streaming
3. An audit log of every action taken

This is non-commercial — it's my own home build, the source is open in the linked GitHub repo, and the portal exists so I can hand operational tasks to a tech assistant without giving them root access to all my systems. Falls under "developer's portfolio / personal infrastructure project".

NS delegation requested so I can manage DNS via Cloudflare (for cloudflared tunnel + Cloudflare Access policies once the domain is live).