### PR TITLE
Add TXT records to riwen.json

### DIFF
--- a/domains/riwen.json
+++ b/domains/riwen.json
@@ -4,6 +4,8 @@
         "email": "comptes@interverti.fr"
     },
     "records": {
-        "URL": "https://interverti.fr"
+        "URL": "https://interverti.fr",
+        "TXT" : "dh=aaa2bd7a605f9364073a095048d2638f66e65e23",
+        "TXT" : "aspe:keyoxide.org:OX5MVJUDC2ZDFBVIYWNXGA37LI"
     }
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://interverti.fr

![preview](https://interverti.fr/preview.png)

# Website Purpose
Personal portfolio website showcasing my work as a Java and TypeScript developer. It presents my technical skills, projects, Minecraft plugin development (Paper/Spigot), and links to related subdomains/projects.

# Why these two txt records
I did an other pull request to add two TXT records, one for Discord connection and one for Keyoxide ASP for having the subdomain on my discord and keyoxide profiles/