### PR TITLE
Register whitebored.is-a.dev

### DIFF
--- a/domains/_dmarc.whitebored.json
+++ b/domains/_dmarc.whitebored.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "Jeql88",
+    "email": "joshedlui4@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "v=DMARC1; p=none;"
+    ]
+  }
+}

--- a/domains/resend._domainkey.whitebored.json
+++ b/domains/resend._domainkey.whitebored.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "Jeql88",
+    "email": "joshedlui4@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDQU+VyqF/Dq6zXGHqXXPahxvs11MZ3fundVaSGblc3eZzEf1k2dRaCXF5emAsoFWCihRdVY3O3ZdZrshGSmrNm3EK0fpHvredrdl3tPVQ16Z6XcB1UJw4VfPwqajM/hc1Kdx8lzqdnDPt8n8E0r5LyBxh23kR6+LRYQ9BQ6mvtcQIDAQAB"
+    ]
+  }
+}

--- a/domains/send.whitebored.json
+++ b/domains/send.whitebored.json
@@ -1,0 +1,17 @@
+{
+  "owner": {
+    "username": "Jeql88",
+    "email": "joshedlui4@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.ap-northeast-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": [
+      "v=spf1 include:amazonses.com ~all"
+    ]
+  }
+}

--- a/domains/whitebored.json
+++ b/domains/whitebored.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Jeql88",
+    "email": "joshedlui4@gmail.com"
+  },
+  "records": {
+    "CNAME": "whiteboard-app-8loo.onrender.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
### Description
Registering `whitebored.is-a.dev` for **Whitebored**, a real-time collaborative whiteboard web application I built (React + Vite frontend, Node.js + Express + Socket.IO backend, MongoDB). Multiple users draw together on an infinite canvas with live cursors, presence, comments and chat over WebSockets. Source: https://github.com/Jeql88/whiteboard-app

### Records
- `whitebored` → CNAME to the app's host (Render).
- `send.whitebored`, `resend._domainkey.whitebored`, `_dmarc.whitebored` → MX/SPF/DKIM/DMARC for transactional email (account verification / password reset) via Resend. No bulk/marketing mail.

### Checklist
- [x] I have read and understood the [Terms of Service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md)
- [x] Records are valid JSON and follow the schema
- [x] The CNAME target is live and serving the application