### PR TITLE
Update TXT record for domain verification

### DIFF
--- a/domains/_vercel.muhammadhassan.json
+++ b/domains/_vercel.muhammadhassan.json
@@ -4,6 +4,6 @@
     "email": "muhammadhassan6@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=muhammadhassan.is-a.dev,3b78cc80407d3850ef3"
+    "TXT": "vc-domain-verify=muhammadhassan.is-a.dev,d1842e8b0e1400100670"
   }
 }

--- a/domains/_vercel.muhammadhassan.json
+++ b/domains/_vercel.muhammadhassan.json
@@ -4,6 +4,6 @@
     "email": "muhammadhassan6@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=muhammadhassan.is-a.dev,d1842e8b0e1400100670"
+    "TXT": "vc-domain-verify=muhammadhassan.is-a.dev,d1842c8b0e1400100670"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.

# Description

Updating the Vercel TXT verification record for `muhammadhassan.is-a.dev`.

The new TXT record is:

`vc-domain-verify=muhammadhassan.is-a.dev,d1842c8b0e1400100670`

This is needed to verify domain ownership on Vercel.