### PR TITLE
Register www.ritiksharma.is-a.dev

### DIFF
--- a/domains/www.ritiksharma.json
+++ b/domains/www.ritiksharma.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Rkcr7",
+    "email": "ritik135001@gmail.com"
+  },
+  "records": {
+    "CNAME": "ritiksharma-v2.netlify.app"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided a preview of my website below.
- [x] I have provided contact information in the `owner` key.

# Website Preview

Live preview: https://ritiksharma-v2.netlify.app

![Portfolio screenshot](https://ritiksharma-v2.netlify.app/view.png)

# Website Purpose

This PR adds the `www` variant of my already-registered subdomain `ritiksharma.is-a.dev` (merged in #36856). Netlify automatically creates a `www.` redirect alias for the primary custom domain and requires DNS verification for it before it will issue a Let's Encrypt certificate; without this record, the certificate provisioning fails. Adding `www.ritiksharma.is-a.dev` pointing to the same Netlify project resolves that.

Owner and target are identical to the parent registration.