### PR TITLE
Add fares.is-a.dev domain

### DIFF
--- a/domains/fares.json
+++ b/domains/fares.json
@@ -1,0 +1,9 @@
+{
+  "domain": "fares.is-a.dev",
+  "owner": {
+    "email": "ferisbouzayen@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Adding my personal domain fares.is-a.dev pointing to Vercel (CNAME: cname.vercel-dns.com).