### PR TITLE
Register lcdimm.is-a.dev

### DIFF
--- a/domains/lcdimm.json
+++ b/domains/lcdimm.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "liqiang11110-ops"
+  },
+  "records": {
+    "CNAME": "liqiang11110-ops.github.io"
+  }
+}


### PR DESCRIPTION
Register lcdimm.is-a.dev for the LCDIMM static site hosted on GitHub Pages.

Target: https://liqiang11110-ops.github.io/lcdimm/
DNS: CNAME liqiang11110-ops.github.io