### PR TITLE
Register abdullahmutlu.is-a.dev

### DIFF
--- a/domains/abdullahmutlu.json
+++ b/domains/abdullahmutlu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "abdullahmutllu",
+    "email": "amutlu540@gmail.com"
+  },
+  "records": {
+    "CNAME": "abdullahmutllu.github.io"
+  }
+}


### PR DESCRIPTION
Registering `abdullahmutlu.is-a.dev` for my personal developer portfolio.

- **Record:** CNAME → `abdullahmutllu.github.io` (GitHub Pages)
- **Use:** personal portfolio site
- The target GitHub Pages site is live and under my control.

Thanks!