### PR TITLE
Register dubai-project.is-a.dev

### DIFF
--- a/domains/dubai-project.json
+++ b/domains/dubai-project.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ayaninkibay",
+        "email": "a.inkibay@gmail.com"
+    },
+    "records": {
+        "CNAME": "ayaninkibay.github.io"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live: https://ayaninkibay.github.io/dubai-project/

![Dubai Project screenshot](https://raw.githubusercontent.com/ayaninkibay/dubai-project/main/screenshot.png)

# Website Purpose

Dubai Project is a free, open-source tournament bracket manager I built and maintain (source: https://github.com/ayaninkibay/dubai-project). It is a single-page web app: single/double elimination and group stages, drag-and-drop player management, realtime spectator/judge sync via Supabase, PNG bracket export and a projector mode. Non-commercial, no ads, no accounts.

The CNAME points to `ayaninkibay.github.io`; the GitHub Pages custom domain will be set to `dubai-project.is-a.dev` right after this PR is merged.