### PR TITLE
Register comprarvsalquilar.is-a.dev

### DIFF
--- a/domains/comprarvsalquilar.json
+++ b/domains/comprarvsalquilar.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "JACamposA",
+    "email": "jcamposarbulu@gmail.com"
+  },
+  "records": {
+    "CNAME": "jacamposa.github.io"
+  }
+}


### PR DESCRIPTION
## Description

Registering a free subdomain for my GitHub Pages project: a Monte Carlo simulator comparing buying vs. renting a home in Argentina (UVA mortgage vs. renting + investing).

- Repo: https://github.com/JACamposA/compraVSalquiler
- Target: jacamposa.github.io (custom domain configured in repo Pages settings)