### PR TITLE
Add shadowx.is-a.dev

### DIFF
--- a/domains/shadowx.json
+++ b/domains/shadowx.json
@@ -1,0 +1,10 @@
+{
+  "description": "Personal staging environment for testing",
+  "owner": {
+    "username": "dr4cary5",
+    "email": "your-email@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
**Link:** https://shadowx-nine.vercel.app
[ShadowX Screenshot](https://github.com/dr4cary5/shadowx/blob/main/U12.jpg)

# Website Purpose
ShadowX is a personal development environment for testing serverless functions and edge network behavior. It serves as a staging platform for experimenting with Vercel's serverless architecture.
