### PR TITLE
Add lumiva.is-a.dev

### DIFF
--- a/lumiva.json
+++ b/lumiva.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Shawnmarcio-a11y",
+    "email": "shawnmarcio140@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
I want to register lumiva.is-a.dev for my e-commerce project in Mozambique.

# Requirements
- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://lumivaloja.vercel.app

The site is a Next.js e-commerce for Mozambican market. Ready for production.