### PR TITLE
Register kira.is-a.dev (dev portfolio)

### DIFF
--- a/domains/kira.json
+++ b/domains/kira.json
@@ -1,0 +1,12 @@
+{
+  "description": "Kira — personal AI dev assistant portfolio",
+  "repo": "https://github.com/radityafahmi/kira-site",
+  "owner": {
+    "username": "radityafahmi",
+    "email": "fahmibudiansyah18@gmail.com"
+  },
+  "records": {
+    "CNAME": "radityafahmi.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview: https://radityafahmi.github.io/kira-site/

The site is a personal developer portfolio. It documents an open-source AI agent project (Kira) and links out to my related GitHub repositories.

Source repository: https://github.com/radityafahmi/kira-site

# Website Purpose

`kira.is-a.dev` will serve as the developer-facing landing page for **Kira**, a personal AI development assistant project. It is purely a portfolio / documentation site that:

- Describes the project and its open-source components
- Links to related public repositories ([openclaw/openclaw](https://github.com/openclaw/openclaw), [9router](https://github.com/radityafahmi/9router), [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI))
- Lists development interests (agent runtimes, LLM tooling, Linux infra)

The page is static HTML, hosted on GitHub Pages, with no payment, signup, or commercial CTA. It is strictly software development related and complies with the is-a.dev Terms of Service.

# Note on previous PR

This is a re-submission after PR #38975 was closed for being commercial / not dev-related. The previous attempt pointed `kira.is-a.dev` directly at a hosted application backend. This PR points the subdomain at a static developer portfolio on GitHub Pages instead, which is the intended use case for is-a.dev.
