### PR TITLE
feat: register booktoskill.is-a.dev

### DIFF
--- a/domains/booktoskill.json
+++ b/domains/booktoskill.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "virgiliojr94",
+        "email": "virgilio.junior94@gmail.com"
+    },
+    "records": {
+        "CNAME": "virgiliojr94.github.io"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://virgiliojr94.github.io/book-to-skill/ (will be served at `booktoskill.is-a.dev` once this PR merges).

<!-- SCREENSHOT: a imagem precisa ser anexada manualmente (arrastar pro PR). -->

# Website Purpose

Documentation site for **book-to-skill**, an open-source (MIT) developer tool that converts books and documents into structured, on-demand agent skills for Claude Code, GitHub Copilot CLI, and Amp. The site documents the architecture, performance, and the skill specification. It is a non-commercial open-source project. Repo: https://github.com/virgiliojr94/book-to-skill

## Record
`domains/booktoskill.json` → `CNAME` → `virgiliojr94.github.io`
