### PR TITLE
add cathcli.is-a.dev

### DIFF
--- a/domains/cathcli.json
+++ b/domains/cathcli.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "clementinepujiutami",
+    "email": "pj.utami41@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Here's your complete copy-paste for the is-a.dev PR:

  ---
  - [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
  - [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
  - [x] My website is **reachable** and **completed**.
  - [x] My website is **software development** related.
  - [x] My website is **not for commercial use**.
  - [x] I have provided contact information in the `owner` key.
  - [x] I have provided a preview of my website below.
  
  # Website Preview
  
  https://landing-7htxgxjz1-amethystcs-projects.vercel.app
  
<img width="1920" height="1034" alt="image" src="https://github.com/user-attachments/assets/9e204b40-5294-40f0-98ee-72c44e2bdd0e" />
  
  # Website Purpose
  
  Landing page for cathCLI — an open-source terminal CLI for the Catholic Bible (NABRE, 73-book canon) and Catholic prayers.
  A free personal devotional tool for reading scripture and prayers from the terminal, featuring a pixel-art cat mascot
  (Pawpe Miau). Not commercial — fully open source.
  
  Repo: https://github.com/clementinepujiutami/cathCLI

