### PR TITLE
Add depth1cnx.json for Jira Worklog Tracker

### DIFF
--- a/domains/depth1cnx.json
+++ b/domains/depth1cnx.json
@@ -5,7 +5,7 @@
     "username": "nattapon8875",
     "email": "nattapon.abza@gmail.com"
   },
-  "record": {
+  "records": {
     "A": ["157.230.41.213"]
   }
 }

--- a/domains/depth1cnx.json
+++ b/domains/depth1cnx.json
@@ -1,0 +1,11 @@
+{
+  "description": "Jira Worklog Tracker",
+  "repo": "https://github.com/nattapon8875/-is-a-dev-register",
+  "owner": {
+    "username": "nattapon8875",
+    "email": "nattapon.abza@gmail.com"
+  },
+  "record": {
+    "A": ["157.230.41.213"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

http://157.230.41.213:8050

# Website Purpose

Personal Jira worklog tracker for monitoring time spent on development tasks by project and tag.