### PR TITLE
Register unidosporvenezuela.is-a.dev

### DIFF
--- a/domains/unidosporvenezuela.json
+++ b/domains/unidosporvenezuela.json
@@ -1,0 +1,11 @@
+{
+  "description": "Unidos como hermanos Venezolanos - earthquake relief information and resources",
+  "repo": "https://github.com/gabybarcodes/unidosporvenezuela.com",
+  "owner": {
+    "username": "gabybarcodes",
+    "email": "cuentaparalela753@gmail.com"
+  },
+  "records": {
+    "CNAME": "gabybarcodes.github.io"
+  }
+}


### PR DESCRIPTION
## Domain
unidosporvenezuela.is-a.dev

## Purpose
Information and relief resources site for the 2026 Venezuela earthquake ("Unidos como hermanos Venezolanos"), hosted on GitHub Pages.

## Record type
CNAME -> gabybarcodes.github.io