### PR TITLE
Register mapal-kochavim-2026.is-a.dev

### DIFF
--- a/domains/mapal-kochavim-2026.json
+++ b/domains/mapal-kochavim-2026.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "arthurkomishenko-commits",
+    "email": "arthur.home.komishenko@gmail.com"
+  },
+  "record": {
+    "CNAME": "arthurkomishenko-commits.github.io"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Domain:** mapal-kochavim-2026.is-a.dev
- **Record type:** CNAME → arthurkomishenko-commits.github.io
- **Purpose:** Event website for a Perseids meteor shower gathering in the Negev desert (Israel), August 2026
- **GitHub Pages:** https://arthurkomishenko-commits.github.io/mapal-kochavim-2026/