### PR TITLE
feat: add proptracker.is-a.dev

### DIFF
--- a/domains/proptracker.json
+++ b/domains/proptracker.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "TradingDevelopment"
+  },
+  "record": {
+    "CNAME": "funded-faves.pages.dev"
+  }
+}


### PR DESCRIPTION
Registering `proptracker.is-a.dev` pointing to `funded-faves.pages.dev` via CNAME.