### PR TITLE
Add techxtreme.is-a.dev

### DIFF
--- a/domains/techxtreme.json
+++ b/domains/techxtreme.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "its-techxtreme",
+    "email": "techxtremebuisness@gmail.com"
+  },
+  "records": {
+    "CNAME": "its-techxtreme.github.io"
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] I have read and understood the [Terms of Service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md). **I agree to continue with the process.**
- [x] My file follows the [Domains file structure](https://github.com/is-a-dev/register/blob/main/domains/README.md)
- [x] My website is **reachable** and **completed** — not a blank or placeholder page
- [x] My website is related to **software development** (portfolio / client work showcase)
- [x] My website is **not** for commercial use of the domain itself
- [x] I've provided contact information in the `owner` key (`its-techxtreme`, `techxtremebuisness@gmail.com`)
- [x] I've provided a website preview below

## Website Preview

**Primary preview:** https://techxtreme-portfolio.vercel.app  
**GitHub Pages:** https://its-techxtreme.github.io/techxtreme-portfolio/

*(Custom domain `techxtreme.is-a.dev` will be enabled after this PR merges — CNAME removed temporarily so the preview no longer redirects to an unregistered subdomain.)*

![Techxtreme portfolio homepage](https://github.com/user-attachments/assets/ac9e3378-856c-4baa-92ff-20053e78726d)

## Website Purpose

Personal portfolio for **Techxtreme**, a remote digital studio. The site showcases real shipped work (WordPress directories, client service sites, AI platforms, EdTech UI) with case studies and screenshots — used to present capabilities to potential clients, not to sell the domain or run ads on the subdomain.