### PR TITLE
Add travel-expense.is-a.dev

### DIFF
--- a/domains/_dmarc.travel-expense.json
+++ b/domains/_dmarc.travel-expense.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jd92-beep",
+    "email": "ftjdfr@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/resend._domainkey.travel-expense.json
+++ b/domains/resend._domainkey.travel-expense.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jd92-beep",
+    "email": "ftjdfr@gmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAixvEENnyiBBe1q/yARdZsXycMctGX18o+bmNJvDVH8jPS/JpK2w9TnKjF4HE8IQdnCWbtcoYIrqhHwxMa2ZcIM8YCKlmgBAobW9WGtAt2Tnro3ut4V9oYRxm1THmUiXqMZHdI+pz5/FohHffttBlPlRmtnET3z3le8xSbWtHVwIDAQAB"
+  }
+}

--- a/domains/send.travel-expense.json
+++ b/domains/send.travel-expense.json
@@ -1,0 +1,15 @@
+{
+  "owner": {
+    "username": "jd92-beep",
+    "email": "ftjdfr@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.us-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}

--- a/domains/travel-expense.json
+++ b/domains/travel-expense.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jd92-beep",
+    "email": "ftjdfr@gmail.com"
+  },
+  "records": {
+    "URL": "https://travel-expense-react.vercel.app"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live app: https://travel-expense-react.vercel.app

![Travel Expense app preview](https://image.thum.io/get/width/1200/crop/800/noanimate/https://travel-expense-react.vercel.app)

# Website Purpose

`travel-expense.is-a.dev` redirects to a completed Travel Expense web app. The nested DNS records under this subdomain are used to verify the app's Resend sender domain for secure transactional app notifications.
