### PR TITLE
Register kaoa.is-a.dev

### DIFF
--- a/domains/kaoa.json
+++ b/domains/kaoa.json
@@ -4,6 +4,6 @@
     "email": "phoenixuser007@gmail.com"
   },
   "records": {
-    "CNAME": "phoenixuser007-debug.github.io"
+    "CNAME": "kaoa-welfare-fund.pages.dev"
   }
 }

--- a/domains/kaoa.json
+++ b/domains/kaoa.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "phoenixuser007-debug",
+    "email": "phoenixuser007@gmail.com"
+  },
+  "records": {
+    "CNAME": "phoenixuser007-debug.github.io"
+  }
+}


### PR DESCRIPTION
### Domain
kaoa.is-a.dev

### Purpose
Hosting a static community welfare-fund contribution report site for the KAOA (1972) residents association on GitHub Pages.

### Record type
CNAME → phoenixuser007-debug.github.io