### PR TITLE
Add Vercel domain configuration for sandipgupta

### DIFF
--- a/domains/_vercel.sandipgupta.json
+++ b/domains/_vercel.sandipgupta.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "GuptaSandip",
+    "email": "sandipgupta7304@gmail.com"
+  },
+  "records": {
+    "TXT": ["vc-domain-verify=sandipgupta.is-a.dev,2e6a5a0d63e3637d7d09"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the 'owner' key.
- [x] I have provided a preview of my website below.

# Website Preview

Link: https://sandip-portfolio-five.vercel.app/
(This is a TXT record for subdomain verification)

# Website Purpose

I am adding a TXT record in a separate file (`_vercel.sandipgupta.json`) to verify ownership for Vercel, as requested by the maintainers.

<img width="955" height="534" alt="image" src="https://github.com/user-attachments/assets/35a73046-9ff9-4fae-bff5-a50f4f73701f" />
