### PR TITLE
Register artbyankit.is-a.dev

### DIFF
--- a/domains/artbyankit.json
+++ b/domains/artbyankit.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "djhrishi19",
+    "email": "djhrishi19@gmail.com"
+  },
+  "records": {
+    "CNAME": "djhrishi19.github.io"
+  }
+}


### PR DESCRIPTION
Registering `artbyankit.is-a.dev` for a handmade Madhubani (Mithila) dress showcase site.

- **Record:** CNAME → `djhrishi19.github.io` (GitHub Pages)
- **Live content** already published at https://djhrishi19.github.io/madhubani/
- Single subdomain, personal/brand use, no wildcard.