### PR TITLE
Register sellermargin.is-a.dev

### DIFF
--- a/domains/sellermargin.json
+++ b/domains/sellermargin.json
@@ -1,0 +1,9 @@
+﻿{
+  "owner": {
+    "username": "leejigu96-stack",
+    "email": "278004847+leejigu96-stack@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "seller-margin-tool.pages.dev"
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] I have read and followed the is-a.dev documentation.
- [x] The domain points to a Cloudflare Pages project owned by me.

## Domain

sellermargin.is-a.dev

## Target

seller-margin-tool.pages.dev

This is for a free seller margin calculator web tool.