### PR TITLE
Add free-ai-api.is-a.dev domain

### DIFF
--- a/domains/free-ai-api.json
+++ b/domains/free-ai-api.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}


### PR DESCRIPTION
## Add free-ai-api.is-a.dev

Adding `free-ai-api.is-a.dev` for my GitHub Pages site.

### Records
- CNAME: `jianchuan3.github.io`

### Reason
Hosting my free AI API service.