### PR TITLE
Register sherpa.is-a.dev

### DIFF
--- a/domains/sherpa.json
+++ b/domains/sherpa.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "urbanlotusai"
+  },
+  "description": "Sherpa — an AWS knowledge assistant.",
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering sherpa.is-a.dev for Sherpa, an AWS knowledge assistant. CNAME points to Vercel (cname.vercel-dns.com).