### PR TITLE
Register mcsa.is-a.dev

### DIFF
--- a/domains/mcsa.json
+++ b/domains/mcsa.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Jerry2003826",
+    "email": "223425819+Jerry2003826@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "jerry2003826.github.io"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
## Summary
- Subdomain: mcsa.is-a.dev
- Points to GitHub Pages: jerry2003826.github.io
- Site: https://github.com/Jerry2003826/mcsa-website (Monash Chinese Student Association official website)

## Checklist
- [x] Website is reachable (GitHub Pages)
- [x] CNAME configured for GitHub Pages
- [x] Owner contact provided

Made with [Cursor](https://cursor.com)