### PR TITLE
feat: add pmtools.is-a.dev

### DIFF
--- a/domains/pmtools.json
+++ b/domains/pmtools.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "obertydev-oss",
+        "email": "obertydev@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds a new subdomain `pmtools.is-a.dev` pointing to Vercel.

### Details
- **Subdomain:** `pmtools`
- **Target:** `cname.vercel-dns.com` (Vercel)
- **Owner GitHub:** [@obertydev-oss](https://github.com/obertydev-oss)
- **Project URL:** https://github.com/obertydev-oss/PMTools
- **Live URL:** https://pmtools.vercel.app

### About the project
**Project Management Tools (PMTools)** — A full-stack web application built with Next.js, TypeScript, Prisma, and PostgreSQL for Product Managers to:
- Register and track software projects
- Manage team members (PIC), documents (PRD/BRD/TRD), and project phases with Gantt timeline
- Log Minutes of Meeting (MoM) and track date change history
- Export reports as PDF or standalone HTML

Open-source, self-hostable, free to use.