### PR TITLE
Register nb.is-a.dev

### DIFF
--- a/domains/nb.json
+++ b/domains/nb.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "hiroshiinada",
+    "email": "hiro.o.inada@gmail.com"
+  },
+  "record": {
+    "CNAME": "nb-app.pages.dev"
+  },
+  "description": "Personal private dashboard (read-only, login-required)"
+}


### PR DESCRIPTION
Adding `nb.is-a.dev` for my personal private dashboard. CNAME points to a Cloudflare Pages project hosting a read-only, login-required viewer for personal notes.