### PR TITLE
Add x3d-pipeline.is-a.dev

### DIFF
--- a/domains/x3d-pipeline.json
+++ b/domains/x3d-pipeline.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Joichiro",
+    "email": "danielketovone@gmail.com"
+  },
+  "records": {
+    "A": ["34.173.80.46"]
+  }
+}


### PR DESCRIPTION
Registering `x3d-pipeline.is-a.dev` pointing to a GCP VM running a 3D asset pipeline dashboard (Streamlit). Owner: Joichiro / danielketovone@gmail.com