### PR TITLE
Delete domains/0xaritro.json

### DIFF
--- a/domains/0xaritro.json
+++ b/domains/0xaritro.json
@@ -1,9 +1,0 @@
-{
-    "owner": {
-        "username": "officialaritro",
-        "email": "officialaritro204@gmail.com"
-    },
-    "records": {
-        "CNAME": "cname.vercel-dns.com"
-    }
-}

--- a/domains/_vercel.0xaritro.json
+++ b/domains/_vercel.0xaritro.json
@@ -1,9 +1,0 @@
-{
-    "owner": {
-        "username": "officialaritro",
-        "email": "officialaritro204@gmail.com"
-    },
-    "records": {
-        "TXT": "vc-domain-verify=0xaritro.is-a.dev,2193b6dca0e2883688ca"
-    }
-}


### PR DESCRIPTION
Invalid TLS certificate. Been here for a while.

@officialaritro Your domain is being removed. This is because the site has no TLS certificate, thus only responding with HTTPS errors.