### PR TITLE
Register cerberus.is-a.dev

### DIFF
--- a/domains/cerberus.json
+++ b/domains/cerberus.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ArsenalRX",
+        "email": "faterivalz@gmail.com"
+    },
+    "records": {
+        "CNAME": "arsenalrx.github.io"
+    }
+}


### PR DESCRIPTION
## Subdomain Registration

- **Subdomain:** cerberus.is-a.dev
- **Record Type:** CNAME
- **Target:** arsenalrx.github.io

Anti-cheat engine project site hosted on GitHub Pages.