### PR TITLE
Register tolu.is-a.dev subdomain

### DIFF
--- a/domains/tolu.json
+++ b/domains/tolu.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "ToXMon"
+  },
+  "records": {
+    "CNAME": "toxmon.github.io"
+  }
+}


### PR DESCRIPTION
## Subdomain Registration

Registering `tolu.is-a.dev` for the Agent Gallery portfolio.

- **Subdomain**: tolu.is-a.dev
- **Owner**: ToXMon
- **Record**: CNAME → toxmon.github.io
- **Purpose**: Interactive portfolio for agentic systems, blockchain, and full-stack engineering
- **Site**: https://toxmon.github.io/agent-workflows/

### Checklist
- [x] The CNAME is set
- [x] The website is live
- [x] I have not used any banned domains