### PR TITLE
Register doscom-bot.is-a.dev

### DIFF
--- a/domains/doscom-bot.json
+++ b/domains/doscom-bot.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "doscomvietnam",
+    "email": "doscom.vietnam@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "harlee.ns.cloudflare.com.",
+      "rick.ns.cloudflare.com."
+    ]
+  }
+}

--- a/domains/doscom-bot.json
+++ b/domains/doscom-bot.json
@@ -5,8 +5,8 @@
   },
   "records": {
     "NS": [
-      "harlee.ns.cloudflare.com.",
-      "rick.ns.cloudflare.com."
+      "harlee.ns.cloudflare.com",
+      "rick.ns.cloudflare.com"
     ]
   }
 }


### PR DESCRIPTION
## Domain
doscom-bot.is-a.dev

## Purpose
Internal admin backend for Doscom Vietnam team. Routes traffic via Cloudflare Tunnel to a self-hosted FastAPI backend serving an internal Facebook Messenger chatbot for our furniture sales operations. Used by 2-3 admin users daily.

## Records
NS delegation to Cloudflare nameservers (harlee + rick) so we can manage subdomain DNS via Cloudflare dashboard.

## Checklist
- [x] My website is properly set up
- [x] My JSON file is using 2-space indentation
- [x] My commit is using a meaningful title
- [x] I have read the README and TERMS OF SERVICE
