### PR TITLE
ci(workflows): pin github actions to commit hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         name: Tests
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - run: npm install
 

--- a/.github/workflows/dnscontrol.yml
+++ b/.github/workflows/dnscontrol.yml
@@ -17,7 +17,7 @@ jobs:
         name: Tests
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - uses: is-a-dev/dnscontrol-action@main
               with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         name: DNS
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Generate creds.json
               run: echo '{"cloudflare":{"TYPE":"CLOUDFLAREAPI","apitoken":"$CLOUDFLARE_API_TOKEN"}}' > ./creds.json

--- a/.github/workflows/raw-api.yml
+++ b/.github/workflows/raw-api.yml
@@ -21,9 +21,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 20.x
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
         name: Label
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/stale@v10
+            - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   days-before-stale: 3


### PR DESCRIPTION
Updated all GitHub Actions dependencies across workflows to use full commit SHAs instead of mutable version tags (e.g., `actions/checkout`, `actions/setup-node`, and `actions/stale`). 

This hardens the CI/CD pipeline by ensuring action dependencies are strictly immutable and prevents potential supply chain attacks.

Seems like GitHub actions are by design insecure, starting to slowly lock down these insecure Actions CI/CD.