### PR TITLE
update yanis.is-a.dev to Vercel new IP + rotate verification token

### DIFF
--- a/domains/_vercel.yanis.json
+++ b/domains/_vercel.yanis.json
@@ -4,6 +4,6 @@
     "email": "yanisoukaci667@gmail.com"
   },
   "records": {
-    "TXT": ["vc-domain-verify=yanis.is-a.dev,d4fd6f76388919ec6508"]
+    "TXT": ["vc-domain-verify=yanis.is-a.dev,0fbd52ee72d9b1687171"]
   }
 }

--- a/domains/yanis.json
+++ b/domains/yanis.json
@@ -4,6 +4,6 @@
     "email": "yanisoukaci667@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "A": ["216.198.79.1"]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://yaniscode.github.io/portfolio (will resolve at yanis.is-a.dev once these DNS records propagate via Vercel)

# Website Purpose

Update existing yanis.is-a.dev DNS records to match Vercel's new requirements:

- **yanis.json**: switch from CNAME (cname.vercel-dns.com) to A record (216.198.79.1), per Vercel's new IP range expansion
- **_vercel.yanis.json**: rotate TXT verification token to match the current Vercel project (previous token was bound to a stale project link, blocking ownership verification)

This is my software development portfolio - I'm a Full-Stack Developer and 2nd year CS student at ESTIN Bejaia, building React, Next.js, Django REST and Flutter projects.