### PR TITLE
Register stageflow.is-a.dev for Resend email setup

### DIFF
--- a/domains/_dmarc.stageflow.json
+++ b/domains/_dmarc.stageflow.json
@@ -1,0 +1,13 @@
+{
+  "owner": {
+    "username": "Martin-Bernard",
+    "email": "martin.bernard780@gmail.com"
+  },
+  "description": "DMARC policy for stageflow.is-a.dev",
+  "records": {
+    "TXT": [
+      "v=DMARC1; p=none;"
+    ]
+  },
+  "proxied": false
+}

--- a/domains/resend._domainkey.stageflow.json
+++ b/domains/resend._domainkey.stageflow.json
@@ -1,0 +1,13 @@
+{
+  "owner": {
+    "username": "Martin-Bernard",
+    "email": "martin.bernard780@gmail.com"
+  },
+  "description": "DKIM key for Resend transactional emails (StageFlow)",
+  "records": {
+    "TXT": [
+      "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrMqbq7cwQ6Eee4nbYiwUFeq3wxI/n2zofCBpN3Q9drRLs9T/xxRwpkTK3j9195IS+QcVe7JulKmiVcsdim4/HC2jjIQn+jlq87U+3HRgpFb4FGQIabyTJZZ7w1Gwe/mT6np4HtFsvQuZkW6C8Aeo4Ueoo7NjT7cPQkXA9J/UdYwIDAQAB"
+    ]
+  },
+  "proxied": false
+}

--- a/domains/send.stageflow.json
+++ b/domains/send.stageflow.json
@@ -1,0 +1,16 @@
+{
+  "owner": {
+    "username": "Martin-Bernard",
+    "email": "martin.bernard780@gmail.com"
+  },
+  "description": "SPF/return-path for Resend (StageFlow)",
+  "records": {
+    "MX": [
+      { "target": "feedback-smtp.eu-west-1.amazonses.com", "priority": 10 }
+    ],
+    "TXT": [
+      "v=spf1 include:amazonses.com ~all"
+    ]
+  },
+  "proxied": false
+}

--- a/domains/stageflow.json
+++ b/domains/stageflow.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "Martin-Bernard",
+    "email": "martin.bernard780@gmail.com"
+  },
+  "description": "StageFlow — choreography planner. Web app deployed at workers.dev.",
+  "repo": "https://github.com/Martin-Bernard/stageflow-web",
+  "records": {
+    "URL": "https://stageflow-web.martin-bernard780.workers.dev"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Hi! I'm registering `stageflow.is-a.dev` for my open-source choreography planner project.

- **App**: https://github.com/Martin-Bernard/stageflow-web
- **Live**: https://stageflow-web.martin-bernard780.workers.dev (Cloudflare Workers)
- **Why**: I need DNS records (DKIM/SPF/DMARC) to send transactional emails 
  (signup verification, invitations, password reset) through Resend. The apex 
  redirects to the live app.

Files:
- `stageflow.json` — apex, URL redirect to the app
- `resend._domainkey.stageflow.json` — DKIM record from Resend
- `send.stageflow.json` — MX + SPF for return-path
- `_dmarc.stageflow.json` — DMARC policy (relaxed)