### PR TITLE
add modforge.is-a.dev

### DIFF
--- a/domains/modforge.json
+++ b/domains/modforge.json
@@ -1,0 +1,27 @@
+{
+  "owner": {
+    "username": "zygimantas802",
+    "email": "remigijus.kilas@gmail.com"
+  },
+  "record": {
+    "A": ["76.76.21.21"]
+  },
+  "subdomains": {
+    "resend._domainkey": {
+      "record": {
+        "TXT": ["p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCeR0UhuflplnUz4CVqTyPZLkFyB+8cDlJsdkk6UrIegcoUfZryOQGCa7u8oqsQX2XI+b8/KTDaPxD/F/X0Rl6IC4Jx1vuHNcSrLchH4QeobqHp+4YhR071iGIWNMABrLdzRGxICj6bRuAKnuQ+f3aoxh1umWDUUKOIzifaAWvS0wIDAQAB"]
+      }
+    },
+    "send": {
+      "record": {
+        "MX": [{ "priority": 10, "value": "feedback-smtp.us-east-1.amazonses.com" }],
+        "TXT": ["v=spf1 include:amazonses.com ~all"]
+      }
+    },
+    "_dmarc": {
+      "record": {
+        "TXT": ["v=DMARC1; p=none;"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding modforge.is-a.dev for ModForge, a custom Minecraft mod commission website.

Includes email DNS records for Resend (DKIM, SPF, DMARC) so transactional 
order confirmation emails work.

Note: the `resend._domainkey` subdomain key contains a dot — please let me know 
if this needs to be handled differently.