### PR TITLE
Register ua95.is-a.dev

### DIFF
--- a/domains/ua95.json
+++ b/domains/ua95.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "kingdrowjin",
+    "email": "lilxdrow007@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `ua95.is-a.dev` for UA-95 — a software systems integrator project site (Vite + React) hosted on Vercel.

- **Record:** CNAME → cname.vercel-dns.com
- **Site:** https://ua-95.vercel.app
- File: `domains/ua95.json`

Thanks!