### PR TITLE
Registering .is-a.dev subdomain

### DIFF
--- a/domains/auth.sg.musahi0128.json
+++ b/domains/auth.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/auth.us.musahi0128.json
+++ b/domains/auth.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/desktop.sg.musahi0128.json
+++ b/domains/desktop.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/desktop.us.musahi0128.json
+++ b/domains/desktop.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/gbom-demo.sg.musahi0128.json
+++ b/domains/gbom-demo.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/gbom-demo.us.musahi0128.json
+++ b/domains/gbom-demo.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/jellyfin.sg.musahi0128.json
+++ b/domains/jellyfin.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/jellyfin.us.musahi0128.json
+++ b/domains/jellyfin.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/lxd.sg.musahi0128.json
+++ b/domains/lxd.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/lxd.us.musahi0128.json
+++ b/domains/lxd.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/me.musahi0128.json
+++ b/domains/me.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/musahi0128.json
+++ b/domains/musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/navidrome.sg.musahi0128.json
+++ b/domains/navidrome.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/navidrome.us.musahi0128.json
+++ b/domains/navidrome.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/npm.sg.musahi0128.json
+++ b/domains/npm.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/npm.us.musahi0128.json
+++ b/domains/npm.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/openlist.sg.musahi0128.json
+++ b/domains/openlist.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/openlist.us.musahi0128.json
+++ b/domains/openlist.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/plex.sg.musahi0128.json
+++ b/domains/plex.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/plex.us.musahi0128.json
+++ b/domains/plex.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/qbittorrent-nox.sg.musahi0128.json
+++ b/domains/qbittorrent-nox.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/qbittorrent-nox.us.musahi0128.json
+++ b/domains/qbittorrent-nox.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/sg.musahi0128.json
+++ b/domains/sg.musahi0128.json
@@ -4,6 +4,6 @@
     "email": "musahi0128@gmail.com"
   },
   "records": {
-    "A": ["158.178.238.252"]
+    "CNAME": "me.musahi0128.is-a.dev"
   }
 }

--- a/domains/sg.musahi0128.json
+++ b/domains/sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/teldrive.sg.musahi0128.json
+++ b/domains/teldrive.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/teldrive.us.musahi0128.json
+++ b/domains/teldrive.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/timetagger.sg.musahi0128.json
+++ b/domains/timetagger.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/timetagger.us.musahi0128.json
+++ b/domains/timetagger.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/timetracker.sg.musahi0128.json
+++ b/domains/timetracker.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/timetracker.sg.musahi0128.json
+++ b/domains/timetracker.sg.musahi0128.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "musahi0128",
-    "email": "musahi0128@gmail.com"
-  },
-  "records": {
-    "A": ["158.178.238.252"]
-  }
-}

--- a/domains/timetracker.us.musahi0128.json
+++ b/domains/timetracker.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/timetracker.us.musahi0128.json
+++ b/domains/timetracker.us.musahi0128.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "musahi0128",
-    "email": "musahi0128@gmail.com"
-  },
-  "records": {
-    "A": ["129.153.85.17"]
-  }
-}

--- a/domains/uptime-kuma.sg.musahi0128.json
+++ b/domains/uptime-kuma.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/uptime-kuma.us.musahi0128.json
+++ b/domains/uptime-kuma.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/us.musahi0128.json
+++ b/domains/us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/us.musahi0128.json
+++ b/domains/us.musahi0128.json
@@ -4,6 +4,6 @@
     "email": "musahi0128@gmail.com"
   },
   "records": {
-    "A": ["129.153.85.17"]
+    "CNAME": "me.musahi0128.is-a.dev"
   }
 }

--- a/domains/webhook-tester.sg.musahi0128.json
+++ b/domains/webhook-tester.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/webhook-tester.us.musahi0128.json
+++ b/domains/webhook-tester.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}

--- a/domains/webmin.sg.musahi0128.json
+++ b/domains/webmin.sg.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["158.178.238.252"]
+  }
+}

