### PR TITLE
Add jadwal.json with owner and records information

### DIFF
--- a/domains/jadwal.json
+++ b/domains/jadwal.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "gorashedev",
+    "email": "griezmannqurashi@gmail.com"
+  },
+  "records": {
+    "CNAME": "gorashedev.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://gorashedev.github.io/jadwal/

# Website Purpose
Landing page for Jadwal, an open-source Android app built with Kotlin & Jetpack Compose, demonstrating modern Android development architecture.
<img width="1080" height="2340" alt="Screenshot_20260522_212154_Jadwal" src="https://github.com/user-attachments/assets/90399a14-a22b-44e1-82c2-bee83dca4d24" />
