### PR TITLE
Register videoscoring.is-a.dev

### DIFF
--- a/domains/videoscoring.json
+++ b/domains/videoscoring.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "xy-ai123",
+        "email": "seexinyi@virtuals.io"
+    },
+    "description": "Permanent URL for the video scoring dashboard (robot-video-pipeline).",
+    "records": {
+        "CNAME": "11955c3c-497b-40e2-ac99-d2ef326d054e.cfargotunnel.com"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

The site is reachable right now via a temporary Cloudflare quick-tunnel URL (the named tunnel that the requested CNAME will point at is already provisioned in my CF account, but no public hostname is wired to it until this PR lands).

**Live preview:** https://sofa-ocean-textbook-monitored.trycloudflare.com/admin/clipping

This is the same site that will be served at `videoscoring.is-a.dev` once the PR is merged + DNS propagates. If the URL above stops working between when I open this PR and when you review it, I'm sorry — quick-tunnel URLs rotate every few hours. Please ping me on the PR and I'll post the current URL.

# Website Purpose

Personal admin dashboard for an egocentric-video / hand-activity scoring pipeline I'm building. The dashboard:

- Lists video submissions ingested from Google Drive
- Lets me review, approve/reject, and clip them
- Generates per-submitter total-duration reports (CSV + PDF)
- Tracks phone-inventory mappings across submitters

It's a personal research tool, not a commercial service. Source code is private during development.

Thanks for reviewing — and for running is-a.dev!
