### PR TITLE
add redlinedigital.is-a.dev

### DIFF
--- a/domains/redlinedigital.json
+++ b/domains/redlinedigital.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "ramoncristobal"
+  },
+  "record": {
+    "CNAME": "master.d3mes86rkjk7g8.amplifyapp.com"
+  }
+}

--- a/domains/redlinedigital.json
+++ b/domains/redlinedigital.json
@@ -2,7 +2,7 @@
   "owner": {
     "username": "ramoncristobal"
   },
-  "record": {
+  "records": {
     "CNAME": "master.d3mes86rkjk7g8.amplifyapp.com"
   }
 }


### PR DESCRIPTION
## Description

Adding `redlinedigital.is-a.dev` for Redline Digital, a web design agency serving small businesses in the Dallas-Fort Worth area.

## Record

- **Type:** CNAME
- **Value:** `master.d3mes86rkjk7g8.amplifyapp.com` (AWS Amplify)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md)
- [x] I have checked that the subdomain is not already taken
- [x] The domain JSON is valid