### PR TITLE
Update Vercel TXT verification token for rohitgande.is-a.dev

### DIFF
--- a/domains/_vercel.rohitgande.json
+++ b/domains/_vercel.rohitgande.json
@@ -4,6 +4,6 @@
     "email": "rohitgande0705@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=is-a.dev,557585bf22731e32449f"
+    "TXT": "vc-domain-verify=rohitgande.is-a.dev,09816155911b956dd61e"
   }
 }


### PR DESCRIPTION
## Pull Request Type
- [x] Domain Registration

## Description
Updating `_vercel.rohitgande.json` with the correct Vercel domain ownership verification token. The previous PR (#41771) used a stale token (Vercel had initially issued a challenge against the wrong domain `is-a.dev`). After adding the domain to my Vercel project again, Vercel issued a corrected token scoped to `rohitgande.is-a.dev` — this PR updates the TXT value to match.

## Checklist
- [x] I have read and agree to the [Terms of Service](https://is-a.dev/docs/terms)
- [x] My domain follows the [domain structure](https://is-a.dev/docs/domain-structure)
- [x] My site/service is reachable and complete (no "under construction" pages)
- [x] My domain is related to programming, software development, or related fields
- [x] My domain is not used for commercial purposes
- [x] I have provided a way to contact me (email in the owner field)