### PR TITLE
add audit-news.is-a.dev

### DIFF
--- a/domains/audit-news.json
+++ b/domains/audit-news.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "gomsei",
+    "email": "gomsei@gmail.com"
+  },
+  "records": {
+    "CNAME": "airy-comfort-production-9059.up.railway.app"
+  }
+}

--- a/domains/audit-news.json
+++ b/domains/audit-news.json
@@ -4,6 +4,6 @@
     "email": "gomsei@gmail.com"
   },
   "records": {
-    "CNAME": "airy-comfort-production-9059.up.railway.app"
+    "CNAME": "rbmsvrn1.up.railway.app"
   }
 }


### PR DESCRIPTION
Adding audit-news.is-a.dev CNAME pointing to Railway deployment for internal audit news briefing service.