### PR TITLE
add nilshogberg.is-a.dev

### DIFF
--- a/domains/nilshogberg.json
+++ b/domains/nilshogberg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Nimaho71",
+        "email": "nils.oi.hogberg@gmail.com"
+    },
+    "record": {
+        "CNAME": "nilshogberg.vercel.app"
+    }
+}


### PR DESCRIPTION
## Domain registration

**Domain:** `nilshogberg.is-a.dev`
**Target:** `nilshogberg.vercel.app` (CNAME)
**GitHub:** https://github.com/Nimaho71

Personal portfolio for Nils Hogberg — software engineer & security researcher.