### PR TITLE
Register apollonin.is-a.dev

### DIFF
--- a/domains/apollonin.json
+++ b/domains/apollonin.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "apollonin",
+    "email": "apollonin@gmail.com"
+  },
+  "records": {
+    "A": ["35.255.19.43"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live at the server this A record points to: http://35.255.19.43 (it will serve from `http://apollonin.is-a.dev` once this is merged).

# Website Purpose

This is a **personal playground** — a sandbox where I test ideas and try out new features (a small FastAPI + Node.js stack running on GCP). It is **non-commercial**, purely for tinkering and learning.
