### PR TITLE
Register burgmann.is-a.dev and nested enhancedspaces subdomain

### DIFF
--- a/domains/burgmann.json
+++ b/domains/burgmann.json
@@ -1,0 +1,10 @@
+{
+  "description": "Official Developer Portfolio and Project Portal for Franz Burgmann",
+  "owner": {
+    "username": "franzbu",
+    "email": "csaa6335@gmail.com"
+  },
+  "records": {
+    "CNAME": "franzbu.github.io"
+  }
+}

--- a/domains/enhancedspaces.burgmann.json
+++ b/domains/enhancedspaces.burgmann.json
@@ -1,0 +1,10 @@
+{
+  "description": "Redirect to the EnhancedSpaces macOS productivity project",
+  "owner": {
+    "username": "franzbu",
+    "email": "csaa6335@gmail.com"
+  },
+  "records": {
+    "URL": "https://github.com/franzbu/EnhancedSpaces.spoon"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
- **Root Portfolio:** https://franzbu.github.io (Now a full, multi-section developer site)
- **Project Subdomain:** https://github.com/franzbu/EnhancedSpaces.spoon

# Website Purpose
It serves as landing page for my developer portfolio.

The site now includes:
1. **Detailed technical documentation** for the HomeAssistantHeating (Python/ESP32) project.
2. **Feature deep-dives** for the EnhancedSpaces.spoon (macOS/Lua) productivity tool.
3. **A directory** of my open-source work on GitHub.

The root domain (`burgmann.is-a.dev`) serves as the official portal for these software projects.