### PR TITLE
Register timothytate.is-a.dev

### DIFF
--- a/domains/timothytate.json
+++ b/domains/timothytate.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AnnontheOne",
+    "email": "yodarocks200@gmail.com"
+  },
+  "records": {
+    "CNAME": "annontheone.github.io"
+  }
+}


### PR DESCRIPTION
Registering `timothytate.is-a.dev` for my personal portfolio site, hosted on GitHub Pages at `annontheone.github.io/portfolio`.

- **Subdomain:** timothytate.is-a.dev
- **Owner:** AnnontheOne
- **Record:** CNAME → annontheone.github.io
- **Purpose:** Personal portfolio (https://github.com/AnnontheOne/portfolio)

Site is ready and waiting on the subdomain to point. Thanks for maintaining is-a.dev!