### PR TITLE
Add 0xchapo.is-a.dev

### DIFF
--- a/domains/0xchapo.json
+++ b/domains/0xchapo.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "yossweh",
+    "email": "cilokcilok15@gmail.com"
+  },
+  "records": {
+    "A": [
+      "129.226.215.57"
+    ],
+    "CNAME": "u108668558.wl059.sendgrid.net"
+  }
+}

--- a/domains/s1._domainkey.json
+++ b/domains/s1._domainkey.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"yossweh","email":"cilokcilok15@gmail.com"},"records":{"CNAME":"s1.domainkey.u108668558.wl059.sendgrid.net"}}

--- a/domains/s2._domainkey.json
+++ b/domains/s2._domainkey.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"yossweh","email":"cilokcilok15@gmail.com"},"records":{"CNAME":"s2.domainkey.u108668558.wl059.sendgrid.net"}}


### PR DESCRIPTION
Adding 0xchapo.is-a.dev for Cold Email Engine SaaS.

Includes:
- A record pointing to VPS (129.226.215.57)
- CNAME for SendGrid email delivery
- DKIM1 and DKIM2 records for email authentication

Used for: 0xChapo - AI-powered cold email platform