### PR TITLE
Codex add metering domain

### DIFF
--- a/domains/jode.json
+++ b/domains/jode.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "DejanIkic",
+        "email": "dikic19999@gmail.com"
+    },
+    "records": {
+        "CNAME": "metering.pages.dev"
+    }
+}

--- a/domains/jode.json
+++ b/domains/jode.json
@@ -1,9 +1,0 @@
-{
-    "owner": {
-        "username": "DejanIkic",
-        "email": "dikic19999@gmail.com"
-    },
-    "records": {
-        "CNAME": "metering.pages.dev"
-    }
-}

--- a/domains/metering.json
+++ b/domains/metering.json
@@ -1,0 +1,13 @@
+{
+  "description": "Metering application served through Cloudflare Tunnel",
+  "owner": {
+    "username": "DejanIkic",
+    "email": "dikic19999@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "meera.ns.cloudflare.com",
+      "sam.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Preview link: https://metering.is-a.dev

Screenshot:
<img width="1105" height="677" alt="vodomjeri prikaz" src="https://github.com/user-attachments/assets/0ff1b609-6b1c-4474-905a-fa86854b1f11" />

# Website Purpose

Metering is a software development project for tracking and managing application metering data. The website is used as a non-commercial project page/API entry point for my metering application and related development work.