### PR TITLE
feat: add wx.is-a.dev domain with NS records

### DIFF
--- a/domains/wx.json
+++ b/domains/wx.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "lizhixu",
+    "email": "lzx@edu.email.cn"
+  },
+  "records": {
+    "NS": ["harleigh.ns.cloudflare.com", "martin.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview


<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/7783309d-3174-4c01-8ebf-6cd9d117fa60" />

This domain is configured with NS records pointing to Cloudflare nameservers for DNS management.

# Website Purpose

This domain will be used for my personal software development projects and portfolio. The NS records are delegated to Cloudflare (`harleigh.ns.cloudflare.com` and `martin.ns.cloudflare.com`) to manage DNS records for various development services and applications.