### PR TITLE
Register moabom.is-a.dev

### DIFF
--- a/domains/moabom.json
+++ b/domains/moabom.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "uuuhyun",
+    "email": "moabom.official@gmail.com"
+  },
+  "records": {
+    "CNAME": "ca-moabom.ambitioushill-953af2e9.koreacentral.azurecontainerapps.io"
+  }
+}


### PR DESCRIPTION
This PR registers `moabom.is-a.dev`.

- **Record**: CNAME → ca-moabom.ambitioushill-953af2e9.koreacentral.azurecontainerapps.io
- **Purpose**: Moabom — a YouTube tech-review aggregation web service (university capstone project), deployed on Azure Container Apps.

I have read and agree to the Terms of Service.
