### PR TITLE
Add wwm-metrics.json for WWM-DMGCALC project

### DIFF
--- a/domains/wwm-metrics.json
+++ b/domains/wwm-metrics.json
@@ -1,0 +1,12 @@
+{
+  "description": "WWM-DMGCALC - Damage calculator and expected value analyzer for Where Winds Meet.",
+  "repo": "https://github.com/Sh1get0ra/WWM-DMGCALC",
+  "owner": {
+    "username": "Sh1get0ra",
+    "email": "ms.tottie.1016@gmail.com"
+  },
+  "record": {
+    "CNAME": "sh1get0ra.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live URL: https://sh1get0ra.github.io/WWM-DMGCALC/

Screenshot attached below.
<img width="1295" height="1210" alt="image" src="https://github.com/user-attachments/assets/a5fc5110-8a35-42fe-8b5c-a50703086129" />

# Website Purpose

WWM-DMGCALC is a fan-made, open-source damage calculator and Martial Index analyzer for the game "Where Winds Meet" (NetEase). Built as a Vanilla HTML/CSS/JS web tool hosted on GitHub Pages.

Features:
- Martial Index calculation (fixed-coefficient damage expectation)
- Gear / xinfa import from the official roleInfo tool
- Tune/Attune affix efficiency analysis, equipment comparison modal
- Greedy gear optimization, tier ranking
- i18n (ja/en/zh/ko), dark/light theme
- OBS overlay mode for streamers
- Fully client-side, no backend, no analytics, no ads, no monetization

Source: https://github.com/Sh1get0ra/WWM-DMGCALC
License: MIT