### PR TITLE
Add NAKI PRIMA WiFi Scanner Monitor domain

### DIFF
--- a/domains/nakiprima
+++ b/domains/nakiprima
@@ -1,0 +1,11 @@
+{
+  "description": "NAKI PRIMA WiFi Scanner Monitor",
+  "domain": "is-a.dev",
+  "subdomain": "nakiprima",
+  "owner": {
+    "username": "B4T4V14"
+  },
+  "record": {
+    "CNAME": "b4t4v14.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
URL: https://b4t4v14.github.io/NAKI_PRIMA/

NAKI PRIMA Monitor Map - interactive WiFi scan visualization dashboard.

# Website Purpose
Software development monitoring tool for displaying WiFi SSID scan data from a drone-based scanner system on an interactive map. Non-commercial, internal use only.