### PR TITLE
Create mlcqdigitalyearbook.json

### DIFF
--- a/domains/mlcqdigitalyearbook.json
+++ b/domains/mlcqdigitalyearbook.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "Kristnn-44"
+    },
+    "records": {
+        "CNAME": "kristnn-44.github.io"
+    }
+}


### PR DESCRIPTION
## Domain
mlcqdigitalyearbook.is-a.dev

## Owner
<img width="1838" height="850" alt="c849887a4738f16fd9a0190316fb1c1a" src="https://github.com/user-attachments/assets/53edc308-e577-42c4-99da-1ec91d1c59cb" />

- GitHub username: Kristnn-44

## Proof
- Website URL: https://kristnn-44.github.io
- (可选) 附上网站截图（可拖拽到此处上传）

## Additional info
这是我校的年鉴网站，包含2020-2026年的PDF预览功能，使用GitHub Pages托管。
![Uploading image.png…]