### PR TITLE
Register ironlog.is-a.dev

### DIFF
--- a/domains/ironlog.json
+++ b/domains/ironlog.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "aykhan019"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain
`ironlog.is-a.dev`

## What is this for?
A personal strength-training tracker (PWA) hosted on Vercel.

## Record
CNAME -> `cname.vercel-dns.com` (Vercel custom domain).

## Checklist
- [x] I have read and agree to the Terms of Service.
- [x] The `owner.username` matches my GitHub username.
- [x] The record points to a service I control.