### PR TITLE
Register pixel-obby.is-a.dev

### DIFF
--- a/domains/pixel-obby.json
+++ b/domains/pixel-obby.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "BB-BK-TK"
+  },
+  "records": {
+    "CNAME": "bb-bk-tk.github.io"
+  }
+}


### PR DESCRIPTION
Registering `pixel-obby.is-a.dev` for my open-source browser game **Pixel Obby**.

- Type: a JavaScript/HTML5 canvas game (endless procedurally-generated obstacle courses)
- Source: https://github.com/BB-BK-TK/pixel-obby
- Currently live at: https://bb-bk-tk.github.io/pixel-obby/
- Record: CNAME -> bb-bk-tk.github.io (GitHub Pages)

The site has full, substantive content (a playable game with menus, a shop, and saving). Thanks for maintaining this service!

Made with [Cursor](https://cursor.com)