### PR TITLE
Add creativity-lab.is-a.dev

### DIFF
--- a/domains/creativity-lab.json
+++ b/domains/creativity-lab.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "timurka",
+    "email": "timurdt@gmail.com"
+  },
+  "records": {
+    "A": ["205.172.57.129"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Preview: http://205.172.57.129:8080/

The preview is hosted on the same server IP used by the A record in this pull request while the domain is awaiting approval.

# Website Purpose

Creativity Lab is a non-commercial software project for a web app / Telegram Mini App that provides creativity tests and scoring experiments.
