### PR TITLE
Register hummus.is-a.dev

### DIFF
--- a/domains/_vercel.hummus.json
+++ b/domains/_vercel.hummus.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "karimsangid",
+        "email": "karimsangid@gmail.com"
+    },
+    "description": "Vercel domain ownership verification for hummus.is-a.dev",
+    "repo": "https://github.com/karimsangid",
+    "records": {
+        "TXT": ["vc-domain-verify=hummus.is-a.dev,1c9893d0e1ad5a2053ad"]
+    }
+}

--- a/domains/hummus.json
+++ b/domains/hummus.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "karimsangid",
+        "email": "karimsangid@gmail.com"
+    },
+    "description": "Hummus Development — product studio site",
+    "repo": "https://github.com/karimsangid",
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
<!-- Reposting with the PR template per @dragsbruh's review. -->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**. <!-- This is a portfolio/showcase: no on-site transactions, no e-commerce, no ads, no paywalls. Same posture as my approved `karimsangid.is-a.dev`. If maintainers interpret a software-studio portfolio as commercial, please flag and I'll close. -->
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live preview (Vercel default URL):** https://hummusdev-site.vercel.app

Screenshot of the home page rendered at the preview URL:
![Site preview](https://hummusdev-site.vercel.app/assets/logo.png)

(Note: the image above is just the logo; please open the preview link for the full page — hero, services, selected work, stack, credentials, process, contact.)

# Website Purpose

Portfolio / showcase site for **Hummus Development** — a software studio. The site documents:

- Software services we offer (web platforms, mobile apps, AI integrations)
- Selected past work (each card links to either a live URL or describes the engagement)
- The technical stack we use
- Process & engagement steps
- Studio credentials (Azure AZ-204, Apple Developer, etc.)

It's a personal/studio showcase — nothing is sold on the site, there are no transactions, no monetization, no ads. Same purpose as my already-approved `karimsangid.is-a.dev`, just for the studio brand instead of the individual.

# Changes in this PR

This PR adds two files:

1. `domains/hummus.json` — the main subdomain record, CNAME → `cname.vercel-dns.com`
2. `domains/_vercel.hummus.json` — Vercel ownership verification TXT record (per https://docs.is-a.dev/guides/vercel/), added per @dragsbruh's review request.