### PR TITLE
Update zxyandreay.is-a.dev DNS records for Vercel

### DIFF
--- a/domains/_vercel.zxyandreay.json
+++ b/domains/_vercel.zxyandreay.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "zxyandreay",
+        "email": "zxyandreay@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=zxyandreay.is-a.dev,cd7155767379427cc4e3"
+    }
+}

--- a/domains/zxyandreay.json
+++ b/domains/zxyandreay.json
@@ -4,6 +4,6 @@
         "email": "zxyandreay@gmail.com"
     },
     "records": {
-        "CNAME": "zxyandreay.github.io"
+        "A": ["216.198.79.1"]
     }
 }


### PR DESCRIPTION
# Requirements

* [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
* [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
* [x] My website is **reachable** and **completed**.
* [x] My website is **software development** related.
* [x] My website is **not for commercial use**.
* [x] I have provided contact information in the `owner` key.
* [x] I have provided a preview of my website below.

# Website Preview

Website link:
https://zxyandreay.is-a.dev/

Vercel preview link:
https://zxyandreayis-adev.vercel.app

Screenshot:

<img width="1351" height="768" alt="image" src="https://github.com/user-attachments/assets/6d7d3bd6-6943-4c44-ab57-ae8e447167dc" />


# Website Purpose

This website is my personal developer portfolio. It showcases my software development projects, product-building work, UI/UX process, and technical background.

The purpose of the website is to present my work, document my projects, and provide a central place for people to learn more about what I build as a developer. It is not used as an ecommerce website, paid service platform, or commercial storefront.

This updates my personal developer portfolio domain from GitHub Pages to Vercel.

The main `domains/zxyandreay.json` record now points to Vercel, and the `domains/_vercel.zxyandreay.json` TXT record is added for Vercel domain verification.