### PR TITLE
Update portfolio.is-a.dev: switch to URL redirect

### DIFF
--- a/domains/portfolio.json
+++ b/domains/portfolio.json
@@ -3,9 +3,9 @@
     "username": "hanjungwoo3",
     "email": "jwhan@cafe24corpai.com"
   },
-  "description": "Official demo for portfolio-web — open-source Korean stock portfolio tracker",
+  "description": "URL redirect for portfolio-web — open-source Korean stock portfolio tracker",
   "repo": "https://github.com/hanjungwoo3/portfolio-web",
   "records": {
-    "CNAME": "hanjungwoo3.github.io"
+    "URL": "https://hanjungwoo3.github.io/portfolio-web/"
   }
 }


### PR DESCRIPTION
## Description

Switching `portfolio.is-a.dev` from a GitHub Pages CNAME record to a URL redirect, pointing to the existing site at `https://hanjungwoo3.github.io/portfolio-web/`.

## Why this change?

The original CNAME setup would have moved the site to a new origin (`portfolio.is-a.dev`), which would break **existing users** because:

- Browser data is origin-isolated — IndexedDB, localStorage, Service Worker cache, OAuth refresh tokens, and installed PWA state all live under `hanjungwoo3.github.io` and would become inaccessible after the move.
- Many users store portfolio data locally (without Google Drive sync) — they would lose data permanently.
- PWA-installed users would need to reinstall.

By using a URL redirect, the short `portfolio.is-a.dev` domain still works as a memorable entry point, but visitors land on the original site origin where their data already exists.

## Changes

- `records.CNAME` → `records.URL`
- Description updated to reflect the redirect behavior

## Checklist

- [x] I have read the [registration documentation](https://www.is-a.dev/docs/)
- [x] I have read the [JSON file structure](https://www.is-a.dev/docs/json-structure)
- [x] My JSON file is valid
- [x] My website meets the requirements