### PR TITLE
Register holtkey-demo.is-a.dev

### DIFF
--- a/domains/holtkey.json
+++ b/domains/holtkey.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Bachir-Ahmed-Rachid",
+    "email": "arachid663@gmail.com"
+  },
+  "records": {
+    "NS": ["clarissa.ns.cloudflare.com", "norman.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
 ## Subdomain
   holtkey-demo.is-a.dev

   ## Purpose
   Demo subdomain for Holtkey, a rental property management platform I'm
   developing. The subdomain will host a periodic demo of the app for stakeholder
   reviews. Backend is NestJS on AWS Fargate, frontend is React, fronted by
   Cloudflare via a Cloudflare Tunnel.

   ## Records
   NS records delegating the zone to Cloudflare's free plan, so I can manage
   DNS/SSL/Tunnel via Cloudflare.

   ## Acknowledgements
   - [x] I have read and agree to the rules.
   - [x] This is a real project, not parking or commercial spam.