### PR TITLE
Register wasimhome.is-a.dev

### DIFF
--- a/domains/wasimhome.json
+++ b/domains/wasimhome.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "wasimakh2",
+        "email": "wasim.akh2@gmail.com"
+    },
+    "records": {
+        "NS": ["coco.ns.cloudflare.com", "darwin.ns.cloudflare.com"]
+    }
+}


### PR DESCRIPTION
### Domain
`wasimhome.is-a.dev`

### Reason for NS records
Delegating to Cloudflare (free plan) to run a named Cloudflare Tunnel + Cloudflare Access (email OTP) in front of my self-hosted Home Assistant instance. NS delegation is required because tunnel public hostnames and Access policies can only attach to a zone in my own Cloudflare account.

### Records
NS → `coco.ns.cloudflare.com`, `darwin.ns.cloudflare.com`

- [x] I have read and agree to the [Terms of Service](https://is-a.dev/terms)
- [x] My file follows the documented JSON structure
- [x] This domain is for personal, non-commercial use