### PR TITLE
Add Vercel TXT verification for preciousatwiine.is-a.dev

### DIFF
--- a/domains/_vercel.preciousatwiine.json
+++ b/domains/_vercel.preciousatwiine.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "PreciousAtwiine",
+    "email": "preciousinshuti3@gmail.com"
+  },
+  "records": {
+    "TXT": ["vc-domain-verify=preciousatwiine.is-a.dev,df433455571a3955b4e6"]
+  }
+}

--- a/domains/preciousatwiine.json
+++ b/domains/preciousatwiine.json
@@ -4,9 +4,7 @@
     "email": "preciousinshuti3@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
-    "TXT": [
-      "vc-domain-verify=preciousatwiine.is-a.dev,df433455571a3955b4e6"
-    ]
+    "CNAME": "cname.vercel-dns.com",
+    "TXT": ["vc-domain-verify=preciousatwiine.is-a.dev,df433455571a3955b4e6"]
   }
 }

--- a/domains/preciousatwiine.json
+++ b/domains/preciousatwiine.json
@@ -4,7 +4,7 @@
     "email": "preciousinshuti3@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com",
+    "A": ["216.198.79.1"],
     "TXT": ["vc-domain-verify=preciousatwiine.is-a.dev,df433455571a3955b4e6"]
   }
 }

--- a/domains/preciousatwiine.json
+++ b/domains/preciousatwiine.json
@@ -5,5 +5,8 @@
   },
   "records": {
     "CNAME": "cname.vercel-dns.com"
+    "TXT": [
+      "vc-domain-verify=preciousatwiine.is-a.dev,df433455571a3955b4e6"
+    ]
   }
 }

--- a/domains/preciousatwiine.json
+++ b/domains/preciousatwiine.json
@@ -4,7 +4,6 @@
     "email": "preciousinshuti3@gmail.com"
   },
   "records": {
-    "A": ["216.198.79.1"],
-    "TXT": ["vc-domain-verify=preciousatwiine.is-a.dev,df433455571a3955b4e6"]
+    "CNAME": "cname.vercel-dns.com"
   }
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://portfolio-kappa-two-50p082n4e1.vercel.app/

<img width="1917" height="907" alt="image" src="https://github.com/user-attachments/assets/6e108e01-e20a-4e9e-a979-902ed31e3ecb" />

# Website Purpose
This is my personal developer portfolio website. I am a Frontend Developer 
at Lumpsum Technologies building production-grade B2B SaaS applications. 
The site showcases my projects, skills, and experience including work built 
with Next.js, TypeScript, and Django. This is purely a personal portfolio 
and is not for commercial use.