### PR TITLE
Register anti-autobiography.is-a.dev

### DIFF
--- a/domains/anti-autobiography.json
+++ b/domains/anti-autobiography.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "thc1006",
+    "email": "84045975+thc1006@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "thc1006.github.io"
+  }
+}

--- a/domains/anti-autobiography.json
+++ b/domains/anti-autobiography.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "thc1006",
-    "email": "84045975+thc1006@users.noreply.github.com"
+    "email": "hctsai+dev@linux.com"
   },
   "records": {
     "CNAME": "thc1006.github.io"


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live (publicly reachable, GitHub Pages): https://thc1006.github.io/arete-exhibition-2026-e-book/

Source code (open source): https://github.com/thc1006/arete-exhibition-2026-e-book

It is a custom-built, open-source web application: a page-flip e-book viewer built with the open-source StPageFlip library, plus a Python (PyMuPDF) rasterization/build pipeline. The deployed site is the running software.

# Website Purpose

A non-commercial, open-source project. I built this web app to present a student graduation exhibition as an interactive page-flip e-book (deep-linkable per page via `?page=N`, responsive, HTTPS). The repository contains the full front-end (HTML/CSS/JS) and the build tooling. No ads, no monetization, purely personal/educational.