### PR TITLE
Register jinholee.is-a.dev

### DIFF
--- a/domains/jinholee.json
+++ b/domains/jinholee.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Jin-HoMLee",
+        "email": "jinho.michael.lee@gmail.com"
+    },
+    "records": {
+        "CNAME": "jin-homlee.github.io"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live at https://jin-homlee.github.io/jin-ho-lee-cv/ (will move to https://jinholee.is-a.dev/ after this PR merges + DNS propagates).

<img width="1552" height="864" alt="Screenshot 2026-05-26 at 15 11 15" src="https://github.com/user-attachments/assets/cb8ce553-3c3a-45ff-b9aa-28286ac97038" />

# Website Purpose

Personal CV / portfolio for a bioinformatics & data science engineer. Machine-readable source-of-truth (YAML + BibTeX) renders to a bilingual website (EN + DE), PDF, JSON Resume, JSON-LD, and plain text via Python and Astro pipelines. Open-source at https://github.com/Jin-HoMLee/jin-ho-lee-cv.
