### PR TITLE
Add humanforce-clockbot.is-a.dev

### DIFF
--- a/domains/humanforce-clockbot.json
+++ b/domains/humanforce-clockbot.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "shivamdubey117",
+    "email": "shivamdubey117@gmail.com"
+  },
+  "record": {
+    "CNAME": "shivamdubey117.github.io"
+  }
+}

--- a/domains/humanforce-clockbot.json
+++ b/domains/humanforce-clockbot.json
@@ -1,9 +1,11 @@
 {
+  "description": "Automated attendance system for Humanforce",
+  "repo": "https://github.com/shivamdubey117/humanforce-clockbot",
   "owner": {
     "username": "shivamdubey117",
     "email": "shivamdubey117@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "shivamdubey117.github.io"
   }
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms)
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/)
- [x] My website is **reachable** and **completed**
- [x] My website is **software development** related
- [x] My website is **not for commercial use**
- [x] I have provided contact information in the `owner` key
- [x] I have provided a preview of my website below

# Website Preview
https://shivamdubey117.github.io/humanforce-clockbot/

![ClockBot Preview](https://github.com/user-attachments/assets/screenshot-of-your-site.png)

# Website Purpose
Automated attendance/clock-in system for employee time tracking using Humanforce WFM. This is a production web application for Panasonic that automates daily clock-in and clock-out processes for team members. It's a software development project demonstrating web automation and GitHub Actions integration.
