### PR TITLE
Register keylink.is-a.dev

### DIFF
--- a/domains/keylink.json
+++ b/domains/keylink.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "sumedhkumar",
+    "email": "sumedhkumar@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "keylink-rho.vercel.app"
+  }
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain:** keylink.is-a.dev
- **Record Type:** CNAME
- **Target:** keylink-rho.vercel.app

### Purpose
KeyLink is a keyword-based content discovery platform for creators. This domain will serve as the primary URL for the web application hosted on Vercel.