### PR TITLE
add voidpulse.is-a.dev

### DIFF
--- a/domains/voidpulse.json
+++ b/domains/voidpulse.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "haidmoham",
+    "email": "haidmoham@gmail.com"
+  },
+  "records": {
+    "CNAME": "wwmoq464.up.railway.app"
+  }
+}


### PR DESCRIPTION
## Description

Adding `voidpulse.is-a.dev` pointing to a Railway-hosted web visualizer.

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have checked that the domain is not already taken
- [x] The domain is pointing to a real project