### PR TITLE
Register neonpong.is-a.dev

### DIFF
--- a/domains/neonpong.json
+++ b/domains/neonpong.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "samuelbanapour",
+        "email": "gamesolodev26@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Registering **neonpong.is-a.dev** for my browser game **Neon Pong** — an HTML5 Pong remake with single-player, local 2-player, and online multiplayer — hosted on Vercel.

- **Record:** `CNAME` → `cname.vercel-dns.com`
- **Live now at:** https://play-neon-pong.vercel.app

Thanks for maintaining is-a.dev! 🙏