### PR TITLE
Add literary-house.is-a.dev

### DIFF
--- a/domains/literary-house.json
+++ b/domains/literary-house.json
@@ -1,0 +1,1 @@
+{ "owner": { "username": "spawnperm" }, "records": { "CNAME": "spawnperm.github.io" }, "proxied": true }


### PR DESCRIPTION
Registering literary-house.is-a.dev subdomain pointing to spawnperm.github.io for PK Business OS portal.