### PR TITLE
feat: add ulysses.is-a.dev

### DIFF
--- a/domains/ulysses.json
+++ b/domains/ulysses.json
@@ -1,0 +1,23 @@
+{
+  "owner": {
+    "username": "Jasper6439",
+    "email": "adios6406@outlook.com"
+  },
+  "records": {
+    "A": [
+      "170.9.246.92"
+    ],
+    "MX": [
+      "mx1.ord1.oracleemaildelivery.com",
+      "mx2.ord1.oracleemaildelivery.com"
+    ],
+    "TXT": [
+      "v=spf1 include:spf.oracleemaildelivery.com ~all",
+      "v=DMARC1; p=none;"
+    ],
+    "CNAME": {
+      "j59yvS604B0DOMJ7yo0a3zEb9L51iEYQ._domainkey": "j59yvS604B0DOMJ7yo0a3zEb9L51iEYQ.ulysses.is-a.dev.dkim.ord1.oracleemaildelivery.com"
+    }
+  },
+  "proxied": false
+}

--- a/domains/ulysses.json
+++ b/domains/ulysses.json
@@ -14,10 +14,7 @@
     "TXT": [
       "v=spf1 include:spf.oracleemaildelivery.com ~all",
       "v=DMARC1; p=none;"
-    ],
-    "CNAME": {
-      "j59yvS604B0DOMJ7yo0a3zEb9L51iEYQ._domainkey": "j59yvS604B0DOMJ7yo0a3zEb9L51iEYQ.ulysses.is-a.dev.dkim.ord1.oracleemaildelivery.com"
-    }
+    ]
   },
   "proxied": false
 }


### PR DESCRIPTION
Add ulysses.is-a.dev domain for OCI Email Delivery.

## Domain Configuration
```json
{
  "owner": {
    "username": "Jasper6439",
    "email": "adios6406@outlook.com"
  },
  "records": {
    "A": ["170.9.246.92"],
    "MX": ["mx1.ord1.oracleemaildelivery.com", "mx2.ord1.oracleemaildelivery.com"],
    "TXT": [
      "v=spf1 include:spf.oracleemaildelivery.com ~all",
      "v=DMARC1; p=none;"
    ],
    "CNAME": {
      "j59yvS604B0DOMJ7yo0a3zEb9L51iEYQ._domainkey": "j59yvS604B0DOMJ7yo0a3zEb9L51iEYQ.ulysses.is-a.dev.dkim.ord1.oracleemaildelivery.com"
    }
  },
  "proxied": false
}
```

## Purpose
- OCI Email Delivery (3,000 emails/month free)
- Self-hosted services (OpenList, Uptime Kuma, Hermes Agent)