### PR TITLE
Add Discord verification for arx.is-a.dev

### DIFF
--- a/domains/_discord.arx.json
+++ b/domains/_discord.arx.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "arturious",
+    "email": "arturbakhtygereyev@gmail.com"
+  },
+  "records": {
+    "TXT": "dh=de804751f7e40ba5e586ad602b257b40879f285d"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Website: [https://arx.is-a.dev/](https://arx.is-a.dev/)

![Preview of the arx personal website](https://raw.githubusercontent.com/arturious/arx/preview-assets/website-preview.png)

# Website Purpose

Add the Discord TXT verification record for the existing arx.is-a.dev personal software development portfolio domain.
