### PR TITLE
fix amithnal.is-a.dev - disable Cloudflare proxy (522 error)

### DIFF
--- a/domains/amithnal.json
+++ b/domains/amithnal.json
@@ -5,5 +5,6 @@
   },
   "records": {
     "CNAME": "server.taile34ada.ts.net"
-  }
+  },
+  "proxied": false
 }


### PR DESCRIPTION
Hi! Really sorry for the extra PR - my domain amithnal.is-a.dev was 
approved earlier today (PR #38683) but is returning a 522 error.

The issue is that Cloudflare's proxy conflicts with Tailscale Funnel, 
which handles its own HTTPS termination. Adding "proxied": false fixes it.

Only change is the single addition of "proxied": false to the existing file.
Really appreciate the earlier approval and sorry for the inconvenience!