### PR TITLE
Update gh-showcase.is-a.dev Vercel verification token

### DIFF
--- a/domains/_vercel.gh-showcase.json
+++ b/domains/_vercel.gh-showcase.json
@@ -4,6 +4,6 @@
         "email": "zikyoubi@gmail.com"
     },
     "records": {
-        "TXT": "vc-domain-verify=gh-showcase.is-a.dev,5150cda655dee1688409"
+        "TXT": "vc-domain-verify=gh-showcase.is-a.dev,553ed9705251497fe52a"
     }
 }


### PR DESCRIPTION
Updates the `_vercel.gh-showcase` TXT record to the current Vercel domain-verification token so `gh-showcase.is-a.dev` can be connected to the project. The previous token is no longer valid. No change to the A record.