### PR TITLE
Register offcampusradar.is-a.dev

### DIFF
--- a/domains/offcampusradar.json
+++ b/domains/offcampusradar.json
@@ -1,0 +1,9 @@
+{
+    "records":  {
+                    "CNAME":  "manish8941.github.io"
+                },
+    "owner":  {
+                  "email":  "my1456243@gmail.com",
+                  "username":  "manish8941"
+              }
+}


### PR DESCRIPTION
Register offcampusradar.is-a.dev for the OffCampus Radar hiring alerts website hosted on GitHub Pages: https://manish8941.github.io/offcampus-radar/