### PR TITLE
Register hermesdima.is-a.dev

### DIFF
--- a/domains/hermesdima.json
+++ b/domains/hermesdima.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Diskurs307"
+  },
+  "records": {
+    "CNAME": "next-sensitive-vehicle-pumps.trycloudflare.com"
+  }
+}


### PR DESCRIPTION
Registering a personal subdomain for Hermes/voice bridge.

CNAME currently points to the active quick tunnel and can be updated later to a named tunnel hostname.