### PR TITLE
Register autobrand.is-a.dev

### DIFF
--- a/domains/autobrand.json
+++ b/domains/autobrand.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "DevScaryCat",
+    "email": "devscarycat@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/autobrand.json
+++ b/domains/autobrand.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "DevScaryCat",
-    "email": "devscarycat@users.noreply.github.com"
+    "email": "devscarycat@icloud.com"
   },
   "records": {
     "CNAME": "cname.vercel-dns.com"


### PR DESCRIPTION
Adding `autobrand.is-a.dev` — download/landing page for AutoBrand Connect (a desktop app). CNAME points to Vercel (cname.vercel-dns.com). Thanks!