### PR TITLE
Create ownership verification JSON for nihal-gupta

### DIFF
--- a/domains/verify-5wnv9bmiu26482gaip2ijmim.nihal-gupta.json
+++ b/domains/verify-5wnv9bmiu26482gaip2ijmim.nihal-gupta.json
@@ -1,0 +1,11 @@
+{
+    "description": "Northflank ownership verification record for nihal-gupta.is-a.dev (temporary — will be removed after verification succeeds)",
+    "owner": {
+        "username": "Nihal-Gupta",
+        "email": "nihalgupta@duck.com"
+    },
+    "records": {
+        "TXT": "238a3d1600b3ede1f06bcba4a03db35427fbde8091daed6e090172a7e9c29"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Add ownership verification record for nihal-gupta.is-a.dev.

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

The website served at the parent subdomain `nihal-gupta.is-a.dev` (registered via the merged PR #38985) is my personal portfolio / "How to work with me" page. It is currently reachable on its Northflank service URL while custom-domain verification is in progress:

**Live URL:** https://nihal--portfolio--nzjmwn7pzkzv.code.run

**Screenshot:** *(paste a screenshot of the portfolio site here in the GitHub PR description — drag-and-drop the image into the textarea and GitHub will upload it)*

# Website Purpose

This pull request **does not register a new website**. It adds a temporary TXT-only record at `verify-5wnv9bmiu26482gaip2ijmim.nihal-gupta.is-a.dev` so that Northflank (the hosting provider for my already-approved portfolio site at `nihal-gupta.is-a.dev`) can verify domain ownership and issue a Let's Encrypt certificate for the custom domain.

The parent subdomain `nihal-gupta.is-a.dev` was approved and merged in PR #38985. That subdomain hosts a personal portfolio website (software-development related, non-commercial) describing my background as a full-stack developer.

Once Northflank's ownership check succeeds and the TLS certificate is provisioned, I will open a follow-up cleanup PR to delete this temporary verification record so it does not linger in the registry.
<img width="1920" height="1080" alt="Screenshot (68)" src="https://github.com/user-attachments/assets/0dfae322-c66c-4e64-be63-e0d828eeb83e" />
