### PR TITLE
Add health-ai-tracker.is-a.dev

### DIFF
--- a/domains/health-ai-tracker.json
+++ b/domains/health-ai-tracker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "poorvabedmutha31",
+    "email": "poorvabedmutha31@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "poorvabedmutha31.github.io"
+  }
+}

--- a/domains/health-ai-tracker.json
+++ b/domains/health-ai-tracker.json
@@ -3,7 +3,7 @@
     "username": "poorvabedmutha31",
     "email": "pbedmutha@ucsd.edu"
   },
-  "record": {
+  "records": {
     "CNAME": "poorvabedmutha31.github.io"
   }
 }

--- a/domains/health-ai-tracker.json
+++ b/domains/health-ai-tracker.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "poorvabedmutha31",
-    "email": "poorvabedmutha31@users.noreply.github.com"
+    "email": "pbedmutha@ucsd.edu"
   },
   "record": {
     "CNAME": "poorvabedmutha31.github.io"


### PR DESCRIPTION
Requesting health-ai-tracker.is-a.dev subdomain for Health AI Adoption Tracker visualization website.