### PR TITLE
fix: update varundasharadhi CNAME to project-specific

### DIFF
--- a/domains/varundasharadhi.json
+++ b/domains/varundasharadhi.json
@@ -4,6 +4,6 @@
     "email": "developerworld.net@gmail.com"
   },
   "records": {
-        "CNAME": "62ffeadbf82ef8f9.vercel-dns-017.com."
+        "CNAME": "62ffeadbf82ef8f9.vercel-dns-017.com"
   }
 }

--- a/domains/varundasharadhi.json
+++ b/domains/varundasharadhi.json
@@ -4,6 +4,6 @@
     "email": "developerworld.net@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+        "CNAME": "62ffeadbf82ef8f9.vercel-dns-017.com."
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [ ] - [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [ ] - [x] My website is **reachable** and **completed**.
- [ ] - [x] My website is **software development** related.
- [ ] - [x] My website is **not for commercial use**.
- [ ] - [x] I have provided contact information in the `owner` key.
Updating CNAME from generic `cname.vercel-dns.com` to project-specific `62ffeadbf82ef8f9.vercel-dns-017.com.` to fix domain verification in Vercel.