### PR TITLE
feat: add Vercel TXT verification records and www subdomain for varundasharadhi

### DIFF
--- a/domains/_vercel.varundasharadhi.json
+++ b/domains/_vercel.varundasharadhi.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+          "username": "VarunDasharadhi",
+          "email": "developerworld.net@gmail.com"
+    },
+    "records": {
+          "TXT": [
+                  "vc-domain-verify=varundasharadhi.is-a.dev,f3679b03fd94820a1f57",
+                  "vc-domain-verify=www.varundasharadhi.is-a.dev,089e0d86842b1d0b801b"
+          ]
+    }
+}

--- a/domains/www.varundasharadhi.json
+++ b/domains/www.varundasharadhi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+          "username": "VarunDasharadhi",
+          "email": "developerworld.net@gmail.com"
+    },
+    "records": {
+          "CNAME": "62ffeadbf82ef8f9.vercel-dns-017.com"
+    }
+}


### PR DESCRIPTION
# Requirements
- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is software development related.
- [x] My website is **not** for commercial use.
- [x] I have provided contact information in the `owner` key.

## What does this PR do?

Adds two new files to complete Vercel domain verification for `varundasharadhi.is-a.dev`:

1. `_vercel.varundasharadhi.json` — TXT records for Vercel domain ownership verification for both `varundasharadhi.is-a.dev` and `www.varundasharadhi.is-a.dev`.
2. `www.varundasharadhi.json` — CNAME record pointing `www.varundasharadhi.is-a.dev` to Vercel.

This follows the [Vercel guide](https://docs.is-a.dev/guides/vercel/) as recommended by maintainer after merging PR #40199.