### PR TITLE
Add Vercel verification for kenzamariyan.is-a.dev

### DIFF
--- a/domains/_vercel.kenzamariyan.json
+++ b/domains/_vercel.kenzamariyan.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "callmezaa",
+    "email": "kenzamariyan32@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=kenzamariyan.is-a.dev,6b59e451e4ad781c0fc8"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live Website:**

https://kenzamariyan-portfolio.vercel.app

**Screenshot:**

<img width="946" height="404" alt="image" src="https://github.com/user-attachments/assets/16c318a1-17fd-456a-a4f8-da2f24f0dfdb" />
<img width="947" height="404" alt="image" src="https://github.com/user-attachments/assets/cf4b7d42-6673-4e99-bc28-4dba247a6551" />
<img width="948" height="402" alt="image" src="https://github.com/user-attachments/assets/d4833454-74be-4b93-a226-1f63d0273bac" />

# Website Purpose

This is my personal software engineering portfolio website built to showcase my projects, technical skills, and professional experience.

This pull request adds the required Vercel TXT verification record (`_vercel.kenzamariyan.json`) for my existing `kenzamariyan.is-a.dev` domain, which was previously approved and merged in PR #42215.

This change is only for Vercel domain ownership verification so that `kenzamariyan.is-a.dev` can be successfully connected to my existing Vercel project.