### PR TITLE
Add rt004.is-a.dev

### DIFF
--- a/domains/rt004.json
+++ b/domains/rt004.json
@@ -1,1 +1,1 @@
-{"owner":{"username":"srychlz"},"record":{"CNAME":"srychlz.github.io"},"proxied":false}
+{"description":"RT 004 / RW 007 Portal Warga Digital","repo":"https://github.com/srychlz/rt004rw007","owner":{"username":"srychlz","email":"suryaputraqq@gmail.com"},"records":{"CNAME":"srychlz.github.io"}}

--- a/domains/rt004.json
+++ b/domains/rt004.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"srychlz"},"record":{"CNAME":"srychlz.github.io"},"proxied":false}


### PR DESCRIPTION
Adding rt004.is-a.dev for RT 004 / RW 007 Portal Warga Digital website. Points to srychlz.github.io via CNAME record.