### PR TITLE
Edit `portfolio.is-a.dev`: switch to URL redirect

### DIFF
--- a/domains/portfolio.json
+++ b/domains/portfolio.json
@@ -6,6 +6,9 @@
   "description": "Official demo for portfolio-web — open-source Korean stock portfolio tracker",
   "repo": "https://github.com/hanjungwoo3/portfolio-web",
   "records": {
-    "CNAME": "hanjungwoo3.github.io"
+    "URL": "https://hanjungwoo3.github.io/portfolio-web/"
+  },
+  "redirect_config": {
+    "redirect_paths": false
   }
 }


### PR DESCRIPTION
## Pull request details

I'm switching `portfolio.is-a.dev` from a CNAME record to a URL redirect so that visitors land on the correct GitHub Pages sub-path (`/portfolio-web/`) instead of the user-page root.

### Why

- The project is served at `https://hanjungwoo3.github.io/portfolio-web/`, not at the root of `hanjungwoo3.github.io`.
- With the current CNAME, browsers hitting `https://portfolio.is-a.dev/` were getting a `*.github.io` certificate back (NET::ERR_CERT_COMMON_NAME_INVALID), since the GitHub Pages site has no CNAME file claiming this hostname.
- A URL redirect (handled by is-a.dev / Cloudflare) cleanly terminates TLS at the edge and forwards visitors to the canonical project URL.

### Type of change

- [x] Edit a domain (`portfolio.is-a.dev`)

### Checklist

- [x] I have read the [docs](https://www.is-a.dev/docs).
- [x] I have not used any [restricted records](https://www.is-a.dev/docs/registration/restrictions/).
- [x] My pull request follows the rules of the JSON file.
- [x] I have tested my JSON file and to my knowledge it is valid.
- [x] My changes follow the JSON [schema](https://raw.githubusercontent.com/is-a-dev/register/main/src/schemas/domain-file.json).