### PR TITLE
Register vampirepapi.is-a.dev

### DIFF
--- a/domains/_vercel.vampirepapi.json
+++ b/domains/_vercel.vampirepapi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vampirepapi",
+        "email": "shubhamsourabh8@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=vampirepapi.is-a.dev,e971b434765de1d5c816"
+    }
+}

--- a/domains/vampirepapi.json
+++ b/domains/vampirepapi.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "vampirepapi",
+        "email": "shubhamsourabh8@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://vampirepapi.vercel.app

![Screenshot of vampirepapi.vercel.app](https://bqkmvc6cuwbc8siq.public.blob.vercel-storage.com/meta/site-screenshot-20260704.png)

# Website Purpose

Personal developer portfolio and blog. I'm a software engineer (SDE-2) and marathon runner — the site carries my selected work and projects, an engineering/running blog, a photo gallery and life goals. Built with Next.js, TypeScript and Postgres; fully non-commercial.

The second file (`_vercel.vampirepapi.json`) is Vercel's domain-ownership TXT verification, per the [is-a.dev Vercel guide](https://docs.is-a.dev/guides/vercel/).
