### PR TITLE
feat: add hermes.is-a.dev

### DIFF
--- a/domains/hermes.json
+++ b/domains/hermes.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "amkaneki1",
+        "email": "stokalucard01@gmail.com"
+    },
+    "records": {
+        "A": ["43.157.200.223"]
+    }
+}


### PR DESCRIPTION
Adding hermes.is-a.dev for my Hermes Agent config dashboard.

**Domain:** hermes.is-a.dev
**A Record:** 43.157.200.223
**Purpose:** Self-hosted Hermes Agent configuration dashboard

Requirements:
- [x] There are no conflicts with existing domains
- [x] The domain is available (confirmed via is-a.dev checker)
- [x] The file is named correctly (hermes.json)
- [x] Records point to a valid IP