### PR TITLE
Register jsdf-events.is-a.dev

### DIFF
--- a/domains/jsdf-events.json
+++ b/domains/jsdf-events.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "naoya7928-0813"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `jsdf-events.is-a.dev` for my personal project: an unofficial site that aggregates Japan Self-Defense Force (JSDF) regional recruitment-event information by prefecture. It points to my Vercel deployment via CNAME (cname.vercel-dns.com). Thanks for the service!