### PR TITLE
Register signvault.is-a.dev

### DIFF
--- a/domains/signvault.json
+++ b/domains/signvault.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Anas-Lees",
+        "email": "anas.newlees@gmail.com"
+    },
+    "records": {
+        "CNAME": "signvault-q8mi.onrender.com"
+    }
+}


### PR DESCRIPTION
Registering `signvault.is-a.dev` for a personal open-source project (SignVault — a digital signature platform).

- Record: `CNAME` -> `signvault-q8mi.onrender.com` (hosted on Render)
- Repo: https://github.com/Anas-Lees/digital-signature-platform

Thanks!