### PR TITLE
Register liuchen.is-a.dev

### DIFF
--- a/domains/liuchen.json
+++ b/domains/liuchen.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "trikitkulhilke330-jpg"
+  },
+  "records": {
+    "CNAME": "trikitkulhilke330-jpg.github.io"
+  }
+}


### PR DESCRIPTION
Registering `liuchen.is-a.dev` for my personal portfolio site, hosted on GitHub Pages.

- **Repo:** https://github.com/trikitkulhilke330-jpg/liuchen-portfolio
- **Record:** CNAME → trikitkulhilke330-jpg.github.io
- The site is a real, content-complete personal portfolio.