### PR TITLE
Add nullsec.json with domain owner and record

### DIFF
--- a/domains/nullsec.json
+++ b/domains/nullsec.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "harman1418"
+    },
+    "record": {
+        "CNAME": "calm-pebble-078a62300.7.azurestaticapps.net"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live URL: https://calm-pebble-078a62300.7.azurestaticapps.net/login

<img width="1917" height="1028" alt="image" src="https://github.com/user-attachments/assets/c3b7111e-ff40-480e-b2c7-6a1b6afc0878" />


# Website Purpose

NullSec is a free, open-source cybersecurity learning platform built for 
students who cannot afford paid platforms like HackTheBox or TryHackMe. 
It provides hands-on hacking labs with real exploitable vulnerable containers 
(SQL injection, LFI, SSRF, privilege escalation, RCE), AI-powered Socratic 
hints powered by Groq/Llama, and structured theory learning paths with quizzes. 
Built with React, FastAPI, PostgreSQL, and Docker. Fully non-commercial, 
free forever, and open source.