### PR TITLE
Update Vercel verification token for shivank-bhardwaj.is-a.dev

### DIFF
--- a/domains/_vercel.shivank-bhardwaj.json
+++ b/domains/_vercel.shivank-bhardwaj.json
@@ -4,6 +4,6 @@
     "email": "theshivankbhardwaj@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=shivank-bhardwaj.is-a.dev,903e087e4df026c6a03f"
+    "TXT": "vc-domain-verify=shivank-bhardwaj.is-a.dev,f0ef5f1f135256c269e0"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live site (HTTPS, fully reachable):** https://shivank-bhardwaj.vercel.app

# Website Purpose

Updating only the `_vercel` ownership-verification TXT value for my already-registered `shivank-bhardwaj.is-a.dev` (Vercel re-issued the token). It's my personal, non-commercial software-engineering portfolio. No other records changed.