### PR TITLE
Register thinkflow.is-a.dev

### DIFF
--- a/domains/thinkflow.json
+++ b/domains/thinkflow.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "elizebeth-a11y"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
### Domain Registration

- **Subdomain**: thinkflow.is-a.dev
- **Record Type**: CNAME
- **Target**: cname.vercel-dns.com (Vercel hosting)

### Purpose
Personal thought capture tool (ThinkFlow) deployed on Vercel.