### PR TITLE
Add jorgemayor.is-a.dev feature

### DIFF
--- a/domains/jorgemayor.json
+++ b/domains/jorgemayor.json
@@ -1,12 +1,10 @@
 {
     "description": "Jorge Mayor's personal website",
-    "domain": "is-a.dev",
-    "subdomain": "jorgemayor",
     "owner": {
         "username": "Joorg3Mayoor",
         "email": "joorgemayoor@gmail.com"
     },
-    "record": {
+    "records": {
         "A": ["83.36.65.55"]
     }
 }

--- a/domains/jorgemayor.json
+++ b/domains/jorgemayor.json
@@ -1,0 +1,12 @@
+{
+    "description": "Jorge Mayor's personal website",
+    "domain": "is-a.dev",
+    "subdomain": "jorgemayor",
+    "owner": {
+        "username": "Joorg3Mayoor",
+        "email": "joorgemayoor@gmail.com"
+    },
+    "record": {
+        "A": ["83.36.65.55"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

http://83.36.65.55/

<img width="1287" height="707" alt="Screenshot_13" src="https://github.com/user-attachments/assets/f75a0c59-f004-4a9b-82b4-a43067b86950" />


# Website Purpose

Personal website and homelab landing page. It includes an about me section describing
my interest in self-hosting, Linux, and infrastructure, along with my tech stack
(Docker, Nginx, Arch Linux) and contact links. The site is fully self-hosted from my
home server running Arch Linux with Docker and Nginx, served over HTTPS via
Let's Encrypt.