### PR TITLE
Register pmlens.is-a.dev

### DIFF
--- a/domains/pmlens.json
+++ b/domains/pmlens.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Arlong6",
+    "email": "tony0912045596@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain
`pmlens.is-a.dev`

## Purpose
Personal side project — a dashboard that surfaces Polymarket markets where
Deribit-implied probabilities disagree (≥5pp gap) and tracks whale flows >$50k.
Currently live at https://pmlens.vercel.app; would like a cleaner URL to share
on Reddit / X.

## Records
CNAME → `cname.vercel-dns.com` (Vercel-hosted static site).

## Checklist
- [x] Read the documentation
- [x] Filled out the JSON file correctly
- [x] Domain doesn't violate Terms of Service