### PR TITLE
Register fazz.is-a.dev

### DIFF
--- a/domains/fazz.json
+++ b/domains/fazz.json
@@ -1,4 +1,8 @@
 {
-  "owner": { "username": "faiznc", "email": "faiznc@gmail.com" },
-  "records": { "URL": "https://github.com/faiznc" }
+  "owner": {
+    "username": "MahmoudHH1"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
 }


### PR DESCRIPTION
Registering `fazz.is-a.dev` for FAZZ — a medical attendance management web app built with Next.js, hosted on Vercel.

- **owner:** MahmoudHH1
- **record:** CNAME -> cname.vercel-dns.com (Vercel)

The domain is already added to the Vercel project, so it will serve over HTTPS as soon as DNS propagates.