### PR TITLE
Register tribebuilder.is-a.dev

### DIFF
--- a/domains/tribebuilder.json
+++ b/domains/tribebuilder.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+          "username": "lanmind2001"
+    },
+    "records": {
+          "CNAME": "lanmind2001.github.io",
+          "TXT": "tiktok-developers-site-verification=RR0Xxffocu7uP1zzYW3GpiKRY3n5oCgH"
+    },
+    "proxied": true
+}

--- a/domains/tribebuilder.json
+++ b/domains/tribebuilder.json
@@ -4,8 +4,7 @@
               "email": "lanmind2001@gmail.com"
       },
       "records": {
-              "CNAME": "lanmind2001.github.io",
-              "TXT": "tiktok-developers-site-verification=RR0Xxffocu7uP1zzYW3GpiKRY3n5oCgH"
+              "CNAME": "lanmind2001.github.io"
       },
       "proxied": true
 }

--- a/domains/tribebuilder.json
+++ b/domains/tribebuilder.json
@@ -1,10 +1,11 @@
 {
-    "owner": {
-          "username": "lanmind2001"
-    },
-    "records": {
-          "CNAME": "lanmind2001.github.io",
-          "TXT": "tiktok-developers-site-verification=RR0Xxffocu7uP1zzYW3GpiKRY3n5oCgH"
-    },
-    "proxied": true
+      "owner": {
+              "username": "lanmind2001",
+              "email": "lanmind2001@gmail.com"
+      },
+      "records": {
+              "CNAME": "lanmind2001.github.io",
+              "TXT": "tiktok-developers-site-verification=RR0Xxffocu7uP1zzYW3GpiKRY3n5oCgH"
+      },
+      "proxied": true
 }


### PR DESCRIPTION
CNAME to lanmind2001.github.io for OAuth redirect page used by TribeBuilder iOS app.
Updated: Removed TXT record that conflicted with CNAME (DNS spec prohibits other records alongside CNAME). Now contains only the CNAME record.