### PR TITLE
Register devops-handbook.is-a.dev

### DIFF
--- a/domains/devops-handbook.json
+++ b/domains/devops-handbook.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "grvtech1"
+  },
+  "records": {
+    "CNAME": "grvtech1.github.io"
+  }
+}


### PR DESCRIPTION
Registering `devops-handbook.is-a.dev` with a CNAME to my GitHub Pages site.

- **Target:** `grvtech1.github.io` (GitHub Pages)
- **Use:** a free, open-source DevOps learning handbook (https://github.com/grvtech1/devops-handbook)

Single file added: `domains/devops-handbook.json`. Thanks for the service! 🙏