### PR TITLE
Update sethplanco.is-a.dev A record to Vercel

### DIFF
--- a/domains/sethplanco.json
+++ b/domains/sethplanco.json
@@ -1,9 +1,9 @@
 {
-  "owner": {
-    "username": "sethski",
-    "email": "sethbplanco@gmail.com"
+  ""owner"": {
+    ""username"": ""sethski"",
+    ""email"": ""sethbplanco@gmail.com""
   },
-  "records": {
-    "A": ["216.198.79.1"]
+  ""records"": {
+    ""A"": [""76.76.21.21""]
   }
 }

--- a/domains/sethplanco.json
+++ b/domains/sethplanco.json
@@ -1,9 +1,11 @@
 {
-  ""owner"": {
-    ""username"": ""sethski"",
-    ""email"": ""sethbplanco@gmail.com""
+  "records": {
+    "A": [
+      "76.76.21.21"
+    ]
   },
-  ""records"": {
-    ""A"": [""76.76.21.21""]
+  "owner": {
+    "email": "sethbplanco@gmail.com",
+    "username": "sethski"
   }
 }


### PR DESCRIPTION
This updates domains/sethplanco.json to point the apex record at Vercel (76.76.21.21) instead of the stale 216.198.79.1 target. The existing _vercel.sethplanco TXT verification record is unchanged.