### PR TITLE
Register finditem.is-a.dev

### DIFF
--- a/domains/finditem.json
+++ b/domains/finditem.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "HarryXin0919",
+    "email": "harryxinfirefly919@gmail.com"
+  },
+  "description": "FindItem — open-source decentralized parts-storage locator firmware for the ESP32-C3 (RGB LED + buzzer guided retrieval).",
+  "repo": "https://github.com/HarryXin0919/FindItem",
+  "records": {
+    "CNAME": "harryxin0919.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live:** https://harryxin0919.github.io/findit-website/
**Source (MIT, public):** https://github.com/HarryXin0919/FindItem

![FindItem website preview](https://raw.githubusercontent.com/HarryXin0919/findit-website/main/preview.png)

# Website Purpose

`finditem.is-a.dev` is the homepage for **FindItem**, an **open-source software project**. It's firmware + a backend that together locate stored electronic parts: when a part is requested, the matching storage bin lights an LED and sounds a buzzer; a backend (Python/FastAPI, with interchangeable Java ports) bridges phone/web requests to the ESP32 devices over MQTT.

**Stack:** ESP32 (Arduino/C++) · FastAPI (Python) · MQTT (Mosquitto) · vanilla HTML/CSS/JS frontend. MIT-licensed; full source at the repo above.

The site documents the project, links prominently to the public source, and is non-commercial. (This is a fresh PR — the page now leads with the open-source software and tech stack, addressing earlier "not software-development related" feedback.)
