### PR TITLE
add offline-3d-layout-planner.is-a.dev

### DIFF
--- a/domains/offline-3d-layout-planner.json
+++ b/domains/offline-3d-layout-planner.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "nekosemaru",
+    "email": "e1514217@gmail.com"
+  },
+  "records": {
+    "CNAME": "nekosemaru.github.io"
+  }
+}


### PR DESCRIPTION
## Description

Registering `offline-3d-layout-planner.is-a.dev` for my GitHub Pages project.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md)
- [x] I have checked that the subdomain is not already taken
- [x] The subdomain is not offensive or inappropriate
- [x] The domain file is correctly formatted

## Additional Information

- **Project**: Offline 3D Layout Planner — a browser-based 3D room layout editor (no external APIs/DB)
- **GitHub Pages URL**: https://nekosemaru.github.io/offline-3d-layout-planner/
- **Repository**: https://github.com/nekosemaru/offline-3d-layout-planner