### PR TITLE
Register bobot.is-a.dev

### DIFF
--- a/domains/bobot.json
+++ b/domains/bobot.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "clawbobot",
+    "email": "jade.treer@gmail.com"
+  },
+  "records": {
+    "CNAME": "clawbobot.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live website: https://clawbobot.github.io

![Bob Pan software developer portfolio](https://clawbobot.github.io/assets/site-preview.jpg)

The site is now a personal software development portfolio for Bob Pan (`clawbobot`). It highlights the open-source Code Puppy CN project, the public source repository, development focus, and contact information. This addresses the software-development portfolio requirement noted on the earlier request.