### PR TITLE
Update divyansh.is-a.dev: Add Vercel TXT Verification Record

### DIFF
--- a/domains/_vercel.divyansh.json
+++ b/domains/_vercel.divyansh.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "DsThakurRawat",
+    "email": "divyanshrawatofficial@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=divyansh.is-a.dev,757ld9fbda5a64b6d060",
+      "vc-domain-verify=www.divyansh.is-a.dev,30823c57a54e02ceef2e"
+    ]
+  }
+}


### PR DESCRIPTION
Adding TXT records at _vercel.divyansh.is-a.dev required by Vercel to verify domain ownership for my portfolio deployment. This step is necessary to resolve a conflict where the domain was previously linked to another Vercel account, allowing me to successfully deploy my site.