### PR TITLE
add athlone.is-a.dev

### DIFF
--- a/domains/athlone.json
+++ b/domains/athlone.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "pescanovaisnotbald",
+    "email": "joanotruiz@gmail.com"
+  },
+  "records": {
+    "CNAME": "athlone-joanotruiz-5024s-projects.vercel.app"
+  }
+}


### PR DESCRIPTION
## Description

Registering `athlone.is-a.dev` — landing page for Athlone, an EMG muscle-performance sensor.

CNAME → `athlone-joanotruiz-5024s-projects.vercel.app` (Vercel production deployment)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md)
- [x] I own the target server/deployment
- [x] The CNAME target is a valid Vercel production URL