### PR TITLE
Registering iceberg.is-a.dev for Iceberg

### DIFF
--- a/domains/iceberg.json
+++ b/domains/iceberg.json
@@ -1,0 +1,11 @@
+{
+  "description": "Iceberg — UAE credit card benefits app",
+  "repo": "https://github.com/SiCloud-iceberg/iceberg",
+  "owner": {
+    "username": "SiCloud-iceberg",
+    "email": "sumedh1001@gmail.com"
+  },
+  "record": {
+    "CNAME": "2eaafb10-22ee-45b9-872d-dfc361a35b1e.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
Registering iceberg.is-a.dev for Iceberg, a UAE credit card benefits app.
This points to a Cloudflare tunnel serving the app.
GitHub repo: https://github.com/SiCloud-iceberg/iceberg