### PR TITLE
feat: register openterraria.is-a.dev

### DIFF
--- a/domains/openterraria.json
+++ b/domains/openterraria.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "tr1v1a"
+    },
+    "records": {
+        "CNAME": "5104d257-ed34-4eae-90f4-3cefe401a77e.cfargotunnel.com"
+    },
+    "proxied": true
+}


### PR DESCRIPTION
- [x] I am registering as a new user
- [x] I have read the [terms](https://is-a.dev/terms)
- [x] The website is somewhat complete
- [x] The website is a non-commercial project

### Website
https://openterraria.vercel.app

### Description
OpenTerraria is a fan-made Terraria trivia project with a searchable database of questions and answers. The backend API is hosted via Cloudflare Tunnel and the frontend is on Vercel.

### Screenshot
A Terraria trivia application with a search interface and random question generator.

### Domain
- `openterraria.is-a.dev` → Cloudflare Tunnel (CNAME to cfargotunnel.com)