### PR TITLE
Add crow.is-a.dev domain for Crow AI platform

### DIFF
--- a/domains/crow.json
+++ b/domains/crow.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "sepulchralvoid666",
+    "email": "crownite@agentmail.to"
+  },
+  "record": {
+    "A": ["129.146.26.223"]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering crow.is-a.dev subdomain for Crow AI — an autonomous agent platform running at 129.146.26.223.