### PR TITLE
Register xhsagent.is-a.dev

### DIFF
--- a/domains/xhsagent.json
+++ b/domains/xhsagent.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "renjianxin929-ux",
+    "email": "renjianxin929-ux@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
I would like to register xhsagent.is-a.dev for my deployed social media automation web app.

Project:
https://social-media-automation-blond.vercel.app

Repository:
https://github.com/renjianxin929-ux/social-media-automation