### PR TITLE
Register breachprotocol.gamesolodev.is-a.dev (nested)

### DIFF
--- a/domains/breachprotocol.gamesolodev.json
+++ b/domains/breachprotocol.gamesolodev.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "samuelbanapour",
+    "email": "samuel.banapour100@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related. <!-- This is a NESTED subdomain; per the guidelines only the root must meet this. My root, gamesolodev.is-a.dev, is my solo game-developer hub. -->
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live:** https://breachprotocol.vercel.app

![Breach Protocol preview](https://raw.githubusercontent.com/samuelbanapour/breach-protocol/main/og-image.png)

# Website Purpose

Nested subdomain for my free, open-source browser game **Breach Protocol**, placed under my existing dev root **gamesolodev.is-a.dev** (registered to the same account). A previous root-level request was declined because it's a game — so per the guidelines (games are allowed on nested subdomains; only the root needs to be software-development related) this registers it correctly as a nested subdomain under my game-dev hub.

Record: `CNAME` → `cname.vercel-dns.com` (hosted on Vercel). Source: https://github.com/samuelbanapour/breach-protocol
