### PR TITLE
Add agora.is-a.dev

### DIFF
--- a/domains/agora.json
+++ b/domains/agora.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Agoraaa203"
+    },
+    "records": {
+        "A": ["209.50.59.182"]
+    },
+    "proxied": true
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview (temporary Cloudflare tunnel to my self-hosted server, will be replaced by `agora.is-a.dev` once this PR is merged):
https://were-temporal-impressed-customise.trycloudflare.com

![preview](https://raw.githubusercontent.com/Agoraaa203/register/assets/agora-portfolio-preview.png)

The landing screen shows "click to enter"; clicking it reveals the full bio/portfolio card (avatar, name, bio, social links, music player).

# Website Purpose

This is my personal developer portfolio / bio page — a small Flask web app I built and self-host on my own VPS. It's a non-commercial personal site (no products, no ads, no revenue). The `A` record points to my server and is proxied through Cloudflare.
