### PR TITLE
Register chumak.is-a.dev

### DIFF
--- a/domains/chumak.json
+++ b/domains/chumak.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "spumony",
+    "email": "ciumac.dev@gmail.com"
+  },
+  "records": {
+    "A": ["204.168.196.101"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Source code (public, MIT-licensed Vite + React + TypeScript build):
https://github.com/spumony/chumak-cv

Screenshot of the built site (rendered locally via `pnpm preview`, identical to the build that will be served on the subdomain once DNS propagates):

![chumak-cv hero — Alexandr Chumak, Senior Frontend Engineer → AI Product Engineer](https://raw.githubusercontent.com/spumony/chumak-cv/main/docs/screenshot.png)

The static build is already deployed to my own Hetzner Cloud server at `204.168.196.101` (Helsinki) — nginx is configured to serve `/var/www/chumak-cv/dist/` for `server_name chumak.is-a.dev`. HTTPS via Let's Encrypt / certbot will be issued as soon as the A record propagates.

# Website Purpose

Personal CV / portfolio site for a Senior Frontend Engineer (5 years React/TypeScript/Next.js) transitioning into AI Product Engineering. The site is a bilingual (EN/RU) single-page static build with:

- Hero with role-line and pitch
- "Now" manifest (what I'm building, reading, open to)
- Selected Work case studies (Problem → Approach → Stack → Outcome)
- Experience, Education, Skills, Languages
- Freelance "Work with me" section
- Two downloadable ATS-friendly PDFs (EN + RU)

Recruiter-facing software-development portfolio. No commercial offering, no ads, no tracking — purely a resume site with a portfolio of public engineering work. Pet-project, not for revenue.
