### PR TITLE
Register disksage.is-a.dev

### DIFF
--- a/domains/disksage.json
+++ b/domains/disksage.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "stealthdev-labs",
+    "email": "264828194+stealthdev-labs@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "stealthdev-labs.github.io"
+  }
+}

--- a/domains/disksage.json
+++ b/domains/disksage.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "stealthdev-labs",
-    "email": "264828194+stealthdev-labs@users.noreply.github.com"
+    "email": "lloaltie+disksage@gmail.com"
   },
   "records": {
     "CNAME": "stealthdev-labs.github.io"


### PR DESCRIPTION
Registering `disksage.is-a.dev` for **DiskSage** — a free, open-source macOS disk cleaner: https://github.com/stealthdev-labs/disksage

- File: `domains/disksage.json`
- Record: `CNAME` → `stealthdev-labs.github.io` (GitHub Pages)
- Owner: @stealthdev-labs