### PR TITLE
Register voti.is-a.dev

### DIFF
--- a/domains/voti.json
+++ b/domains/voti.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "LimChangHun81",
+    "email": "lim.chang.hun81@gmail.com"
+  },
+  "records": {
+    "CNAME": "cf1b5b48-2130-4338-9dc0-47cc31076027.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
Registering voti.is-a.dev as a CNAME to a Cloudflare Tunnel for a personal project.