### PR TITLE
Add freedooms.is-a.dev

### DIFF
--- a/domains/freedooms.json
+++ b/domains/freedooms.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "dacdoyx",
+    "email": "dacdoyx@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "dacdoyx13-free-dooms.hf.space"
+  }
+}

--- a/domains/freedooms.json
+++ b/domains/freedooms.json
@@ -1,7 +1,6 @@
 {
   "owner": {
-    "username": "dacdoyx",
-    "email": "dacdoyx@users.noreply.github.com"
+    "username": "dacdoyx"
   },
   "records": {
     "CNAME": "dacdoyx13-free-dooms.hf.space"


### PR DESCRIPTION
Subdomain: freedooms.is-a.dev
Target: dacdoyx13-free-dooms.hf.space (CNAME)

Free LLM chat API with multiple model backends.