### PR TITLE
Register gunnerkanbanboard.is-a.dev

### DIFF
--- a/domains/gunnerkanbanboard.json
+++ b/domains/gunnerkanbanboard.json
@@ -1,0 +1,10 @@
+{
+  "description": "Kanban Note — Dev team board with project workflow, bug tracking, and feature planning",
+  "owner": {
+    "username": "Gh0st-Gunner"
+  },
+  "records": {
+    "CNAME": "gh0st-gunner.github.io"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
## Summary
Registering `gunnerkanbanboard.is-a.dev` for my dev team Kanban board app.

- **Subdomain**: gunnerkanbanboard.is-a.dev
- **CNAME target**: gh0st-gunner.github.io
- **Purpose**: Dev team Kanban board with project workflow, bug tracking, and feature planning
- **Owner**: Gh0st-Gunner

## Checklist
- [x] The subdomain is not already registered
- [x] The JSON file is valid
- [x] The CNAME record points to my GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)