### PR TITLE
feat: add threat.is-a.dev domain

### DIFF
--- a/domains/threat.json
+++ b/domains/threat.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "xkbm",
+    "email": "matteo10082010@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain

- **Domain:** `threat.is-a.dev`
- **Owner GitHub:** xkbm
- **DNS Record:** CNAME → `cname.vercel-dns.com` (Vercel hosting)

Deployed via Vercel (threat-bot-discord project).