### PR TITLE
Register webora.is-a.dev

### DIFF
--- a/domains/webora.json
+++ b/domains/webora.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "talha50819",
+    "email": "talhasiddiqui433@gmail.com"
+  },
+  "records": {
+    "CNAME": "webora-398.netlify.app"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [ ] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. if not provided your PR will be closed with no questions asked. -->

Live: https://webora-398.netlify.app (will resolve at https://webora.is-a.dev once this PR is merged)

![Webora homepage preview](https://raw.githubusercontent.com/talha50819/webora-preview-assets/master/preview.png)

# Website Purpose

Webora is a web design and development agency site (my startup) — built with Next.js/TypeScript/Tailwind, covering services, portfolio/case studies, agency info, and contact. Flagging honestly: this is a commercial business site, not a hobby/non-commercial project, so it does not meet the "not for commercial use" requirement above. Submitting anyway per the site owner's request — understand this may be closed for that reason.
