### PR TITLE
Register reda.is-a.dev

### DIFF
--- a/domains/_vercel.reda.json
+++ b/domains/_vercel.reda.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"E-Roar"},"records":{"TXT":"vc-domain-verify=reda.is-a.dev,090c5cbec1c90968277c"},"proxied":false}

--- a/domains/reda.json
+++ b/domains/reda.json
@@ -1,9 +1,1 @@
-{
-  "owner": {
-    "username": "redaAssemghor",
-    "discord": "r3dapt"
-  },
-  "records": {
-    "CNAME": "portfolio-mocha-eta-22.vercel.app"
-  }
-}
+{"owner":{"username":"E-Roar"},"records":{"CNAME":"cname.vercel-dns.com"}}


### PR DESCRIPTION
Registering `reda.is-a.dev` subdomain pointing to Vercel.

- CNAME: cname.vercel-dns.com
- Vercel TXT verification included
- Owner: E-Roar