### PR TITLE
Register portfolio.is-a.dev

### DIFF
--- a/domains/portfolio.json
+++ b/domains/portfolio.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "hanjungwoo3",
+    "email": "jwhan@cafe24corpai.com"
+  },
+  "description": "Official demo for portfolio-web — open-source Korean stock portfolio tracker",
+  "repo": "https://github.com/hanjungwoo3/portfolio-web",
+  "record": {
+    "CNAME": "hanjungwoo3.github.io"
+  }
+}

--- a/domains/portfolio.json
+++ b/domains/portfolio.json
@@ -5,7 +5,7 @@
   },
   "description": "Official demo for portfolio-web — open-source Korean stock portfolio tracker",
   "repo": "https://github.com/hanjungwoo3/portfolio-web",
-  "record": {
+  "records": {
     "CNAME": "hanjungwoo3.github.io"
   }
 }


### PR DESCRIPTION
## Description

This subdomain will host the official demo of [portfolio-web](https://github.com/hanjungwoo3/portfolio-web), an open-source Korean stock portfolio tracker.

## Why this domain?

The project already has 4+ active forks running on personal GitHub Pages instances (go2gogo, finance.lifebuzz.xyz, greatois-lab, aswoogi), making `portfolio.is-a.dev` an ideal canonical demo URL for the OSS community.

## Usage

- Live demo for OSS users to try before forking
- Documentation reference link
- Not for commercial purposes

## Checklist

- [x] I have read the [registration documentation](https://www.is-a.dev/docs/)
- [x] I have read the [JSON file structure](https://www.is-a.dev/docs/json-structure)
- [x] My JSON file is valid
- [x] My website meets the requirements