### PR TITLE
Add weblix.is-a.dev

### DIFF
--- a/domains/weblix.json
+++ b/domains/weblix.json
@@ -1,0 +1,11 @@
+{
+  "description": "Weblix Web Agency — Professional websites for Egyptian businesses",
+  "repo": "https://github.com/abdulslmys-123/weblix-site",
+  "owner": {
+    "username": "abdulslmys-123",
+    "email": "abdulslm.ys@gmail.com"
+  },
+  "record": {
+    "CNAME": "abdulslmys-123.github.io"
+  }
+}


### PR DESCRIPTION
Registering weblix.is-a.dev for Weblix Web Agency - a web design agency based in Cairo, Egypt. Points to abdulslmys-123.github.io.