### PR TITLE
add sangat-tools

### DIFF
--- a/domains/sangat-tools.json
+++ b/domains/sangat-tools.json
@@ -1,0 +1,11 @@
+{
+    "record":  {
+                   "CNAME":  "106d9ffa-955b-4b75-855f-f50e0ce3a9a8.cfargotunnel.com"
+               },
+    "description":  "SANGAT Tools - Free PDF and Image toolkit online",
+    "repo":  "https://github.com/showkennbachik-beep/sangat_safe_site",
+    "owner":  {
+                  "email":  "mrkbaloch@gmail.com",
+                  "username":  "showkennbachik-beep"
+              }
+}


### PR DESCRIPTION
Adding sangat-tools.is-a.dev subdomain for SANGAT PDF & Image Tools.

Repo: https://github.com/showkennbachik-beep/sangat_safe_site