### PR TITLE
Register dropxtor.is-a.dev

### DIFF
--- a/domains/dropxtor.json
+++ b/domains/dropxtor.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "dropmoltbot"
+  },
+  "records": {
+    "CNAME": "dropxtor-profile.vercel.app"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
## Subdomain Registration

**Subdomain:** dropxtor.is-a.dev
**CNAME:** dropxtor-profile.vercel.app

### Description
Personal developer portfolio — terminal/CRT style profile page.
Site is live at https://dropxtor-profile.vercel.app/

### Preview
![dropxtor-profile](https://dropxtor-profile.vercel.app/)

### Checklist
- [x] Website is complete and live
- [x] Personal website / portfolio
- [x] Non-commercial
- [x] JSON file follows domain structure guidelines
- [x] Filename is valid (lowercase, alphanumeric)