### PR TITLE
Add ACM validation record for dmitry-maranik.is-a.dev

### DIFF
--- a/domains/_99e2ba9ae2fdea4dde1014ac58d58649.dmitry-maranik.json
+++ b/domains/_99e2ba9ae2fdea4dde1014ac58d58649.dmitry-maranik.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "dmitrymaranik",
+    "email": "dmitrymaranik@gmail.com"
+  },
+  "records": {
+    "CNAME": "_4dcb6a1e93453062fdcbc5a45ad48f8a.jkddzztszm.acm-validations.aws"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://d3046l6za10p4z.cloudfront.net

# Website Purpose

This is a follow-up to my already-merged registration of `dmitry-maranik.is-a.dev` (#38366), which points at an AWS CloudFront distribution for my personal portfolio site.

This PR adds a single AWS Certificate Manager DNS-validation record (`_99e2ba9ae2fdea4dde1014ac58d58649.dmitry-maranik`) so CloudFront can serve a valid TLS certificate for the subdomain as one of its alternate domain names. It is a standard ACM DNS-validation CNAME, kept DNS-only (not proxied) so ACM can resolve it. The root subdomain remains my software-engineering portfolio (four live demo apps — agentic chat, a recommender, an IDP pipeline, and a multi-agent cloud-migration planner).