### PR TITLE
Register mc.sludgexfactory.is-a.dev

### DIFF
--- a/domains/mc.sludgexfactory.json
+++ b/domains/mc.sludgexfactory.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "SludgeXFactory"
+  },
+  "records": {
+    "A": ["174.165.217.118"]
+  }
+}

--- a/domains/sludgexfactory.json
+++ b/domains/sludgexfactory.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "SludgeXFactory"
+  },
+  "records": {
+    "URL": "https://ancientmc.xuhuanze.workers.dev"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Client/site URL: https://ancientmc.xuhuanze.workers.dev

This subdomain will be used for the AncientMC browser client/server connection setup. AncientMC is a non-commercial Minecraft/Eaglercraft development project.
