### PR TITLE
Add 12 free subdomains for GitHub Pages

### DIFF
--- a/domains/ai-api-free.json
+++ b/domains/ai-api-free.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/ai-free-api.json
+++ b/domains/ai-free-api.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/api-monetize.json
+++ b/domains/api-monetize.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/deepseek-free.json
+++ b/domains/deepseek-free.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/devapi-free.json
+++ b/domains/devapi-free.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/free-ai-proxy.json
+++ b/domains/free-ai-proxy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/free-ai-service.json
+++ b/domains/free-ai-service.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/free-api-proxy.json
+++ b/domains/free-api-proxy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/free-gpt-api-fun.json
+++ b/domains/free-gpt-api-fun.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/free-llm-api.json
+++ b/domains/free-llm-api.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/free-llm-proxy.json
+++ b/domains/free-llm-proxy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}

--- a/domains/gpt-free-api.json
+++ b/domains/gpt-free-api.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jianchuan3",
+    "email": "406429544@qq.com"
+  },
+  "records": {
+    "CNAME": "jianchuan3.github.io"
+  }
+}


### PR DESCRIPTION
Adding multiple .is-a.dev domains for free AI API service.

- `ai-free-api.is-a.dev` (CNAME)
- `deepseek-free.is-a.dev` (CNAME)
- `free-llm-api.is-a.dev` (CNAME)
- `free-gpt-api-fun.is-a.dev` (CNAME)
- `free-ai-service.is-a.dev` (CNAME)
- `devapi-free.is-a.dev` (CNAME)
- `free-api-proxy.is-a.dev` (CNAME)
- `free-llm-proxy.is-a.dev` (CNAME)
- `ai-api-free.is-a.dev` (CNAME)
- `gpt-free-api.is-a.dev` (CNAME)
- `free-ai-proxy.is-a.dev` (CNAME)
- `api-monetize.is-a.dev` (CNAME)