### PR TITLE
feat: add zekrom-ss.is-a.dev domain

### DIFF
--- a/domains/zekrom-ss.json
+++ b/domains/zekrom-ss.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "ubaidumer"
+  },
+  "records": {
+    "CNAME": "v62ksigc.up.railway.app"
+  }
+}

--- a/domains/zekrom-ss.json
+++ b/domains/zekrom-ss.json
@@ -1,6 +1,6 @@
 {
   "owner": {
-    "username": "ubaidumer"
+    "username": "mohammadubaidsiddique-a11y"
   },
   "records": {
     "CNAME": "v62ksigc.up.railway.app"

--- a/domains/zekrom-ss.json
+++ b/domains/zekrom-ss.json
@@ -1,8 +1,1 @@
-{
-  "owner": {
-    "username": "mohammadubaidsiddique-a11y"
-  },
-  "records": {
-    "CNAME": "v62ksigc.up.railway.app"
-  }
-}
+{"owner":{"username":"mohammadubaidsiddique-a11y","email":"mohammadubaidsiddique@gmail.com"},"records":{"CNAME":"v62ksigc.up.railway.app"}}


### PR DESCRIPTION
## Domain Registration

Registering **zekrom-ss.is-a.dev** for my project Zekrom-SS, hosted on Railway.

### CNAME
- Target: `v62ksigc.up.railway.app` (Railway-provided)

### Preview
The site is currently live at: https://zekrom-ss-production.up.railway.app

---

### Checklist
- [x] I have read and followed the [domain structure docs](https://docs.is-a.dev/domain-structure/)
- [x] My JSON file follows the correct format
- [x] I have provided a valid preview of my site