### PR TITLE
Register vpizarrotraslados.is-a.dev

### DIFF
--- a/domains/vpizarrotraslados.json
+++ b/domains/vpizarrotraslados.json
@@ -1,7 +1,6 @@
 {
   "owner": {
-    "username": "PanchaPizarro",
-    "email": "PanchaPizarro@users.noreply.github.com"
+    "username": "PanchaPizarro"
   },
   "records": {
     "CNAME": "panchapizarro.github.io"

--- a/domains/vpizarrotraslados.json
+++ b/domains/vpizarrotraslados.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "PanchaPizarro",
+    "email": "PanchaPizarro@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "panchapizarro.github.io"
+  }
+}


### PR DESCRIPTION
Registering `vpizarrotraslados.is-a.dev` with a CNAME record pointing to my GitHub Pages site.

**Website preview (live):** https://panchapizarro.github.io/traslados-v-region/
**Target:** panchapizarro.github.io

This is a personal airport-transfer service website. Thanks for your work maintaining this! 🙏