### PR TITLE
Add pravatadhikari.is-a.dev

### DIFF
--- a/domains/pravatadhikari.json
+++ b/domains/pravatadhikari.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "adhocpra",
+    "email": "adhikaripravat19@gmail.com"
+  },
+  "description": "Pravat Adhikari — Data Analyst & CS Student portfolio",
+  "repo": "https://github.com/adhocpra/adhocpra.github.io",
+  "records": {
+    "CNAME": "adhocpra.github.io"
+  }
+}


### PR DESCRIPTION
## Description

Requesting `pravatadhikari.is-a.dev` for my developer portfolio.

## Details

- **Subdomain:** `pravatadhikari.is-a.dev`
- **GitHub username:** adhocpra
- **Target:** GitHub Pages at `adhocpra.github.io`
- **Use:** Personal portfolio — data analyst & CS student

## Checklist

- [x] I have read the contributing guidelines
- [x] I have a legitimate use for this subdomain
- [x] The CNAME target is confirmed working