### PR TITLE
Register parmeettalwar.is-a.dev (Vercel portfolio)

### DIFF
--- a/domains/_vercel.parmeettalwar.json
+++ b/domains/_vercel.parmeettalwar.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Parmeetsinghtalwar",
+    "email": "parmeetsinghtalwar@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=parmeettalwar.is-a.dev,d8b05058cbe097b54e3a"
+  }
+}

--- a/domains/parmeettalwar.json
+++ b/domains/parmeettalwar.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Parmeetsinghtalwar",
+    "email": "parmeetsinghtalwar@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
## Summary
- Register `parmeettalwar.is-a.dev` for personal portfolio hosted on Vercel
- A record → `216.198.79.1`
- Vercel domain verification TXT included

## Site
Portfolio deployed on Vercel (GitHub: Parmeetsinghtalwar/Portfolio)

## Checklist
- [x] `domains/parmeettalwar.json`
- [x] `domains/_vercel.parmeettalwar.json`