### PR TITLE
add phareth.is-a.dev

### DIFF
--- a/domains/phareth.json
+++ b/domains/phareth.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "HaoSophareth",
+    "email": "haosophareth070@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Website Link: https://phareth.vercel.app/ (phareth.is-a.dev), https://missting.vercel.app (phareth.is-a.dev/missting)

<img width="1512" height="982" alt="Screenshot 2026-05-14 at 4 03 00 AM" src="https://github.com/user-attachments/assets/9e433f12-c1b2-4c27-b058-21be0ca58209" />

<img width="1512" height="982" alt="Screenshot 2026-05-13 at 5 36 02 PM" src="https://github.com/user-attachments/assets/2eb71dfb-67c1-4271-88f2-85bb58ceb65f" />

# Website Purpose

This is my personal developer domain. The root will serve as a personal page and `phareth.is-a.dev/missting` will host the landing page for Missting which is an open-source macOS menu bar app that connects to Google Calendar to help wee what is coming up, get a reminder closer to time, and auto-join at the right moment.