### PR TITLE
Register amroalghoul.is-a.dev

### DIFF
--- a/domains/amroalghoul.json
+++ b/domains/amroalghoul.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "mohamedhadri"
+    },
+    "records": {
+        "CNAME": "mohamedhadri.github.io"
+    }
+}


### PR DESCRIPTION
Registering `amroalghoul.is-a.dev` for my personal developer portfolio (React + Vite + TypeScript front-end), hosted on GitHub Pages at mohamedhadri/amroalghoul-portfolio. Record: CNAME -> mohamedhadri.github.io. Owner username matches PR author. Followed the docs/schema.