### PR TITLE
Add alfan-januar.is-a.dev

### DIFF
--- a/domains/alfan-januar.json
+++ b/domains/alfan-januar.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Arsenfa",
+    "email": "alfanjanuar50@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Add alfan-januar.json

- Domain: alfan-januar.is-a.dev
- Target: cname.vercel-dns.com (Vercel-hosted portfolio)
- Owner: Arsenfa (alfanjanuar50@gmail.com)

Closes the earlier attempt on alfanjanuar (subdomain already taken).

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://alfanjanuar-portfolio.vercel.app

![Portfolio Preview](https://github.com/user-attachments/assets/e3e642b0-fde3-4652-a50e-e7c0370ab58b)

# Website Purpose

Personal developer portfolio showcasing my work as a Frontend & Mobile Developer. The site features real enterprise projects built during my internship at PT Akur Pratama (Yogya Center) — including a Warehouse Management System and a Self-Checkout application — alongside personal projects such as an HTML5 Canvas game, a Telegram AI bot, and Linux desktop customization. The portfolio is entirely non-commercial and serves solely to demonstrate my technical skills and project experience to potential employers and collaborators.
