### PR TITLE
Register: eubaram.is-a.dev

### DIFF
--- a/domains/eubaram.json
+++ b/domains/eubaram.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "Jonas-Augustinus-Linus",
+    "email": "158859839+Jonas-Augustinus-Linus@users.noreply.github.com"
+  },
+  "description": "EU연합 통합시스템 — 바람의나라 클래식 공성 점수 인증, 명예의 전당, 4성주 관리 (Korean MMORPG guild alliance dashboard)",
+  "repo": "https://github.com/Jonas-Augustinus-Linus/eubaram",
+  "records": {
+    "CNAME": "jonas-augustinus-linus.github.io"
+  }
+}


### PR DESCRIPTION
## Domain
`eubaram.is-a.dev`

## Records
- CNAME → `jonas-augustinus-linus.github.io`

## Site
EU연합 통합시스템 — 바람의나라 클래식 (Korean MMORPG) 게임 길드 연합의 공성 점수 인증 / 통계 / 명예의 전당 / 4성주 관리 대시보드.

PWA 지원, 정적 사이트 (GitHub Pages 호스팅) + Google Apps Script 백엔드.

## Repo
https://github.com/Jonas-Augustinus-Linus/eubaram

## Live (current)
https://jonas-augustinus-linus.github.io/eubaram/