### PR TITLE
Register teaching-system.is-a.dev

### DIFF
--- a/domains/teaching-system.json
+++ b/domains/teaching-system.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "xglacb869"
+  },
+  "records": {
+    "A": [
+      "75.2.60.5"
+    ]
+  }
+}

--- a/domains/www.teaching-system.json
+++ b/domains/www.teaching-system.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "xglacb869"
+  },
+  "records": {
+    "CNAME": "patrul-flashcards-study.netlify.app"
+  }
+}


### PR DESCRIPTION
## Domain registration\n\nRegister:\n- teaching-system.is-a.dev\n- www.teaching-system.is-a.dev\n\n## DNS target\n\n- teaching-system.is-a.dev -> Netlify A record 75.2.60.5\n- www.teaching-system.is-a.dev -> patrul-flashcards-study.netlify.app\n\n## Website preview\n\nhttps://patrul-flashcards-study.netlify.app\n\nThe Netlify site has already been configured with the custom domain and keeps the default netlify.app address accessible.