### PR TITLE
Add _vercel.alfan-januar.is-a.dev TXT record for Vercel verification

### DIFF
--- a/domains/_vercel.alfan-januar.json
+++ b/domains/_vercel.alfan-januar.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Arsenfa",
+    "email": "arsenfaa@gmail.com"
+  },
+  "records": {
+    "TXT": ["vc-domain-verify=alfan-januar.is-a.dev,676561f435ca016e0a5f"]
+  }
+}


### PR DESCRIPTION
Adding TXT record for Vercel domain ownership verification of `alfan-januar.is-a.dev`.

- **File:** `domains/_vercel.alfan-januar.json`
- **Verification value:** `vc-domain-verify=alfan-januar.is-a.dev,676561f435ca016e0a5f`

This is required by Vercel to confirm domain ownership before the custom domain can be connected.

Thank you!