### PR TITLE
Register impulse.is-a.dev

### DIFF
--- a/domains/impulse.json
+++ b/domains/impulse.json
@@ -1,10 +1,11 @@
 {
     "owner": {
-        "username": "Skromnyx",
-        "email": "andrew@oval-plate-464820-p5.iam.gserviceaccount.com"
+        "username": "htsgladiatis"
     },
-    "record": {
-        "A": ["109.69.22.112"]
+    "records": {
+        "A": [
+            "109.69.22.112"
+        ]
     },
     "proxied": true
 }

--- a/domains/impulse.json
+++ b/domains/impulse.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "Skromnyx",
+        "email": "andrew@oval-plate-464820-p5.iam.gserviceaccount.com"
+    },
+    "record": {
+        "A": ["109.69.22.112"]
+    },
+    "proxied": true
+}


### PR DESCRIPTION
Registered impulse.is-a.dev with A record pointing to 109.69.22.112 (VPS).

This domain will be used for a VK Mini App and webchat service.