### PR TITLE
Register haizeiwang.is-a.dev

### DIFF
--- a/domains/haizeiwang.json
+++ b/domains/haizeiwang.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "naive000"
+  },
+  "records": {
+    "CNAME": "naive000.github.io"
+  }
+}

--- a/domains/haizeiwang.json
+++ b/domains/haizeiwang.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "naive000"
+    "username": "naive000",
+    "email": "goodnaive@gmail.com"
   },
   "records": {
     "CNAME": "naive000.github.io"


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Preview link: https://naive000.github.io/haizeiwang-bohol-pilot/#pilot

Screenshot:

![Haizeiwang Bohol pilot preview](https://naive000.github.io/haizeiwang-bohol-pilot/preview.png)

# Website Purpose

`haizeiwang.is-a.dev` will host a static preview of the Haizeiwang / Bohol fisheries data-station software prototype. The site demonstrates a software-development pilot concept with prototype UI, public data-signal presentation, workflow explanation, and a static demo experience. It is used as a non-commercial project/demo preview and does not process payments, sell products, or provide paid account signup.
