### PR TITLE
Register rushmarket.is-a.dev

### DIFF
--- a/domains/rushmarket.json
+++ b/domains/rushmarket.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Samfresh-ai"
+  },
+  "records": {
+    "A": ["75.2.60.5"]
+  }
+}

--- a/domains/www.rushmarket.json
+++ b/domains/www.rushmarket.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Samfresh-ai"
+  },
+  "records": {
+    "CNAME": "rush-marketplace-samfresh.netlify.app"
+  }
+}


### PR DESCRIPTION
## Domain request

Register `rushmarket.is-a.dev` and `www.rushmarket.is-a.dev` for the Rush marketplace public demo.

Preview: https://rush-marketplace-samfresh.netlify.app

Records:
- `rushmarket.is-a.dev` -> Netlify A record `75.2.60.5`
- `www.rushmarket.is-a.dev` -> CNAME `rush-marketplace-samfresh.netlify.app`
