### PR TITLE
feat: register dxti.is-a.dev

### DIFF
--- a/domains/dxti.json
+++ b/domains/dxti.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"mel0way"},"record":{"CNAME":"mel0way.github.io"}}

--- a/domains/dxti.json
+++ b/domains/dxti.json
@@ -1,1 +1,9 @@
-{"owner":{"username":"mel0way"},"record":{"CNAME":"mel0way.github.io"}}
+{
+  "owner": {
+    "username": "mel0way",
+    "email": "xingyuchen052@gmail.com"
+  },
+  "records": {
+    "CNAME": "mel0way.github.io"
+  }
+}


### PR DESCRIPTION
## Description
Register `dxti.is-a.dev` for the DXTI (大学TI) project.

## Domain
- **Subdomain**: dxti.is-a.dev
- **CNAME**: mel0way.github.io

## Project
DXTI is a university personality test (MBTI-style) for Chinese students.
GitHub: https://github.com/mel0way/dxti