### PR TITLE
Add Vercel verification TXT for dropxtor.is-a.dev

### DIFF
--- a/domains/_vercel.dropxtor.json
+++ b/domains/_vercel.dropxtor.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "dropmoltbot"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=dropxtor.is-a.dev,1a580435944e3b35be71"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Verification Record

Adding  with TXT record to verify domain ownership for dropxtor.is-a.dev (registered in #41769, merged).

**Record:** TXT = vc-domain-verify=dropxtor.is-a.dev,1a580435944e3b35be71

This is a subdomain of dropxtor.is-a.dev which I own (PR #41769).

### Checklist
- [x] Parent subdomain dropxtor.is-a.dev exists and is owned by dropmoltbot
- [x] TXT record is for Vercel domain verification
- [x] JSON follows domain structure guidelines