### PR TITLE
Add valdelomar116.is-a.dev (Railway)

### DIFF
--- a/domains/_railway-verify.valdelomar116.json
+++ b/domains/_railway-verify.valdelomar116.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "Pierxsss7"
+    },
+    "records": {
+        "TXT": "railway-verify=683fdab24c7ef6cc366aeae0e8a58bd37dca7b1c9e4783eeb5835cd34498b3cd"
+    }
+}

--- a/domains/valdelomar116.json
+++ b/domains/valdelomar116.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "Pierxsss7"
+    },
+    "records": {
+        "CNAME": "lo3tui7g.up.railway.app"
+    }
+}


### PR DESCRIPTION
Subdomain **valdelomar116.is-a.dev** for I.E. Abraham Valdelomar 116 school management system hosted on Railway.