### PR TITLE
Register djagla.is-a.dev

### DIFF
--- a/domains/_vercel.djagla.json
+++ b/domains/_vercel.djagla.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "djagla",
+        "email": "jagla.daniel@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=djagla.is-a.dev,d7d60b199b7e97b2a2cf"
+    }
+}

--- a/domains/djagla.json
+++ b/domains/djagla.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "djagla",
+        "email": "jagla.daniel@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Registering djagla.is-a.dev for my personal projects, currently a portfolio dashboard hosted on Vercel (CNAME to cname.vercel-dns.com).

- [x] I have read and agree to the [Terms of Service](https://is-a.dev/terms)
- [x] The file is placed in the domains directory and follows the documented JSON structure