### PR TITLE
Register frida.is-a.dev

### DIFF
--- a/domains/frida.json
+++ b/domains/frida.json
@@ -1,0 +1,12 @@
+{
+  "description": "Frida — luxury bag catalog (private link-share)",
+  "repo": "https://github.com/naimozcan/frida-katalog",
+  "owner": {
+    "username": "naimozcan",
+    "email": "naimyasirozcan@gmail.com"
+  },
+  "records": {
+    "CNAME": "frida-katalog.pages.dev"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Domain
`frida.is-a.dev`

## Owner
- **Username:** naimozcan
- **Email:** naimyasirozcan@gmail.com

## DNS Record
- **CNAME:** `frida-katalog.pages.dev` (Cloudflare Pages)
- **Proxied:** false

## Purpose
Static catalog viewer for a small luxury accessories business based in Turkey.
The `.pages.dev` TLD is currently blocked at the ISP level in Turkey, so a custom-named subdomain is needed for accessibility. The site itself is a simple HTML/JS catalog (no scraping, no abuse).

## Repo
https://github.com/naimozcan/frida-katalog

## Compliance
- Not a reserved subdomain
- Used for personal/business catalog only
- Will follow is-a.dev TOS