### PR TITLE
Add rt004.is-a.dev

### DIFF
--- a/domains/rt004.json
+++ b/domains/rt004.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"srychlz"},"record":{"CNAME":"srychlz.github.io"},"proxied":false}


### PR DESCRIPTION
Adding rt004.is-a.dev for RT 004 / RW 007 neighborhood organization website.

- CNAME pointing to srychlz.github.io
- GitHub Pages already configured
- Website: https://srychlz.github.io/rt004rw007/