### PR TITLE
Register statsformulaone.is-a.dev

### DIFF
--- a/domains/statsformulaone.json
+++ b/domains/statsformulaone.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Kirushahahaha"
+  },
+  "records": {
+    "CNAME": "kirushahahaha.github.io"
+  }
+}


### PR DESCRIPTION
Adding statsformulaone.is-a.dev for a Formula 1 statistics dashboard (React app). CNAME -> kirushahahaha.github.io