### PR TITLE
Add dbt-state-oss.is-a.dev

### DIFF
--- a/domains/dbt-state-oss.json
+++ b/domains/dbt-state-oss.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "sudo-pradip",
+    "email": "pradipsudo@gmail.com"
+  },
+  "records": {
+    "CNAME": "sudo-pradip.github.io"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://sudo-pradip.github.io/dbt-state-oss/

<img width="1837" height="484" alt="image" src="https://github.com/user-attachments/assets/672bbc72-e3a4-432e-a5c6-7e1d61e5ad2b" />

# Website Purpose
Documentation and landing page for **dbt-state-oss**, an open-source, Apache-2.0, self-hosted decision server for the dbt-state client. It lets dbt skip redundant model runs and defer to prod with run-state kept in your own storage, instead of a metered hosted service. Non-commercial / free open-source.
