### PR TITLE
Register superlite.is-a.dev

### DIFF
--- a/domains/superlite.json
+++ b/domains/superlite.json
@@ -1,0 +1,6 @@
+{
+  "owner": "kelvinzero",
+  "record": {
+    "CNME": "Superlite-OS.github.io"
+  }
+}


### PR DESCRIPTION
## Requirements
- [x] I've read and understood the [docs](https://docs.is-a.dev)
- [x] My file is in the `domains/` folder and is in the correct format
- [x] My domain is not already taken
- [x] I'm registering for a GitHub Pages site

## Purpose
Register `superlite.is-a.dev` for SuperLite OS project website — an ultra-lightweight Linux desktop environment (300MB) built on Alpine Linux.

## Records
- CNAME → Superlite-OS.github.io