### PR TITLE
Register pr-gradient.is-a.dev

### DIFF
--- a/domains/pr-gradient.json
+++ b/domains/pr-gradient.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "lazzy-panda",
+    "email": "grifx.design@gmail.com"
+  },
+  "records": {
+    "CNAME": "pr-gradient.onrender.com"
+  }
+}


### PR DESCRIPTION
Registering `pr-gradient.is-a.dev` for an internal tool that manages blogger placements for a Russian cosmetics holding (8 brands). The site is deployed on Render and serves a single-page Next.js app.

- Project URL: https://pr-gradient.onrender.com
- Source: https://github.com/lazzy-panda/pr-gradient
- Record: CNAME → pr-gradient.onrender.com
- Use case: internal team tool for managing PR campaigns

Thanks!