### PR TITLE
add carthical.is-a.dev domain with Vercel verification

### DIFF
--- a/domains/_vercel.carthical.json
+++ b/domains/_vercel.carthical.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "carthical",
+        "email": "karthikgowdaa24@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=carthical.is-a.dev,da71572a752a655e7b6b"
+    }
+}


### PR DESCRIPTION
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Link:** https://carthical-dev.vercel.app/

**Screenshot:**
![carthical-dev vercel app](https://carthical-dev.vercel.app/assets/og-image.jpg)
<img width="1282" height="641" alt="og-image" src="https://github.com/user-attachments/assets/deb95b6b-78a6-4a22-907a-6b0889ca70ca" />


# Website Purpose

Personal portfolio and resume website showcasing my work as a full-stack software engineer — including project architecture, technical stack, and a contact form for collaboration inquiries.