### PR TITLE
Add jadwal.json with owner and records information

### DIFF
--- a/domains/jadwal.json
+++ b/domains/jadwal.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "gorashedev",
+    "email": "griezmannqurashi@gmail.com"
+  },
+  "records": {
+    "CNAME": "gorashedev.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://gorashedev.github.io/jadwal/

# Website Purpose
It is a landing page for "Jadwal", a free and open-source Android study assistant app built with Kotlin and Jetpack Compose.
<img width="591" height="1280" alt="photo_5800651524697427456_y" src="https://github.com/user-attachments/assets/17137ffa-a3d7-4193-bdd3-4febaf883769" />
<img width="591" height="1280" alt="photo_5800651524697427457_y" src="https://github.com/user-attachments/assets/aa5e779f-090d-485f-8d10-f94b483798ee" />
