### PR TITLE
feat: add kairos.is-a.dev

### DIFF
--- a/domains/kairos.json
+++ b/domains/kairos.json
@@ -1,0 +1,11 @@
+{
+    "description": "Kairos — Autonomous Incident Intelligence, AI-native SRE tool",
+    "repo": "https://github.com/Sahith59/Kairos",
+    "owner": {
+        "username": "Sahith59",
+        "email": "sahith0904@gmail.com"
+    },
+    "record": {
+        "A": ["150.136.229.156"]
+    }
+}

--- a/domains/kairos.json
+++ b/domains/kairos.json
@@ -5,7 +5,7 @@
         "username": "Sahith59",
         "email": "sahith0904@gmail.com"
     },
-    "record": {
+    "records": {
         "A": ["150.136.229.156"]
     }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live URL: http://150.136.229.156:3000

<!-- Take a screenshot of your site and drag it into this box -->

# Website Purpose

Kairos is an open-source, AI-native Site Reliability Engineering tool built
as a portfolio project to demonstrate agentic system engineering. It watches
production logs, detects anomalies in real-time, and delivers validated Root
Cause Analysis reports in seconds using a self-reflective LangGraph
multi-agent loop (Investigator → Critic) backed by ChromaDB vector RAG,
Neo4j GraphRAG, and Redis semantic caching. The full stack — FastAPI,
Next.js, LangGraph, Docker — is open source at
https://github.com/Sahith59/Kairos.


<img width="1898" height="936" alt="image" src="https://github.com/user-attachments/assets/45e1e2b5-43a0-424e-ba44-169c902c92b2" />
