### PR TITLE
Update patrickleehua.json: point CNAME to GitHub Pages

### DIFF
--- a/domains/patrickleehua.json
+++ b/domains/patrickleehua.json
@@ -3,6 +3,6 @@
     "username": "patrickleehua"
   },
   "records": {
-    "CNAME": "personal-cv-site-bv3.pages.dev"
+    "CNAME": "patrickleehua.github.io"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live: https://patrickleehua.github.io/personal-cv-site/

<img width="1038" height="703" alt="patrickleehua.is-a.dev preview" src="https://github.com/user-attachments/assets/8c231c8d-966f-4106-8811-f546b22627ab" />

# Website Purpose

This is my personal developer portfolio / CV website (bilingual zh/en) showing my software engineering background, projects and resume.

This PR only updates my existing `patrickleehua.is-a.dev` record: it changes the CNAME target from Cloudflare Pages (`personal-cv-site-bv3.pages.dev`) to GitHub Pages (`patrickleehua.github.io`), because Cloudflare Pages no longer supports is-a.dev custom domains (cross-account CNAME, error 1044). No new subdomain is being registered.
