### PR TITLE
Register abel.is-a.dev

### DIFF
--- a/domains/abel.json
+++ b/domains/abel.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "muhamadabel",
+    "email": "muhamadabelugm@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering abel.is-a.dev for my developer portfolio (hosted on Vercel). CNAME points to cname.vercel-dns.com. Thanks!