### PR TITLE
Register fitpedia.is-a.dev

### DIFF
--- a/domains/fitpedia.json
+++ b/domains/fitpedia.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "zakurazaaa",
-    "email": "zakurazaaa@users.noreply.github.com"
+    "email": "infra@salehere.co.th"
   },
   "records": {
     "CNAME": "zakurazaaa.github.io"

--- a/domains/fitpedia.json
+++ b/domains/fitpedia.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "zakurazaaa",
+    "email": "zakurazaaa@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "zakurazaaa.github.io"
+  }
+}


### PR DESCRIPTION
Adding `fitpedia.is-a.dev` as a CNAME to `zakurazaaa.github.io` for FitPedia — a Thai-language exercise reference web app (React + Vite, GitHub Pages).

- Record: CNAME -> zakurazaaa.github.io
- Single CNAME record only.

Thanks!