### PR TITLE
Register prism.is-a.dev

### DIFF
--- a/domains/prism.json
+++ b/domains/prism.json
@@ -1,0 +1,4 @@
+{
+  "owner": { "username": "uxwangy-code", "email": "265025489+uxwangy-code@users.noreply.github.com" },
+  "records": { "CNAME": "xmark-review-d8fad0.netlify.app" }
+}


### PR DESCRIPTION
Registering prism.is-a.dev (CNAME to a Netlify site). Personal knowledge hub. Thanks!