### PR TITLE
Add _vercel.vigneshwar-lokoji.json for Vercel domain ownership verification

### DIFF
--- a/domains/_vercel.vigneshwar-lokoji.json
+++ b/domains/_vercel.vigneshwar-lokoji.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "vigneshwar-lokoji",
+    "email": "lokojivigneshwar@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=vigneshwar-lokoji.is-a.dev,29b70705d0bc5001fd15"
+  }
+}


### PR DESCRIPTION
This adds a TXT record at `_vercel.vigneshwar-lokoji.is-a.dev` required by Vercel to verify domain ownership for the portfolio project already live at https://portfolio-ebon-one-ym1y3vyrrc.vercel.app

This is a companion to PR #41248 (already merged) which added the main `vigneshwar-lokoji.json` with the CNAME record.