### PR TITLE
Update Vercel verification tokens and add www records for rohitgande.is-a.dev

### DIFF
--- a/domains/_vercel.rohitgande.json
+++ b/domains/_vercel.rohitgande.json
@@ -4,6 +4,9 @@
     "email": "rohitgande0705@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=rohitgande.is-a.dev,6b5af78085220fcda500"
+    "TXT": [
+      "vc-domain-verify=rohitgande.is-a.dev,6b5af78085220fcda500",
+      "vc-domain-verify=www.rohitgande.is-a.dev,073f88013de53e452830"
+    ]
   }
 }

--- a/domains/_vercel.www.rohitgande.json
+++ b/domains/_vercel.www.rohitgande.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "rg-incognito",
-    "email": "rohitgande0705@gmail.com"
-  },
-  "records": {
-    "TXT": "vc-domain-verify=www.rohitgande.is-a.dev,073f88013de53e452830"
-  }
-}

--- a/domains/_vercel.www.rohitgande.json
+++ b/domains/_vercel.www.rohitgande.json
@@ -4,6 +4,6 @@
     "email": "rohitgande0705@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=rohitgande.is-a.dev,6b5af78085220fcda500"
+    "TXT": "vc-domain-verify=www.rohitgande.is-a.dev,073f88013de53e452830"
   }
 }

--- a/domains/www.rohitgande.json
+++ b/domains/www.rohitgande.json
@@ -4,6 +4,6 @@
     "email": "rohitgande0705@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=rohitgande.is-a.dev,6b5af78085220fcda500"
+    "CNAME": "8aaa58376a7dc462.vercel-dns-017.com."
   }
 }

--- a/domains/www.rohitgande.json
+++ b/domains/www.rohitgande.json
@@ -4,6 +4,6 @@
     "email": "rohitgande0705@gmail.com"
   },
   "records": {
-    "CNAME": "8aaa58376a7dc462.vercel-dns-017.com."
+    "CNAME": "8aaa58376a7dc462.vercel-dns-017.com"
   }
 }


### PR DESCRIPTION
## Pull Request Type
- [x] Domain Registration

## Description
Three changes bundled together to fully verify `rohitgande.is-a.dev` on Vercel and add the `www` redirect subdomain:

1. `_vercel.rohitgande.json` — updated TXT token to the current Vercel-issued challenge (`6b5af78085220fcda500`)
2. `www.rohitgande.json` — new file, CNAME for the www redirect Vercel auto-adds
3. `_vercel.www.rohitgande.json` — new file, TXT verification for the www subdomain

This is the final set of records needed; previous PRs (#41653, #41771, #41797) set up the initial CNAME and earlier token attempts.

## Checklist
- [x] I have read and agree to the [Terms of Service](https://is-a.dev/docs/terms)
- [x] My domain follows the [domain structure](https://is-a.dev/docs/domain-structure)
- [x] My site/service is reachable and complete (no "under construction" pages)
- [x] My domain is related to programming, software development, or related fields
- [x] My domain is not used for commercial purposes
- [x] I have provided a way to contact me (email in the owner field)