### PR TITLE
Add ddgcfmail0620.is-a.dev

### DIFF
--- a/domains/ddgcfmail0620.json
+++ b/domains/ddgcfmail0620.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "latckong"
+  },
+  "records": {
+    "NS": [
+      "emma.ns.cloudflare.com",
+      "felicity.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
Delegate the subdomain to Cloudflare nameservers for a Cloudflare Email Routing / Cloudflare Temp Email receiving setup. This is a personal software development/testing project and is not for commercial use.

<!-- YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED! -->
# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
<!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
<!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [ ] My website is **reachable** and **completed**.
<!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related.
<!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**.
<!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key.
<!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [ ] I have provided a preview of my website below.
<!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. if not provided your PR will be closed with no questions asked. -->
No website preview is available yet. This request is for NS delegation to Cloudflare so the subdomain can be used as a Cloudflare Email Routing / Cloudflare Temp Email receiving entry. The Cloudflare zone cannot become active until the NS delegation exists.

If NS-only delegation for an email-routing development/test project is outside is-a.dev scope, please close this PR.

# Website Purpose
The purpose of `ddgcfmail0620.is-a.dev` is to provide a personal, non-commercial software development/testing entry for Cloudflare Email Routing and a Cloudflare Temp Email Worker inbox, so forwarded test mail can be received and inspected during development.