### PR TITLE
Register javs-dev.is-a.dev

### DIFF
--- a/domains/javs-dev.json
+++ b/domains/javs-dev.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "wwillesw",
+    "email": "willesw@proton.me"
+  },
+  "records": {
+    "CNAME": "javs-dev.is-a.dev"
+  }
+}


### PR DESCRIPTION
## Registration

Registering javs-dev.is-a.dev subdomain.

**Owner:** wwillesw
**Purpose:** Developer tools platform - Cloudflare Workers deployment for email infrastructure and AI agent tooling.

This subdomain will be used for:
- Cloudflare Worker deployment (temporary email service for developer authentication flows)
- AI agent email infrastructure
- Developer tooling and automation

Related project: [cloudflare_temp_email](https://github.com/dreamhunter2333/cloudflare_temp_email)