### PR TITLE
Add Vercel TXT verification for rohitgande.is-a.dev

### DIFF
--- a/domains/_vercel.rohitgande.json
+++ b/domains/_vercel.rohitgande.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "rg-incognito",
+    "email": "rohitgande0705@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=is-a.dev,557585bf22731e32449f"
+  }
+}


### PR DESCRIPTION
## Pull Request Type
- [x] Domain Registration

## Description
Adding the Vercel ownership-verification TXT record for `rohitgande.is-a.dev` (already registered in PR #41653, merged). Vercel requires this `_vercel` TXT record before it will let the domain be claimed/attached to my Vercel project.

## Checklist
- [x] I have read and agree to the [Terms of Service](https://is-a.dev/docs/terms)
- [x] My domain follows the [domain structure](https://is-a.dev/docs/domain-structure)
- [x] My site/service is reachable and complete (no "under construction" pages)
- [x] My domain is related to programming, software development, or related fields
- [x] My domain is not used for commercial purposes
- [x] I have provided a way to contact me (email in the owner field)