### PR TITLE
Add muhub.json for domain configuration

### DIFF
--- a/domains/muhub.json
+++ b/domains/muhub.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "kumota-1985",
+    "email": "kubota.yusuke2006@gmail.com"
+  },
+  "records": {
+    "A": ["161.33.177.142"]
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
<img width="1262" height="1298" alt="image" src="https://github.com/user-attachments/assets/77c29d53-98ff-432a-beaf-bc9e3b70ea69" />
Live site: https://muhub.duckdns.org
(Screenshot attached below.)

# Website Purpose

muhub is a web application I built and maintain — a student portal for Muroran Institute of Technology (Japan).
It provides syllabus search, a timetable maker, the official class schedule, and a graduation-requirements roadmap.
Frontend is vanilla JavaScript; backend is FastAPI + SQLite; self-hosted behind Caddy on my own server.
It is a personal, non-commercial software-development project.
I need a proper domain because my university's campus network web filter blocks dynamic-DNS domains
(the current DuckDNS address), so classmates cannot reach the site on the campus WiFi.