### PR TITLE
Register soloappsstudio.is-a.dev

### DIFF
--- a/domains/soloappsstudio.json
+++ b/domains/soloappsstudio.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "samuelbanapour",
+    "email": "samuel.banapour100@gmail.com"
+  },
+  "records": {
+    "CNAME": "solo-apps-studio-website.web.app"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: **https://solo-apps-studio-website.web.app**

# Website Purpose

This is the project showcase for **Solo Apps Studio**, my one-person independent studio where I build games and apps by hand across desktop, the web, and Apple platforms. The site introduces the studio and showcases my projects — Sky Mood, Neon Pong, Nertz, RolePlay AI, Echoes of the Returning, Super Wii Bros, and more — with notes on where each runs and a contact form.

The DNS record is a single `CNAME` to `solo-apps-studio-website.web.app` (Firebase Hosting, DNS-only).

It is **non-commercial**: the website itself has no ads, no pricing, no checkout, and sells nothing — it is purely a portfolio/showcase of personal software-development projects.
