### PR TITLE
Register mayurrawte.is-a.dev

### DIFF
--- a/domains/mayurrawte.json
+++ b/domains/mayurrawte.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "mayurrawte",
+    "email": "mayur@shipthis.co"
+  },
+  "records": {
+    "CNAME": "mayurrawte.github.io"
+  }
+}


### PR DESCRIPTION
Registering `mayurrawte.is-a.dev` as a CNAME to my GitHub Pages site (`mayurrawte.github.io`).

- Owner: @mayurrawte
- Record: CNAME -> mayurrawte.github.io