### PR TITLE
add tiago-lab.is-a.dev

### DIFF
--- a/domains/tiago-lab.json
+++ b/domains/tiago-lab.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "TiagoMarante",
+    "email": "tiagofmarante@gmail.com"
+  },
+  "records": {
+    "CNAME": "74130c4a-9438-4ab7-9a8e-4afaff5cef08.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is reachable and completed.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

## Website Preview

**Live link:** https://tiago-lab.is-a.dev

### Website Purpose

Registering tiago-lab.is-a.dev to remotely access my homelab server (running through a Cloudflare Tunnel) without needing to open or forward any ports.