### PR TITLE
Register greedislandkr.is-a.dev

### DIFF
--- a/domains/greedislandkr.json
+++ b/domains/greedislandkr.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "popkjee-ux",
+    "email": "popkj@nexon.co.kr"
+  },
+  "records": {
+    "CNAME": "popkjee-ux.github.io"
+  }
+}


### PR DESCRIPTION
Registering `greedislandkr.is-a.dev` for a personal static site hosted on GitHub Pages.

- Owner: @popkjee-ux
- Record: CNAME -> popkjee-ux.github.io
- Site: https://github.com/popkjee-ux/greedisland-cards