### PR TITLE
Add gacha-tracker.is-a.dev

### DIFF
--- a/domains/gacha-tracker.json
+++ b/domains/gacha-tracker.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "akela2109"
+  },
+  "records": {
+    "CNAME": "akela2109.github.io"
+  }
+}


### PR DESCRIPTION
﻿Adding `gacha-tracker.is-a.dev` for my open-source gacha event tracker (Genshin / Honkai: Star Rail / Wuthering Waves / Neverness to Everness).

- Static site hosted on GitHub Pages: https://akela2109.github.io/gacha-event-tracker/
- Record: CNAME -> akela2109.github.io
- Source repo: https://github.com/akela2109/gacha-event-tracker

Thanks!
