### PR TITLE
Add rafaelchuco.is-a.dev

### DIFF
--- a/domains/_vercel.rafaelchuco.json
+++ b/domains/_vercel.rafaelchuco.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"rafaelchuco","email":"rafael.chuco1908@gmail.com"},"records":{"TXT":"vc-domain-verify=rafaelchuco.is-a.dev,52e0bc36ffaf9ad80c7e"}}

--- a/domains/rafaelchuco.json
+++ b/domains/rafaelchuco.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"rafaelchuco","email":"rafael.chuco1908@gmail.com"},"records":{"A":["216.198.79.1"]}}


### PR DESCRIPTION
## Requirements
- [x] The website is complete
- [x] Personal/portfolio website
- [x] Non-commercial project
- [x] I have read the terms

## Website Preview
- Live URL: https://rafael-chuco-portfolio.vercel.app/
- Requested subdomain: rafaelchuco.is-a.dev
- DNS target in Vercel: A 216.198.79.1
- Vercel verification TXT added in this PR

## Notes
- This is my personal developer portfolio hosted on Vercel.
- I disabled the www redirect in Vercel as recommended by the docs.
- If needed, I can share any extra verification details from Vercel.