### PR TITLE
feat: add lumina-api.is-a.dev

### DIFF
--- a/domains/lumina.json
+++ b/domains/lumina.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "xgg-2",
+    "email": "bnnasfywsf@gmail.com"
+  },
+  "record": {
+    "CNAME": "lumina-api-ky2v.onrender.com"
+  }
+}

--- a/domains/xgg-2.json
+++ b/domains/xgg-2.json
@@ -3,7 +3,7 @@
     "username": "xgg-2",
     "email": "xgg.2dev@proton.me"
   },
-  "record": {
+  "records": {
     "CNAME": "xgg-2p.pages.dev"
   }
 }

--- a/domains/xgg-2.json
+++ b/domains/xgg-2.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "xgg-2",
+    "email": "xgg.2dev@proton.me"
+  },
+  "record": {
+    "CNAME": "xgg-2p.pages.dev"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Link: https://lumina-api-ky2v.onrender.com

# Website Purpose

A public REST API that exposes Discord user presence and profile data (avatar, status, badges, and decorations) for use in developer portfolios and personal websites. Built with Node.js and hosted on Render.