### PR TITLE
Add Vercel domain configuration for muzammilmemon

### DIFF
--- a/domains/_vercel.muzammilmemon.json
+++ b/domains/_vercel.muzammilmemon.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "muzammilexe",
+    "email": "memon.muzammil24@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=is-a.dev,2adbfef6082bbc15855e"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://portfolio-sandy-nine-99.vercel.app

<!-- Add a screenshot of your website here by dragging and dropping an image into this box -->
<img width="1467" height="1008" alt="Screenshot 2026-05-12 160228" src="https://github.com/user-attachments/assets/181993f4-ba09-4436-9b58-0aa5e9386c8e" />



# Website Purpose
This is a Vercel TXT verification record for my personal developer portfolio at muzammilmemon.is-a.dev, required to verify domain ownership with Vercel.