### PR TITLE
Register edudesign.is-a.dev

### DIFF
--- a/domains/edudesign.json
+++ b/domains/edudesign.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "ralitabi"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
## Domain
`edudesign.is-a.dev`

## Purpose
Personal/educational project site (EduDesign UK — student academic, CV, coding and design help), hosted on Vercel.

## Records
- `CNAME` -> `cname.vercel-dns.com`

I have read and agree to the Terms of Service.