### PR TITLE
Register speedtest.is-a.dev

### DIFF
--- a/domains/isitdownrightnow.json
+++ b/domains/isitdownrightnow.json
@@ -1,0 +1,13 @@
+{
+  "owner": {
+    "username": "firekids2026-coder",
+    "email": "firekids2026@gmail.com"
+  },
+  "description": "Personal mirror of isitdownrightnow.app for faster regional access and uptime archiving.",
+  "record": {
+    "NS": [
+      "fay.ns.cloudflare.com",
+      "norm.ns.cloudflare.com"
+    ]
+  }
+}

--- a/domains/speedtest.json
+++ b/domains/speedtest.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "firekids2026-coder",
+    "email": "firekid2024@gmail.com"
+  },
+  "record": {
+    "NS": [
+      "clarissa.ns.cloudflare.com",
+      "felicity.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
Subdomain: isitdownrightnow.is-a.dev
Project: Personal mirror of https://isitdownrightnow.app/ for faster regional load times
and as an uptime-data archive for my own monitoring use.

Why NS delegation: Using Cloudflare for DNS, SSL, and edge caching.
NS delegation to fay.ns.cloudflare.com / norm.ns.cloudflare.com lets me manage
all records there.

Original site relation: Mirror only. No affiliation claimed; clear attribution to
the original site will be displayed.
