### PR TITLE
feat: register appointment-app.is-a.dev

### DIFF
--- a/domains/appointment-app.json
+++ b/domains/appointment-app.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "boitetoute",
+        "email": "boite.route@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Hi! Adding `appointment-app.is-a.dev` as the staging URL for an open-source-style appointment booking webapp I'm building as a personal full-stack project.

**Stack** :
- Frontend : React + Vite (deployed on Vercel via this CNAME)
- Backend : Spring Boot 3.3 + Java 21 + PostgreSQL (Neon)
- Auth : JWT + OAuth2
- CI/CD via GitHub auto-deploy

The frontend repo is at https://github.com/boitetoute/appointment-fe — a personal project where I'm experimenting with modern fullstack patterns (multi-tenant data, async email confirmations, .ics calendar exports, etc.). I'm using this subdomain to share the work-in-progress with a couple of friends who are testing and giving feedback.

Thanks for running this service!
