### PR TITLE
Add fruit-farm.is-a.dev

### DIFF
--- a/domains/asuid.fruit-farm.json
+++ b/domains/asuid.fruit-farm.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "centGeek"
+  },
+  "records": {
+    "TXT": "83E8DF6A874E271D812F7813F9E320DEE0B069D6B4F4F7DFB059FC323ED865AD"
+  }
+}

--- a/domains/fruit-farm.json
+++ b/domains/fruit-farm.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "centGeek"
+  },
+  "records": {
+    "CNAME": "ca-frontend.jollybay-34cbe6d0.polandcentral.azurecontainerapps.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Description

Registering `fruit-farm.is-a.dev` for a fruit-orchard management web app hosted on **Azure Container Apps**.

- `domains/fruit-farm.json` — `CNAME` to the app's Azure Container Apps hostname (`proxied: false` so the managed TLS certificate can be issued — Azure rejects domains behind a Cloudflare proxy).
- `domains/asuid.fruit-farm.json` — a `TXT` record (`asuid.`) required by Azure to verify domain ownership before binding the managed certificate.

Both records are needed together for Azure Container Apps custom-domain + free managed certificate setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)