### PR TITLE
Add scambusterph.json

### DIFF
--- a/domains/scambusterph.json
+++ b/domains/scambusterph.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "keane3029-lab",
+    "email": "keane3029@gmail.com"
+  },
+  "records": {
+    "CNAME": "keane3029-lab.github.io"
+  }
+}


### PR DESCRIPTION
## Subdomain
scambusterph.is-a.dev

## Purpose
Requesting a subdomain for ScamBuster PH, a civic anti-scam organization 
based in Cagayan de Oro, Mindanao, Philippines. The site provides scam 
awareness resources, a victim intake form for fraud reports, and hosts 
ongoing investigations into online scam operations targeting Filipino users.

## Hosting
This subdomain will point to a GitHub Pages site (CNAME record).

## Checklist
- [x] I have read and agree with the Terms of Service
- [x] I have read and understood the guidelines for choosing a subdomain
- [x] My chosen subdomain does not relate to any of the following (as outlined in the domain guidelines): Piracy, Malware, Phishing, Spam, Inappropriate content
- [x] My chosen subdomain is not a top 2,000 popular website
- [x] My pull request contains only one commit