### PR TITLE
Update CNAME to dileepapeiris.github.io

### DIFF
--- a/domains/dileepapeiris.json
+++ b/domains/dileepapeiris.json
@@ -4,6 +4,6 @@
     "email": "dileepapeiris5@gmail.com"
   },
   "records": {
-    "CNAME": "portfolio-v2-1nb.pages.dev"
+    "CNAME": "dileepapeiris.github.io"
   }
 }


### PR DESCRIPTION
Replace the CNAME record in domains/dileepapeiris.json to point to dileepapeiris.github.io instead of portfolio-v2-1nb.pages.dev so the domain resolves to the GitHub Pages site.


# Website Preview
**Live URL:** [Website Preview](https://dileepapeiris.github.io/)


# Website Purpose
This is my personal developer portfolio.