### PR TITLE
Add hardik.json for GitHub projects portfolio

### DIFF
--- a/domains/hardik.json
+++ b/domains/hardik.json
@@ -1,11 +1,11 @@
 {
-       "description": "Hardik's GitHub Projects Portfolio",
-       "domain": "hardik.is-a.dev",
-       "owner": {
-         "email": "Hndrd2681@gmail.com",
-         "username": "hndrd0",
-         "repo": "https://github.com/Hndrd0/Hndrd0"
-       },
-       "repo": "https://github.com/Hndrd0/Hndrd0",
-       "url": "https://raw.githubusercontent.com/Hndrd0/Hndrd0/main/index.html"
-     }
+  "description": "Hardik's GitHub Projects Portfolio",
+  "domain": "hardik.is-a.dev",
+  "owner": {
+    "email": "Hndrd2681@gmail.com",
+    "username": "hndrd0",
+    "repo": "https://github.com/Hndrd0/Hndrd0"
+  },
+  "repo": "https://github.com/Hndrd0/Hndrd0",
+  "url": "https://raw.githubusercontent.com/Hndrd0/Hndrd0/main/index.html"
+}

--- a/domains/hardik.json
+++ b/domains/hardik.json
@@ -1,0 +1,11 @@
+{
+       "description": "Hardik's GitHub Projects Portfolio",
+       "domain": "hardik.is-a.dev",
+       "owner": {
+         "email": "Hndrd2681@gmail.com",
+         "username": "hndrd0",
+         "repo": "https://github.com/Hndrd0/Hndrd0"
+       },
+       "repo": "https://github.com/Hndrd0/Hndrd0",
+       "url": "https://raw.githubusercontent.com/Hndrd0/Hndrd0/main/index.html"
+     }


### PR DESCRIPTION
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). 
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). 
- [x] My website is **reachable** and **completed**. 
- [x] My website is **software development** related. 
- [x] My website is **not for commercial use**. 
- [x] I have provided contact information in the `owner` key
- [x] I have provided a preview of my website below.

# Website Preview
(Link)[https://github.com/Hndrd0/Hndrd0/blob/main/preview.png]
<img width="1919" height="958" alt="preview" src="https://github.com/user-attachments/assets/3ab06ef2-672b-4b39-adf1-7c532b95bbbf" />

# Website Purpose
Personal portfolio website showcasing my GitHub projects and software development experience that links directly to my GitHub profile where visitors can explore my repositories and contributions. In the future i plan to revamp this.