### PR TITLE
Register nospoon, onlymath, sonicmeans

### DIFF
--- a/domains/nospoon.json
+++ b/domains/nospoon.json
@@ -1,0 +1,9 @@
+{
+	"owner": {
+		"username": "lyfar",
+		"email": "lyfar@users.noreply.github.com"
+	},
+	"records": {
+		"CNAME": "nospoon-693.pages.dev"
+	}
+}

--- a/domains/nospoon.json
+++ b/domains/nospoon.json
@@ -1,7 +1,7 @@
 {
 	"owner": {
 		"username": "lyfar",
-		"email": "lyfar@users.noreply.github.com"
+		"email": "touchgrass.main@gmail.com"
 	},
 	"records": {
 		"CNAME": "nospoon-693.pages.dev"

--- a/domains/onlymath.json
+++ b/domains/onlymath.json
@@ -1,0 +1,9 @@
+{
+	"owner": {
+		"username": "lyfar",
+		"email": "lyfar@users.noreply.github.com"
+	},
+	"records": {
+		"CNAME": "nospoon-693.pages.dev"
+	}
+}

--- a/domains/onlymath.json
+++ b/domains/onlymath.json
@@ -1,7 +1,7 @@
 {
 	"owner": {
 		"username": "lyfar",
-		"email": "lyfar@users.noreply.github.com"
+		"email": "touchgrass.main@gmail.com"
 	},
 	"records": {
 		"CNAME": "nospoon-693.pages.dev"

--- a/domains/sonicmeans.json
+++ b/domains/sonicmeans.json
@@ -1,0 +1,9 @@
+{
+	"owner": {
+		"username": "lyfar",
+		"email": "lyfar@users.noreply.github.com"
+	},
+	"records": {
+		"CNAME": "nospoon-693.pages.dev"
+	}
+}

--- a/domains/sonicmeans.json
+++ b/domains/sonicmeans.json
@@ -1,7 +1,7 @@
 {
 	"owner": {
 		"username": "lyfar",
-		"email": "lyfar@users.noreply.github.com"
+		"email": "touchgrass.main@gmail.com"
 	},
 	"records": {
 		"CNAME": "nospoon-693.pages.dev"


### PR DESCRIPTION
Three subdomains, each CNAME to the same Cloudflare Pages site (`nospoon-693.pages.dev`):

- `nospoon.is-a.dev`
- `onlymath.is-a.dev`
- `sonicmeans.is-a.dev`

Small static site — bare HTML, native MathML, no trackers. The Pages project already has these three hostnames added as custom domains, so they resolve and serve as soon as the CNAMEs merge. Thanks for running this.