### PR TITLE
Various updates to avery.is-a.dev and kay.is-a.dev

### DIFF
--- a/domains/_discord.avery.json
+++ b/domains/_discord.avery.json
@@ -4,6 +4,6 @@
     "email": "thekayaurora@gmail.com"
   },
   "records": {
-    "TXT": "dh=1689cf0ea1d42896eb051eb9e15a570760796eee"
+    "TXT": "dh=74298aacaeec580c21c7383d83dd6bf9600b9037"
   }
 }

--- a/domains/kay.json
+++ b/domains/kay.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "AveryEclipse",
-    "email": "thekayaurora@gmail.com"
-  },
-  "records": {
-    "URL": "https://avery.is-a.dev"
-  }
-}

--- a/domains/tweets.avery.json
+++ b/domains/tweets.avery.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "AveryEclipse",
-    "email": "thekayaurora@gmail.com"
-  },
-  "records": {
-    "CNAME": "averyeclipse.github.io"
-  }
-}

--- a/domains/tweets.kay.json
+++ b/domains/tweets.kay.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "AveryEclipse",
-    "email": "thekayaurora@gmail.com"
-  },
-  "records": {
-    "URL": "https://tweets.avery.is-a.dev"
-  }
-}


### PR DESCRIPTION
This PR changes the Discord TXT record for avery.is-a.dev, removes the nested subdomains tweets.avery.is-a.dev and tweets.kay.is-a.dev, and removes the redirect from kay.is-a.dev to avery.is-a.dev (making the former available again)