### PR TITLE
feat: add wc-arena.is-a.dev

### DIFF
--- a/domains/wc-arena.json
+++ b/domains/wc-arena.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Adipati07"
+    },
+    "records": {
+        "CNAME": "parliament-duration-verified-pride.trycloudflare.com"
+    },
+    "proxied": true
+}


### PR DESCRIPTION
## Domain Registration

**Subdomain:** `wc-arena.is-a.dev`

**Purpose:** World Cup 2026 Prediction Arena - A platform for predicting FIFA World Cup 2026 match scores with predictions stored on-chain via Walrus/Sui blockchain.

**Website:** https://parliament-duration-verified-pride.trycloudflare.com

**Preview:**
![WC Prediction Arena](https://parliament-duration-verified-pride.trycloudflare.com)

**Technical Details:**
- TypeScript + Express server
- MemWal SDK for on-chain storage
- Cloudflare Tunnel for public access
- PM2 managed process

**Domain Configuration:**
```json
{
    "owner": {
        "username": "Adipati07"
    },
    "records": {
        "CNAME": "parliament-duration-verified-pride.trycloudflare.com"
    },
    "proxied": true
}
```

**GitHub Repository:** https://github.com/Adipati07/wc-prediction-arena