### PR TITLE
Register globe-news.is-a.dev

### DIFF
--- a/domains/globe-news.json
+++ b/domains/globe-news.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+      "username": "LiLy2026wx",
+      "email": "ripplewabi@rippleclio.com"
+    },
+    "records": {
+      "CNAME": "globe-news-do4.pages.dev"
+    }
+  }


### PR DESCRIPTION
 # Requirements

  - [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
  - [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
  - [x] My website is **reachable** and **completed**.
  - [x] My website is **software development** related.
  - [x] My website is **not for commercial use**.
  - [x] I have provided contact information in the `owner` key.
  - [x] I have provided a preview of my website below.

  # Website Preview

  **Live URL**: https://globe-news-do4.pages.dev/
  **Repository**: https://github.com/LiLy2026wx/globe-news

<img width="1264" height="1200" alt="屏幕截图 2026-05-28 182905" src="https://github.com/user-attachments/assets/c67828b4-7f4d-48d8-a5cd-a8f304efb95b" />


  # Website Purpose

  `globe-news` is an open-source educational web visualization that renders daily international news from 30 countries
  onto an interactive 3D globe using [globe.gl](https://github.com/vasturiano/globe.gl). News headlines are auto-fetched
   from RSS feeds via a GitHub Actions cron job and grouped into 5 fixed categories (politics, military, economy,
  technology, aviation).

  The project is non-commercial — built as a hobby tool to help children visually learn about world events. There are no
   ads, no tracking, no monetization. The source code (HTML/JS frontend + Python fetcher + GitHub Actions workflow +
  Cloudflare Pages deploy) demonstrates browser-side 3D visualization, RSS parsing, and CI-driven static-site
  automation.

  Currently hosted on Cloudflare Pages; migrating to `globe-news.is-a.dev` to bypass WeChat's silent blacklisting of
  `*.pages.dev` subdomains (which causes `ERR_NAME_NOT_RESOLVED` in WeChat's in-app browser).
