### PR TITLE
Register otalist.is-a.dev

### DIFF
--- a/domains/_vercel.otalist.json
+++ b/domains/_vercel.otalist.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Javier2006pj",
+        "email": "javier2006pj@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=otalist.is-a.dev,675d0e4e8bcaed697ea5"
+    }
+}

--- a/domains/otalist.json
+++ b/domains/otalist.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Javier2006pj",
+    "email": "javier2006pj@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `otalist.is-a.dev` for my anime portal **Otalist**.

- Points to Vercel via `CNAME` → `cname.vercel-dns.com`.
- Source: https://github.com/Javier2006pj/Otalist

Thanks!