### PR TITLE
Add minishare.is-a.dev Resend DNS records

### DIFF
--- a/domains/resend._domainkey.minishare.json
+++ b/domains/resend._domainkey.minishare.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "irfan7o"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCid+t2wkE3/bgWk7BVE/AE7C2HuZIOl1yQ8lCYPGDT5fYpJ8tPA8XKySVzN0hc9A78PVHL4Y7LbLtjcLqs0D3KzZncEtNgzbdmXfjaspuass46fkUs7HyO0XmdXw1IhHFKGDkllGCe6ip1DkxuF/EUoA0oDzF4pwI7puHe0HsB2wIDAQAB"
+  }
+}

--- a/domains/send.minishare.json
+++ b/domains/send.minishare.json
@@ -1,0 +1,14 @@
+{
+  "owner": {
+    "username": "irfan7o"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.us-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
Adds the DNS records required to verify Resend for `minishare.is-a.dev`:
- `send.minishare.is-a.dev` MX/SPF records
- `resend._domainkey.minishare.is-a.dev` DKIM TXT record

This supports transactional OTP email delivery for MiniShare.