### PR TITLE
Register monrdv.is-a.dev

### DIFF
--- a/domains/monrdv.json
+++ b/domains/monrdv.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "boitetoute",
+        "email": "boite.route@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Hi! Adding `monrdv.is-a.dev` for my appointment booking app, currently in private beta with a handful of users.

The app lets small businesses (medical, beauty, consulting…) manage their bookings. The frontend is on Vercel, backend on Koyeb — both still running on their default `*.vercel.app` / `*.koyeb.app` URLs which look a bit rough for the beta testers I'm inviting, so a cleaner subdomain would help.

Frontend repo: https://github.com/boitetoute/appointment-fe

Thanks for running this service!
