### PR TITLE
Register matindarwish.is-a.dev

### DIFF
--- a/domains/matindarwish.json
+++ b/domains/matindarwish.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Matinthereal",
+        "email": "DarwishEnterprises@protonmail.com"
+    },
+    "records": {
+        "CNAME": "matinthereal.github.io"
+    }
+}


### PR DESCRIPTION
Registering `matindarwish.is-a.dev` for my personal portfolio / bio website.

- **Owner:** @Matinthereal
- **Record:** `CNAME` → `matinthereal.github.io`
- **Live site (currently on GitHub Pages):** https://matinthereal.github.io/matindarwish-site/

The file follows the schema (owner.username + records, CNAME-only). Thanks for the service! ⭐