### PR TITLE
Register johnperricruz.is-a.dev

### DIFF
--- a/domains/_vercel.johnperricruz.json
+++ b/domains/_vercel.johnperricruz.json
@@ -1,0 +1,4 @@
+  {
+    "owner": { "username": "johnperricruz", "email": "johnperricruz@gmail.com" },
+    "records": { "TXT": "vc-domain-verify=johnperricruz.is-a.dev,3d3ea9455744b0be2acd" }
+  }

--- a/domains/johnperricruz.json
+++ b/domains/johnperricruz.json
@@ -1,0 +1,4 @@
+  {
+    "owner": { "username": "johnperricruz", "email": "johnperricruz@gmail.com" },
+    "records": { "A": ["216.198.79.1"] }
+  }


### PR DESCRIPTION
# Requirements

  - [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
  - [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
  - [x] My website is **reachable** and **completed**.
  - [x] My website is **software development** related.
  - [x] My website is **not for commercial use**.
  - [x] I have provided contact information in the `owner` key.
  - [x] I have provided a preview of my website below.

  # Website Preview

  Live site: https://portfolio-sage-nine-10.vercel.app/

<img width="3010" height="1508" alt="SCR-20260625-nkzp" src="https://github.com/user-attachments/assets/0009524f-f5a0-4b1c-ba98-e2e689b8d967" />


  # Website Purpose

  A personal developer portfolio for John Perri Cruz (Sr. Frontend Developer). It's built as "Bug
  Blaster," an 8-bit arcade shooter you play in the browser; clearing the waves unlocks the portfolio
  screen with my experience, projects, and contact links. Non-commercial — it exists to showcase my
  frontend work.

  Two things before you submit:
  1. Only tick the boxes that are actually true. Don't claim "not for commercial use" if the site
  advertises paid services — but a portfolio is fine, so all boxes apply here.
  2. The live URL right now is your *.vercel.app address (the is-a.dev domain isn't live until this PR
  merges). Use that vercel.app link + a screenshot of it. Reviewers need to see the working site.