### PR TITLE
Register omarbengourich.is-a.dev

### DIFF
--- a/domains/omarbengourich.json
+++ b/domains/omarbengourich.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "omarBENgourich",
+    "email": "omarbengourich@gmail.com"
+  },
+  "records": {
+    "CNAME": "omarbengourich.github.io"
+  }
+}


### PR DESCRIPTION
Adding `omarbengourich.is-a.dev` — personal developer portfolio.

- CNAME to `omarbengourich.github.io` (GitHub Pages, already live)
- Owner: @omarBENgourich