### PR TITLE
Add toumai.is-a.dev

### DIFF
--- a/domains/toumai.json
+++ b/domains/toumai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "faycalhabibahmatalbachar",
+    "email": "iamfaycalhabib@gmail.com"
+  },
+  "records": {
+    "CNAME": "faycalhabibahmatalbachar.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://faycalhabibahmatalbachar.github.io/toumai-web/

It's a chat web app for Toumai AI, an AI assistant I built (mobile app + FastAPI backend + this Next.js frontend). The homepage explains the project and links straight into a working chat you can try instantly as a guest, with streaming responses and a model switcher.

# Website Purpose

This is the web client for Toumai AI, a personal AI assistant project I develop end-to-end (backend, mobile app, and this site). It's not monetized in any way, no ads, no paid plans, just a place to try the assistant from a browser and see the project. I'd like toumai.is-a.dev as the home for it.