### PR TITLE
Register usa26.is-a.dev

### DIFF
--- a/domains/usa26.json
+++ b/domains/usa26.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "m4nur0ssi",
+    "email": "m4nu.r0ssi@gmail.com"
+  },
+  "records": {
+    "CNAME": "m4nur0ssi.github.io"
+  }
+}


### PR DESCRIPTION
Adding usa26.is-a.dev -> m4nur0ssi.github.io (GitHub Pages). Personal World Cup 2026 web app.