### PR TITLE
Register phil.is-a.dev

### DIFF
--- a/domains/_vercel.phil.json
+++ b/domains/_vercel.phil.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "GhostEsso",
+    "email": "lilipitaham@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=phil.is-a.dev,4b2f70539a0a4cf47de6"
+  }
+}

--- a/domains/phil.json
+++ b/domains/phil.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "GhostEsso",
+    "email": "lilipitaham@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering phil.is-a.dev for my developer portfolio (Next.js site hosted on Vercel).

- phil.json — CNAME to Vercel
- _vercel.phil.json — TXT for Vercel domain ownership verification