### PR TITLE
Add personal portfolio site configuration for Nihal Gupta

### DIFF
--- a/domains/nihal-gupta.json
+++ b/domains/nihal-gupta.json
@@ -1,0 +1,11 @@
+{
+    "description": "Personal portfolio site for Nihal Gupta — backend / full-stack developer",
+    "owner": {
+        "username": "Nihal-Gupta",
+        "email": "Nihal-Gupta@users.noreply.github.com"
+    },
+    "record": {
+        "CNAME": "nihal--portfolio--nzjmwn7pzkzv.code.run"
+    },
+    "proxied": false
+}

--- a/domains/nihal-gupta.json
+++ b/domains/nihal-gupta.json
@@ -1,8 +1,8 @@
-{
+ {
     "description": "Personal portfolio site for Nihal Gupta — backend / full-stack developer",
     "owner": {
       "username": "Nihal-Gupta",
-      "email": "Nihal-Gupta@users.noreply.github.com"
+      "email": "nihalgupta@duck.com"
     },
     "records": {
       "CNAME": "nihal--portfolio--nzjmwn7pzkzv.code.run"

--- a/domains/nihal-gupta.json
+++ b/domains/nihal-gupta.json
@@ -1,11 +1,11 @@
 {
     "description": "Personal portfolio site for Nihal Gupta — backend / full-stack developer",
     "owner": {
-        "username": "Nihal-Gupta",
-        "email": "Nihal-Gupta@users.noreply.github.com"
+      "username": "Nihal-Gupta",
+      "email": "Nihal-Gupta@users.noreply.github.com"
     },
-    "record": {
-        "CNAME": "nihal--portfolio--nzjmwn7pzkzv.code.run"
+    "records": {
+      "CNAME": "nihal--portfolio--nzjmwn7pzkzv.code.run"
     },
     "proxied": false
-}
+  }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live URL: https://nihal--portfolio--nzjmwn7pzkzv.code.run/

(Screenshot attached below — drag the file in.)
<img width="1400" height="1800" alt="portfolio_preview" src="https://github.com/user-attachments/assets/cf456f58-0525-4c46-a7da-25e9dd301dfc" />

# Website Purpose

Personal portfolio and "user manual" site for me as a full-stack developer. Sections cover my work history (backend / cloud / applied AI across banking, telecom, and GenAI), my approach to collaboration, my availability, and a community-consulting offer for people learning to build software. Non-commercial — no sales, no ads, no paid services. Hosted via Northflank as a static nginx container; the is-a.dev CNAME will replace the long Northflank URL.
