### PR TITLE
Add gokulnathv.is-a.dev and gokulnath.is-a.dev

### DIFF
--- a/domains/_vercel.gokulnath.json
+++ b/domains/_vercel.gokulnath.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Coding-Devil",
+        "email": "gokulnathvenkateshan821@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=gokulnath.is-a.dev,b1e738ba6071ca6f7f77"
+    }
+}

--- a/domains/_vercel.gokulnathv.json
+++ b/domains/_vercel.gokulnathv.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Coding-Devil",
+        "email": "gokulnathvenkateshan821@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=gokulnathv.is-a.dev,1a8347eca099865b74b0"
+    }
+}

--- a/domains/gokulnath.json
+++ b/domains/gokulnath.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Coding-Devil",
+        "email": "gokulnathvenkateshan821@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}

--- a/domains/gokulnathv.json
+++ b/domains/gokulnathv.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Coding-Devil",
+        "email": "gokulnathvenkateshan821@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live: https://gokulnathv.vercel.app (the deployment that both `gokulnathv.is-a.dev` and `gokulnath.is-a.dev` will point to)

![Portfolio preview](https://raw.githubusercontent.com/Coding-Devil/register/preview-assets/portfolio-preview.png)

# Website Purpose

This is my personal developer portfolio. It documents my work as an AI engineer building agentic and semantic systems — projects, certifications, work experience, and writing. Non-commercial, just a place for recruiters and collaborators to find me.

Two subdomains in one PR:
- `gokulnathv.is-a.dev` — primary, matches my Vercel project handle (`gokulnathv.vercel.app`)
- `gokulnath.is-a.dev` — cleaner alias I'll redirect to the primary

The two `_vercel.*.json` files are the Vercel ownership-verification TXT records required because `.is-a.dev` is on the Public Suffix List.
