### PR TITLE
feat: add donprueba.is-a.dev domain

### DIFF
--- a/domains/donprueba.json
+++ b/domains/donprueba.json
@@ -1,0 +1,20 @@
+{
+  "owner": {
+    "username": "G4V0"
+  },
+  "records": {
+    "CNAME": "donprueba.online",
+    "TXT": [
+      "google-site-verification=jaxGOAPXX2jUW-vSZxoRbmWYxLty_U1FDVVh-qtwtEk",
+      "v=spf1 include:_spf.google.com ~all"
+    ],
+    "MX": [
+      { "target": "ASPMX.L.GOOGLE.COM", "priority": 1 },
+      { "target": "ALT1.ASPMX.L.GOOGLE.COM", "priority": 5 },
+      { "target": "ALT2.ASPMX.L.GOOGLE.COM", "priority": 5 },
+      { "target": "ALT3.ASPMX.L.GOOGLE.COM", "priority": 10 },
+      { "target": "ALT4.ASPMX.L.GOOGLE.COM", "priority": 10 }
+    ]
+  },
+  "proxied": true
+}

--- a/domains/donprueba.json
+++ b/domains/donprueba.json
@@ -1,6 +1,6 @@
 {
   "owner": {
-    "username": "G4V0"
+    "username": "zahirbombap-hub"
   },
   "records": {
     "CNAME": "donprueba.online",


### PR DESCRIPTION
## Domain Registration

Registering `donprueba.is-a.dev` with:
- **CNAME** → donprueba.online (proxied via Cloudflare)
- **MX** → Google Workspace (ASPMX.L.GOOGLE.COM)
- **TXT** → Google verification + SPF for Google

### Owner
- **GitHub:** @zahirbombap-hub

CC: @is-a-dev/maintainers