### PR TITLE
Register sellerdog.is-a.dev

### DIFF
--- a/domains/sellerdog.json
+++ b/domains/sellerdog.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "leejigu96-stack",
+    "email": "hijginfo@proton.me"
+  },
+  "records": {
+    "CNAME": "seller-margin-tool.pages.dev"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Adds sellerdog.is-a.dev for the Sellerdog seller tool site.\n\nTarget: seller-margin-tool.pages.dev\nOwner email: hijginfo@proton.me