### PR TITLE
Register aldorino.is-a.dev

### DIFF
--- a/domains/_vercel.aldorino.json
+++ b/domains/_vercel.aldorino.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MetalHacker01",
+        "email": "aldorino.rrushi@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=aldorino.is-a.dev,845914fb9c754ca0afa0"
+    }
+}

--- a/domains/aldorino.json
+++ b/domains/aldorino.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MetalHacker01",
+        "email": "aldorino.rrushi@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview (Vercel deployment, pending DNS swap to `aldorino.is-a.dev`):
<YOUR-VERCEL-URL>

Screenshot:
<img width="1915" height="905" alt="Screenshot 2026-05-21 094320" src="https://github.com/user-attachments/assets/99919b2a-59b3-4bd3-b4a6-f4bdf21ce227" />

# Website Purpose

Personal portfolio for Aldorino Rrushi - a Salesforce Marketing Cloud Solution Engineer based in Tirana, Albania. The site presents:

- My role, experience, and 7× Salesforce certifications (Agentforce, AI Associate, Marketing Cloud Consultant, Developer, Administrator, Email Specialist, Platform Foundations) plus 2 HubSpot certifications.
- Four open-source software projects I've built (MIT-licensed): [SFMC Scout](https://github.com/MetalHacker01/SFMC_Scout), [CloudPage Maestro](https://github.com/MetalHacker01/CloudPage_Maestro), [Maestro Builder](https://github.com/MetalHacker01/MaestroBuilder), and [SFMC STO Activity](https://github.com/MetalHacker01/SFMC_STO_CustomActivity) — browser extensions and a visual email builder, all built to fill real gaps in the Salesforce Marketing Cloud ecosystem.
- Long-form case studies for each project with architecture diagrams, code excerpts, and lessons learned.
- A build-time-generated AI-readable markdown layer (`/v2/index.md`, `/v2/index.txt`, per-project case study `.md` files) so language models and crawlers can read the site content without executing the React SPA.

Tech stack: Vite, React, TypeScript, Tailwind CSS, shadcn/ui. Source code is public at https://github.com/MetalHacker01/aldorino_rrushi_portfolio for transparency.

The site is non-commercial, software-development-focused, and complete (not a placeholder or template).
