### PR TITLE
Register inezabonheur.is-a.dev

### DIFF
--- a/domains/_vercel.inezabonheur.json
+++ b/domains/_vercel.inezabonheur.json
@@ -1,0 +1,5 @@
+{
+  "owner": { "username": "InezaBonheurCedrick", "email": "inezabonheur100@gmail.com" },
+  "description": "Vercel domain verification for inezabonheur.is-a.dev",
+  "records": { "TXT": "vc-domain-verify=inezabonheur.is-a.dev,9d368d987d49d5669abc" }
+}

--- a/domains/inezabonheur.json
+++ b/domains/inezabonheur.json
@@ -1,0 +1,5 @@
+{
+  "owner": { "username": "InezaBonheurCedrick", "email": "inezabonheur100@gmail.com" },
+  "description": "Portfolio of Ineza Bonheur Cedrick, full-stack software developer in Kigali, Rwanda.",
+  "records": { "A": ["216.198.79.1"] }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live deployment (the is-a.dev domain will point here once this PR is merged):
https://dev-portfolio-zeta-wine.vercel.app

<img width="1280" height="603" alt="image" src="https://github.com/user-attachments/assets/9b840af0-578d-4142-934e-9e7cc0c187d1" />
<img width="1280" height="598" alt="image" src="https://github.com/user-attachments/assets/9857db96-4abd-45af-9e0e-5950bf8611c5" />
<img width="1280" height="602" alt="Screenshot 2026-07-01 192806" src="https://github.com/user-attachments/assets/df073afa-b932-4116-beb6-951a891b553b" />
<img width="1280" height="599" alt="Screenshot 2026-07-01 192830" src="https://github.com/user-attachments/assets/34c8e444-dd45-4340-8650-ed1f60471c3e" />
<img width="1276" height="594" alt="image" src="https://github.com/user-attachments/assets/19bb881f-fa62-45b1-aa79-873f0b533613" />
<img width="1279" height="598" alt="image" src="https://github.com/user-attachments/assets/091e9a1e-0519-46e8-8bad-829b6fb866df" />



# Website Purpose

A personal developer portfolio for Ineza Bonheur Cedrick, a full-stack software
developer based in Kigali, Rwanda. It showcases projects, work experience, skills,
and services (React, Next.js, NestJS, Node, TypeScript, PostgreSQL, MongoDB, React
Native). Non-commercial — it's a personal portfolio, not a store or paid service.
