### PR TITLE
olatunjilawal.is-a.dev

### DIFF
--- a/domains/_vercel.olatunjilawal.json
+++ b/domains/_vercel.olatunjilawal.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "joma-biggestFan4",
+        "email": "jomakazejr@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=olatunjilawal.is-a.dev,fc4fda80ede0e2799d4f"
+    }
+}

--- a/domains/olatunjilawal.json
+++ b/domains/olatunjilawal.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "joma-biggestFan4",
+        "email": "jomakazejr@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
- [x] I **agree** to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.
# Website Preview
<img width="1919" height="993" alt="Screenshot 2026-06-30 204744" src="https://github.com/user-attachments/assets/94dbd47e-1162-4696-8a67-9bf8001b758a" />
<img width="1919" height="993" alt="Screenshot 2026-06-30 204744" src="https://github.com/user-attachments/assets/94dbd47e-1162-4696-8a67-9bf8001b758a" />
https://olatunjilawal.vercel.app/
# Website Purpose
This is my personal portfolio website showcasing my work as a web developer.