### PR TITLE
add vercel TXT verification for phareth.is-a.dev

### DIFF
--- a/domains/_vercel.phareth.json
+++ b/domains/_vercel.phareth.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "HaoSophareth",
+    "email": "sophareth.hao@uni.minerva.edu"
+  },
+  "records": {
+    "TXT": ["vc-domain-verify=phareth.is-a.dev,adf3c9e7a47b32a31dd6"]
+  }
+}


### PR DESCRIPTION
Adding TXT record at `_vercel.phareth.is-a.dev` to verify domain ownership with Vercel for the `phareth.is-a.dev` domain (registered in #38175).