### PR TITLE
domain: register agentic-os.is-a.dev

### DIFF
--- a/domains/agentic-os.json
+++ b/domains/agentic-os.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "AlexKingstonvlr"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering **agentic-os.is-a.dev** for the Agentic OS project — an open-source multi-agent dashboard.

CNAME → cname.vercel-dns.com (Vercel hosting).