### PR TITLE
Add pressshop.is-a.dev domain

### DIFF
--- a/domains/pressshop.json
+++ b/domains/pressshop.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "dngesler-blip"
+  },
+  "records": {
+    "A": ["2.26.117.170"]
+  }
+}


### PR DESCRIPTION
## Requirements
- [X] I have checked the [domain structure guidelines](https://docs.is-a.dev/domain-structure) and followed them.
- [X] I have checked the [domain availability](https://www.is-a.dev/) and my domain is available.
- [X] I have checked that my file is in the `domains/` directory and follows the naming convention `pressshop.json`.
- [X] I have checked the [terms of service](https://is-a.dev/terms) and agreed to them.

## Description
Register `pressshop.is-a.dev` for PressShop - an industrial AI platform (B2B marketplace for stamping equipment). This is a software development project built with Next.js 16 + TypeScript + Supabase.

## Preview
The site currently shows an industrial production tracking prototype at http://2.26.117.170