--- a/domains/webmin.us.musahi0128.json
+++ b/domains/webmin.us.musahi0128.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "musahi0128",
+    "email": "musahi0128@gmail.com"
+  },
+  "records": {
+    "A": ["129.153.85.17"]
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. if not provided your PR will be closed with no questions asked. -->
https://auth.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/2303bcb9-f9cc-45be-a385-fb47b18827c7" />
https://desktop.oci-us-aarch64-1.webredirect.org/
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/a33d4ae0-999c-4fc4-b972-03c46538122f" />
https://jellyfin.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/74f16957-56d6-4ec4-ac5f-084683ef95fb" />
https://lxd-ui.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/7721563c-a612-4576-9c70-580c1ac1fb92" />
https://musahi0128.github.io
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/d7e521e6-b4fd-4a32-a3c0-95a1895316bc" />
https://navidrome.oci-sg-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/27df8328-3e3e-4625-97a4-575024590f12" />
https://npm.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/9f7c0127-10cd-4533-b6a0-61135bc22758" />
https://openlist.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/4a07c450-4f2f-43fe-96c2-b50dc1aa6940" />
https://qbittorrent-nox.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/3bf1e288-5126-4a96-a8bf-1d7eefa04008" />
https://timetagger.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/c44cc284-dc0d-45c3-8a00-65ea43f6029c" />
https://uptime-kuma.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/a5c77c46-cb83-4ffc-b57c-8a63ce824892" />
https://webhook-tester.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/1ca2f148-c5ee-4227-bfc9-d005a3875243" />
https://webmin.oci-us-aarch64-1.webredirect.org
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/0841c177-70e9-4535-85f7-45b2a91db80c" />

# Website Purpose
<!-- Please tell us the purpose or motive behind your website. For example, it is a portfolio website, etc. -->
The main purpose is to showcase my capability with setting up and managing those services.
- My profile page, would like to migrate and host it from my server
  - musahi0128.is-a.dev → https://musahi0128.github.io
  - me.musahi0128.is-a.dev → https://musahi0128.github.io
  - sg.musahi0128.is-a.dev → https://musahi0128.github.io
  - us.musahi0128.is-a.dev → https://musahi0128.github.io
- [Authelia](https://github.com/authelia/authelia)
  - auth.sg.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain
  - auth.us.musahi0128.is-a.dev → https://auth.oci-us-aarch64-1.webredirect.org
- Xubuntu desktop
  - desktop.sg.musahi0128.is-a.dev → https://desktop.oci-sg-aarch64-1.webredirect.org
  - desktop.us.musahi0128.is-a.dev → https://desktop.oci-us-aarch64-1.webredirect.org
- [Jellyfin](https://github.com/jellyfin/jellyfin)
  - jellyfin.sg.musahi0128.is-a.dev → https://jellyfin.oci-sg-aarch64-1.webredirect.org
  - jellyfin.us.musahi0128.is-a.dev → https://jellyfin.oci-us-aarch64-1.webredirect.org
- [Canonical LXD](https://github.com/canonical/lxd)
  - lxd.sg.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain
  - lxd.us.musahi0128.is-a.dev → https://lxd-ui.oci-us-aarch64-1.webredirect.org
- [Navidrome](https://github.com/navidrome/navidrome)
  - navidrome.sg.musahi0128.is-a.dev → https://navidrome.oci-sg-aarch64-1.webredirect.org
  - navidrome.us.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
- [Nginx Proxy Manager](https://github.com/NginxProxyManager/nginx-proxy-manager)
  - npm.sg.musahi0128.is-a.dev → https://npm.oci-sg-aarch64-1.webredirect.org
  - npm.us.musahi0128.is-a.dev → https://npm.oci-us-aarch64-1.webredirect.org
- [OpenList](https://github.com/OpenListTeam/OpenList)
  - openlist.sg.musahi0128.is-a.dev → https://openlist.oci-sg-aarch64-1.webredirect.org
  - openlist.us.musahi0128.is-a.dev → https://openlist.oci-us-aarch64-1.webredirect.org
- [Plex Media Server](https://www.plex.tv/media-server-downloads/?cat=computer&plat=linux)
  - plex.sg.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
  - plex.us.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
- [qBittorrent Web UI](https://github.com/qbittorrent/qBittorrent)
  - qbittorrent-nox.sg.musahi0128.is-a.dev → https://qbittorrent-nox.oci-sg-aarch64-1.webredirect.org
  - qbittorrent-nox.us.musahi0128.is-a.dev → https://qbittorrent-nox.oci-us-aarch64-1.webredirect.org
- [Teldrive](https://github.com/tgdrive/teldrive)
  - teldrive.sg.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
  - teldrive.us.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
- [TimeTagger](https://github.com/almarklein/timetagger)
  - timetagger.sg.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
  - timetagger.us.musahi0128.is-a.dev → https://timetagger.oci-us-aarch64-1.webredirect.org
- [Uptime Kuma](https://github.com/louislam/uptime-kuma)
  - uptime-kuma.sg.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
  - uptime-kuma.us.musahi0128.is-a.dev → https://uptime-kuma.oci-us-aarch64-1.webredirect.org
- [Webhook.site](https://github.com/webhooksite/webhook.site)
  - webhook-tester.sg.musahi0128.is-a.dev → Not up yet, would like to setup with the new domain later
  - webhook-tester.us.musahi0128.is-a.dev → https://webhook-tester.oci-us-aarch64-1.webredirect.org
- [Webmin](https://github.com/webmin/webmin)
  - webmin.sg.musahi0128.is-a.dev → https://webmin.oci-sg-aarch64-1.webredirect.org
  - webmin.us.musahi0128.is-a.dev → https://webmin.oci-us-aarch64-1.webredirect.org

Thank you very much for your great free service!