### PR TITLE
Add orbit.json with domain owner and records

### DIFF
--- a/domains/orbit.json
+++ b/domains/orbit.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "neycooks",
+        "email": "fifakitzofficil@gmail.com"
+    },
+    "records": {
+        "URL": "https://orbit.fifakitzofficil.workers.dev"
+    }
+}


### PR DESCRIPTION
# Requirements
- [x] i agree to the terms of service
- [x] my file follows the domain structure
- [x] my website is reachable and completed
- [x] my website is software development related
- [x] my website is not for commercial use
- [x] i have provided contact info in the owner key
- [x] i have provided a preview of my website below
# Website Preview
live link: https://orbit.fifakitzofficil.workers.dev
screenshots: (screenshots of the landing page — hero section, api explorer, feature cards, docs table — all visible)
# Website Purpose
orbit api is a free rest api that serves real-time ea fc (fifa) player stats, club data, league info, and nation flags. its built for devs who wanna build fifa-related apps, trackers, or tools without dealing with bloated scrapers or paid apis. think of it like a lightweight, developer-first alternative for fetching fifa player data fast and clean. i know i have mentioned the url early in the website, ill change it if rejection occors. THE LANDING PAGE OF THE API SITE IS - https://neycooks.github.io/orbit/

- note from me [i am requesting this domain for the cloudflare api and not for the api landing page :D, i told this so that no confusion happens]

<img width="1295" height="731" alt="Screenshot 2026-05-10 144401" src="https://github.com/user-attachments/assets/378a1c89-1b3e-4adc-b411-22d364eda910" />
<img width="1294" height="723" alt="Screenshot 2026-05-10 144336" src="https://github.com/user-attachments/assets/e0be3718-faf3-45bf-aa50-c78fe5309561" />
<img width="1297" height="723" alt="Screenshot 2026-05-10 144317" src="https://github.com/user-attachments/assets/3789a953-7310-49b7-a049-2a43905b7a13" />
<img width="1298" height="724" alt="Screenshot 2026-05-10 144249" src="https://github.com/user-attachments/assets/f97dc294-4a29-45b2-baf6-725ba80d2bbf" />
<img width="1302" height="718" alt="Screenshot 2026-05-10 144418" src="https://github.com/user-attachments/assets/0cdf5ad8-b06f-4747-bc48-a9a781617e41" />
