### PR TITLE
Add pravatadhikari.is-a.dev

### DIFF
--- a/domains/pravatadhikari.json
+++ b/domains/pravatadhikari.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "adhocpra",
+    "email": "adhikaripravat19@gmail.com"
+  },
+  "description": "Pravat Adhikari — Data Analyst & CS Student portfolio",
+  "repo": "https://github.com/adhocpra/adhocpra.github.io",
+  "records": {
+    "CNAME": "adhocpra.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This is a fully built static HTML/CSS portfolio hosted on GitHub Pages. The CNAME is currently configured for `pravatadhikari.is-a.dev`, so `adhocpra.github.io` redirects to the pending custom domain — the site will be fully accessible once this PR is merged and DNS propagates.

- Source repository: https://github.com/adhocpra/adhocpra.github.io
- GitHub Pages URL: https://adhocpra.github.io (currently redirects to the custom domain pending this PR)

The site includes sections for: About, Projects (data analytics / Python), Skills, and a Resume PDF download. It is a complete, non-template portfolio built with semantic HTML and CSS.

# Website Purpose

Personal portfolio website for Pravat Adhikari, a CS graduate and aspiring Data Scientist. The site showcases software development projects, data analytics work, and Python development skills — and is strictly non-commercial.