### PR TITLE
Register clide.is-a.dev

### DIFF
--- a/domains/clide.json
+++ b/domains/clide.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "ixumix",
+    "email": "ixumix.sds@gmail.com"
+  },
+  "record": {
+    "CNAME": "restless-grass-b01c.ixumix-sds.workers.dev"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering clide.is-a.dev for my personal project — CLIDE LABS.
CNAME points to my Cloudflare Workers deployment.
