### PR TITLE
Add Vercel domain configuration for ukasha

### DIFF
--- a/domains/_vercel.ukasha.json
+++ b/domains/_vercel.ukasha.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ProPlexity1",
+    "email": "ukasha636@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=is-a.dev,3d63286e48d9f2cf3194"
+  }
+}


### PR DESCRIPTION
This PR adds the Vercel domain ownership verification TXT record (_vercel.ukasha.json) for ukasha.is-a.dev, which was already approved in a previous PR. No changes to the website itself — purely a verification record needed to connect the domain on Vercel's side.