### PR TITLE
Add tangerdantan.is-a.dev subdomain

### DIFF
--- a/domains/tangerdantan.json
+++ b/domains/tangerdantan.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"ucfzem"},"record":{"CNAME":"tanger.ucfzem.workers.dev"}}


### PR DESCRIPTION
Subdomain registration for **Tanger d'Antan** — a photo gallery of historic Tangier.

- **Owner:** ucfzem
- **Record:** CNAME → tanger.ucfzem.workers.dev (Cloudflare Workers)