### PR TITLE
Register ogtraderld.is-a.dev

### DIFF
--- a/domains/ogtraderld.json
+++ b/domains/ogtraderld.json
@@ -1,8 +1,8 @@
-{
+  {
     "owner": {
       "username": "imlukasd"
     },
-    "record": {
+    "records": {
       "A": ["103.69.97.196"]
     }
   }

--- a/domains/ogtraderld.json
+++ b/domains/ogtraderld.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+      "username": "imlukasd"
+    },
+    "record": {
+      "A": ["103.69.97.196"]
+    }
+  }


### PR DESCRIPTION
## Requirements

  - [x] I agree to the Terms of Service.
  - [x] My file is following the domain structure.
  - [x] My website is reachable and completed.
  - [x] My website is software development related.
  - [x] My website is not for commercial use.
  - [x] I have provided contact information in the `owner` key.
  - [x] I have provided a preview of my website below.

  ## Website Preview

  http://103.69.97.196

  ## Website Purpose

  An open, public leaderboard dashboard for OG traders, showing Volume, Open Interest, and estimated ROI rankings using public RISEx APIs.
