### PR TITLE
Add ripan-nursalam.is-a.dev subdomain

### DIFF
--- a/domains/ripan-nursalam.json
+++ b/domains/ripan-nursalam.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"Ascalon231"},"records":{"CNAME":"portofolio.nursalamripan231.workers.dev"},"proxied":true}


### PR DESCRIPTION
Adds the subdomain `ripan-nursalam.is-a.dev` pointing to `portofolio.nursalamripan231.workers.dev` (Cloudflare Worker).

```json
{
  "owner": {
    "username": "Ascalon231"
  },
  "records": {
    "CNAME": "ripan.nursalam.workers.dev"
  },
  "proxied": true
}
```

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

**Website Preview:**
![](https://github.com/Ascalon231/register/releases/download/untagged-5effbe746e4b87eeb88e/portfolio-ss.png)

**Website Purpose:**
Developer profile website, used for highlighting as a digital portfolio of a software engineer.