### PR TITLE
Register opc-board.is-a.dev

### DIFF
--- a/domains/opc-board.json
+++ b/domains/opc-board.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"Elimek","email":"souandonlykml@gmail.com"},"records":{"CNAME":"elimek.github.io"}}


### PR DESCRIPTION
Registering opc-board.is-a.dev subdomain for my OPC Board project (https://github.com/Elimek/opc-board).

- **Owner**: Elimek
- **Email**: souandonlykml@gmail.com
- **Record**: CNAME → elimek.github.io
- **Purpose**: GitHub Pages for One-Person Company Operating System