### PR TITLE
Add Google verification for gokulnathv.is-a.dev

### DIFF
--- a/domains/gokulnathv.json
+++ b/domains/gokulnathv.json
@@ -4,6 +4,7 @@
         "email": "gokulnathvenkateshan821@gmail.com"
     },
     "records": {
-        "A": ["216.198.79.1"]
+        "A": ["216.198.79.1"],
+        "TXT": ["google-site-verification=krqhfzNsy0X0exlFDa9KqyJNdtryYtebWQZib2qVcbo"]
     }
 }


### PR DESCRIPTION
## Summary
- Add Google Search Console TXT verification record for `gokulnathv.is-a.dev`
- Preserve the existing A record pointing to `216.198.79.1`

## Verification
- Parsed `domains/gokulnathv.json` successfully with Node JSON parser


# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. --
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**. 
- [x] I have provided contact information in the `owner` key. 
- [x] I have provided a preview of my website below. 

# Website Preview
 https://gokulnath.is-a.dev/ 
 
<img width="1897" height="946" alt="image" src="https://github.com/user-attachments/assets/4ef467bf-cd72-4409-bd2c-26af8bd2f8e5" />


# Website Purpose
My personal Portfolio

