### PR TITLE
Register pekobot.is-a.dev (+ verify subdomain)

### DIFF
--- a/domains/_vercel.pekobot.json
+++ b/domains/_vercel.pekobot.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "pekoMaster"
+    "username": "pekoMaster",
+    "email": "pekopekopekopekomura@gmail.com"
   },
   "records": {
     "TXT": [

--- a/domains/_vercel.pekobot.json
+++ b/domains/_vercel.pekobot.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "pekoMaster"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=pekobot.is-a.dev,171173a57b9da1040af4",
+      "vc-domain-verify=verify.pekobot.is-a.dev,127f27809c00f2370f43"
+    ]
+  }
+}

--- a/domains/pekobot.json
+++ b/domains/pekobot.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "pekoMaster"
+    "username": "pekoMaster",
+    "email": "pekopekopekopekomura@gmail.com"
   },
   "records": {
     "CNAME": "fd453273298335de.vercel-dns-017.com"

--- a/domains/pekobot.json
+++ b/domains/pekobot.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "pekoMaster"
+  },
+  "records": {
+    "CNAME": "fd453273298335de.vercel-dns-017.com"
+  }
+}

--- a/domains/verify.pekobot.json
+++ b/domains/verify.pekobot.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "pekoMaster"
+  },
+  "records": {
+    "CNAME": "a4af9a126f0465e7.vercel-dns-017.com"
+  }
+}

--- a/domains/verify.pekobot.json
+++ b/domains/verify.pekobot.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "pekoMaster"
+    "username": "pekoMaster",
+    "email": "pekopekopekopekomura@gmail.com"
   },
   "records": {
     "CNAME": "a4af9a126f0465e7.vercel-dns-017.com"


### PR DESCRIPTION
﻿# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://peko-embed.vercel.app (currently served on our Vercel domain; `pekobot.is-a.dev` will point to the same deployment once DNS is live)

![PekoEmbed homepage](https://raw.githubusercontent.com/pekoMaster/register/assets/screenshots/pekoembed-home.png)

# Website Purpose

PekoEmbed is a free, non-commercial Discord bot that fixes X/Twitter link previews (multi-image layouts, inline video, quote tweets) with a web control panel for server admins. The root domain serves the project homepage (features, supported platforms, privacy policy, terms).

This PR registers three files:

- `pekobot.json` — root subdomain, project homepage (Vercel)
- `verify.pekobot.json` — nested subdomain hosting the YouTube membership verification flow for our community Discord server (Vercel)
- `_vercel.pekobot.json` — Vercel domain-ownership verification TXT records for the two domains above

Contact: via GitHub (@pekoMaster). Happy to add a Discord handle to the owner key if preferred.
