### PR TITLE
Register instadance-videos.is-a.dev

### DIFF
--- a/domains/instadance-videos.json
+++ b/domains/instadance-videos.json
@@ -1,0 +1,10 @@
+{
+  "description": "Landing page with links to Instagram dance videos",
+  "repo": "https://github.com/mataneyal278/Landing-page-for-qr",
+  "owner": {
+    "username": "mataneyal278"
+  },
+  "records": {
+    "CNAME": "mataneyal278.github.io"
+  }
+}


### PR DESCRIPTION
Adds instadance-videos.is-a.dev for a GitHub Pages landing page with links to Instagram dance videos.\n\nTarget: https://github.com/mataneyal278/Landing-page-for-qr\nDNS: CNAME mataneyal278.github.io\n\nValidation: npm test