### PR TITLE
Update tsu.is-a.dev owner and redirect to tsu.ar

### DIFF
--- a/domains/tsu.json
+++ b/domains/tsu.json
@@ -1,9 +1,9 @@
 {
   "owner": {
-    "username": "dot-tsu",
+    "username": "tsu-ld",
     "email": "lucanahtsu@gmail.com"
   },
   "records": {
-    "CNAME": "dot-tsu.github.io"
+    "URL": "https://tsu.ar"
   }
 }


### PR DESCRIPTION
Updating owner username from dot-tsu to tsu-ld (new GitHub username) and changing records to URL redirect to https://tsu.ar.

the subdomain is currently hijacked by a casino (thanks @ok-coder1 for letting me know)