### PR TITLE
Register daptordarattler.is-a.dev

### DIFF
--- a/domains/daptordarattler.json
+++ b/domains/daptordarattler.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "daptordarattler",
+    "email": "dfdnusenu@gmail.com"
+  },
+  "records": {
+    "CNAME": "daptordarattler.github.io"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview (served from GitHub Pages while DNS propagates):
**https://daptordarattler.github.io/**

Screenshot:

![Preview of daptordarattler.is-a.dev CV](https://raw.githubusercontent.com/daptordarattler/register/preview-assets/screenshot.png)

Full-page screenshot: [screenshot-full.png](https://raw.githubusercontent.com/daptordarattler/register/preview-assets/screenshot-full.png)

# Website Purpose

Personal software-engineer CV / portfolio site for Dominic Fui Dodzi-Nusenu, documenting 8+ years of full-stack engineering work across fintech, AI governance, and asset management — including projects like Alleina AI (EU AI Act compliance SaaS), Soupmarkets (multi-tenant brokerage platform), and TASCIM (multi-agent Claude Code orchestration). Single-page static HTML/CSS site; non-commercial; software-development focused.

Once this PR merges, the `CNAME` file in the GitHub Pages repo will be re-enabled so the site serves at the custom subdomain through your Cloudflare proxy.
