### PR TITLE
chore: update ranveer.is-a.dev (add Google site verification TXT)

### DIFF
--- a/domains/ranveer.json
+++ b/domains/ranveer.json
@@ -1,9 +1,15 @@
 {
-      "owner": {
-              "username": "RanveerSingh1997",
-              "email": "ranveergour781@gmail.com"
-      },
-      "records": {
-              "CNAME": "ranveersingh1997.github.io"
-      }
+    "owner": {
+        "username": "RanveerSingh1997",
+        "email": "ranveergour781@gmail.com"
+    },
+    "records": {
+        "A": [
+            "185.199.108.153",
+            "185.199.109.153",
+            "185.199.110.153",
+            "185.199.111.153"
+        ],
+        "TXT": "google-site-verification=nKoEiD8mhnvf8fc6TU7-8GXYc6sdysw818KRWF3z7f4"
+    }
 }


### PR DESCRIPTION
Updates `ranveer.is-a.dev` to add a Google Search Console domain-verification TXT record (needed to register as a verified publisher on pub.dev for my Flutter package [air_pointer](https://pub.dev/packages/air_pointer)).

Since a TXT record cannot coexist with a CNAME at the same name, the existing CNAME to `ranveersingh1997.github.io` is replaced with the four GitHub Pages A records — the site continues to be served by GitHub Pages unchanged.

- Replace `CNAME: ranveersingh1997.github.io` with GitHub Pages A records (185.199.108–111.153)
- Add `TXT: google-site-verification=...`

Follow-up to #42179.
