### PR TITLE
Register herick-kumata.is-a.dev

### DIFF
--- a/domains/herick-kumata.json
+++ b/domains/herick-kumata.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "haykCAKI",
+    "email": "herickyk@gmail.com"
+  },
+  "description": "Portfolio de Herick Akio Yoshii Kumata — Data Engineer",
+  "repo": "https://github.com/haykCAKI/curriculo",
+  "records": {
+    "CNAME": "haykcaki.github.io"
+  }
+}


### PR DESCRIPTION
### Domain Registration

- **Subdomain:** herick-kumata.is-a.dev
- **Record type:** CNAME → haykcaki.github.io
- **Purpose:** Personal portfolio website — Herick Akio Yoshii Kumata, Data Engineer

### Checklist
- [x] I have read the [documentation](https://docs.is-a.dev)
- [x] I have followed the correct file format
- [x] My GitHub Pages site is live at haykcaki.github.io/curriculo