### PR TITLE
Add pubgarena.is-a.dev domain

### DIFF
--- a/domains/p/pubgarena.json
+++ b/domains/p/pubgarena.json
@@ -1,0 +1,1 @@
+{"record":{"CNAME":"pubg-tournament-seven.vercel.app"},"owner":{"username":"muhammadmoazam630-a11y"}}


### PR DESCRIPTION
Adding pubgarena.is-a.dev subdomain for my PUBG esports tournament platform hosted on Vercel.