### PR TITLE
Delegate bobot.is-a.dev to Cloudflare

### DIFF
--- a/domains/bobot.json
+++ b/domains/bobot.json
@@ -4,6 +4,9 @@
     "email": "jade.treer@gmail.com"
   },
   "records": {
-    "CNAME": "clawbobot.github.io"
+    "NS": [
+      "leah.ns.cloudflare.com",
+      "rick.ns.cloudflare.com"
+    ]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] I own and control the Cloudflare zone receiving this delegation.
- [x] The website remains configured at `clawbobot.github.io`.
- [x] The Cloudflare DNS record for the website is prepared before delegation.

# Change

Replace the existing CNAME record with the two nameservers assigned by Cloudflare:

- `leah.ns.cloudflare.com`
- `rick.ns.cloudflare.com`

This delegation is required to keep the GitHub Pages website at `bobot.is-a.dev` while adding Cloudflare Email Routing for `hello@bobot.is-a.dev`.