### PR TITLE
Register rann.is-a.dev

### DIFF
--- a/domains/rann.json
+++ b/domains/rann.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "frieren17-dev",
+    "email": "rannielabueg17@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `rann.is-a.dev` for my developer portfolio.

- **Owner / GitHub:** frieren17-dev
- **Record:** CNAME → `cname.vercel-dns.com` (Vercel)
- **Purpose:** Personal developer portfolio site
- I've read the docs and the JSON validates against the schema.