### PR TITLE
Register ramieid.is-a.dev

### DIFF
--- a/domains/_vercel.ramieid.json
+++ b/domains/_vercel.ramieid.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "rae81",
+    "email": "ramieid04@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=ramieid.is-a.dev,15a1017551d47b154e55"
+  }
+}

--- a/domains/ramieid.json
+++ b/domains/ramieid.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "rae81",
+    "email": "ramieid04@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview: **https://rami-portfolio-sable.vercel.app**

It is a complete, original portfolio (Next.js + GSAP): an animated hero, an "About" ID card, experience/education, a skills section, a "Selected Work" grid of real engineering projects, a publications viewer, and a working contact form. The hero "Press Power" button boots an in-browser desktop ("RamiOS") where each project opens as its own app with architecture diagrams.

# Website Purpose

Personal developer/engineering portfolio for Rami Eid, a Computer & Communications Engineering graduate (Cybersecurity & AI). It showcases software/security engineering projects, DFIR work, and first-author research papers. Non-commercial; purely a personal portfolio.

---

Records:
- `domains/ramieid.json` — A record `216.198.79.1` (Vercel)
- `domains/_vercel.ramieid.json` — Vercel domain-ownership TXT verification
