### PR TITLE
feat: add inbox-cleaner.is-a.dev

### DIFF
--- a/domains/inbox-cleaner.json
+++ b/domains/inbox-cleaner.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "iampushpendra",
+    "email": "pushpendra.singh@freed.care"
+  },
+  "records": {
+    "CNAME": "iampushpendra.github.io"
+  }
+}


### PR DESCRIPTION
## What

Registering `inbox-cleaner.is-a.dev` → `iampushpendra.github.io`

## About the project

Inbox Cleaner is an open-source web app that scans Gmail across all 5 categories, shows senders ranked by email count with category badges and timestamps, and lets users move all emails from selected senders to Trash with one click.

- GitHub: https://github.com/iampushpendra/inbox-cleaner
- Live: https://iampushpendra.github.io/inbox-cleaner/
- Vanilla JS, zero dependencies, no backend