### PR TITLE
fix: update vanguard CNAME to correct cloudflared tunnel

### DIFF
--- a/domains/vanguard.json
+++ b/domains/vanguard.json
@@ -4,6 +4,6 @@
     "email": "zhanghongwei7703@gmail.com"
   },
   "record": {
-    "CNAME": "b6203ebf-2c01-4df3-9713-f042c40f2522.cfargotunnel.com"
+    "CNAME": "e6d563e3-6d5e-4fd3-bd3e-7c96623b1018.cfargotunnel.com"
   }
 }

--- a/domains/vanguard.json
+++ b/domains/vanguard.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "kxr722",
+    "email": "zhanghongwei7703@gmail.com"
+  },
+  "record": {
+    "CNAME": "b6203ebf-2c01-4df3-9713-f042c40f2522.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
Updated CNAME record for vanguard.is-a.dev from old tunnel `b6203ebf-2c01-4df3-9713-f042c40f2522.cfargotunnel.com` to current tunnel `e6d563e3-6d5e-4fd3-bd3e-7c96623b1018.cfargotunnel.com`. The old tunnel no longer exists.