### PR TITLE
Register kittygram.is-a.dev and taski.is-a.dev

### DIFF
--- a/domains/kittygram.json
+++ b/domains/kittygram.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "infinity74853"
+  },
+  "records": {
+    "A": ["158.160.236.143"]
+  }
+}

--- a/domains/taski.json
+++ b/domains/taski.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "infinity74853"
+  },
+  "records": {
+    "A": ["IP_АДРЕС_TASKI"]
+  }
+}

--- a/domains/taski.json
+++ b/domains/taski.json
@@ -3,6 +3,6 @@
     "username": "infinity74853"
   },
   "records": {
-    "A": ["IP_АДРЕС_TASKI"]
+    "A": ["158.160.236.143"]
   }
 }


### PR DESCRIPTION
Registering two domains for my study projects from Yandex Practicum:

- kittygram.is-a.dev → Kittygram app (cat photos)
- taski.is-a.dev → Taski app (task manager)

Both projects are already deployed and running.

- [x] I agree to the Terms of Service
- [x] My file follows the domain structure
- [x] My website is reachable and completed
- [x] My website is software development related
- [x] My website is not for commercial use
- [x] I have provided contact information in the `owner` key
- [x] I have provided a preview of my website below

## Website Preview

**kittygram.is-a.dev:** http://158.160.236.143:9000

**taski.is-a.dev:** http://158.160.236.143:80

## Website Purpose

Educational projects for Yandex Practicum Python course.
