### PR TITLE
update lauurnce.is-a.dev

### DIFF
--- a/domains/lauurnce.json
+++ b/domains/lauurnce.json
@@ -4,6 +4,7 @@
     "email": "paneslawrence8@gmail.com"
   },
   "records": {
-    "CNAME": "lawrence-eigen.vercel.app"
+    "A": ["216.198.79.1"],
+    "TXT": "vc-domain-verify=lauurnce.is-a.dev,7298fba061d0a5702df5"
   }
 }


### PR DESCRIPTION
> Update to an already-registered domain (`lauurnce.is-a.dev`, merged in #41896). This PR switches the record from a CNAME to an A record and adds a `_vercel` TXT record so Vercel can verify domain ownership (the domain was previously linked to another Vercel project, so Vercel requires a TXT verification record).

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://lawrence-eigen.vercel.app

# Website Purpose

Personal developer portfolio — projects, competitions, and community leadership work. This PR adds the TXT record required to connect the domain to my Vercel project over HTTPS.