### PR TITLE
Add Vercel TXT verification for amanjot.is-a.dev

### DIFF
--- a/domains/_vercel.amanjot.json
+++ b/domains/_vercel.amanjot.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "amanmalhotra911",
+    "email": "amanmalhotra911@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=amanjot.is-a.dev,f793d0f63be54306b412"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. if not provided your PR will be closed with no questions asked. -->

Live: https://personal-website-ten-chi-40.vercel.app (will resolve at https://amanjot.is-a.dev once this TXT record verifies)

<img width="1200" height="798" alt="amanjot.is-a.dev preview" src="https://github.com/user-attachments/assets/6ec319a5-3fe1-42a0-8c28-5faf5d588000" />

# Website Purpose
<!-- Please tell us the purpose or motive behind your website. For example, it is a portfolio website, etc. -->

Follow-up to merged #41909 (registered amanjot.is-a.dev). This adds the `_vercel.amanjot` TXT record Vercel requires to verify domain ownership before it will serve the site — same root domain, same personal portfolio for Amanjot Malhotra.
