### PR TITLE
add f1predictor.is-a.dev

### DIFF
--- a/domains/f1predictor.json
+++ b/domains/f1predictor.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "CCguvycu",
+    "email": "cameroncull5@gmail.com"
+  },
+  "records": {
+    "CNAME": "motorsport-telemetry.onrender.com"
+  }
+}


### PR DESCRIPTION
Registering `f1predictor.is-a.dev` pointing to `motorsport-telemetry.onrender.com` — an F1 race predictor using Monte Carlo simulation.