### PR TITLE
Register memecoin-academy.is-a.dev

### DIFF
--- a/domains/memecoin-academy.json
+++ b/domains/memecoin-academy.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "WyattSlinde"
+  },
+  "records": {
+    "CNAME": "wyattslinde.github.io"
+  }
+}


### PR DESCRIPTION
## Domain
`memecoin-academy.is-a.dev`

## Purpose
Free, educational website that teaches memecoin trading concepts and how to read a Solana trading terminal. Static site hosted on GitHub Pages.

## Record
CNAME → `wyattslinde.github.io`

Target repo: https://github.com/WyattSlinde/memecoin-academy (live at https://wyattslinde.github.io/memecoin-academy/)

I confirm this domain will be used for legitimate, non-malicious purposes and complies with the Terms of Service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)