### PR TITLE
Register yiliu.is-a.dev

### DIFF
--- a/domains/yiliu.json
+++ b/domains/yiliu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "VladimirPeng",
+    "email": "1flowShenzhen@gmail.com"
+  },
+  "records": {
+    "CNAME": "vladimirpeng.github.io"
+  }
+}


### PR DESCRIPTION
## Register yiliu.is-a.dev

- **Domain:** yiliu.is-a.dev
- **CNAME:** vladimirpeng.github.io
- **Owner:** VladimirPeng
- **Email:** 1flowShenzhen@gmail.com

This subdomain will be used for 继流智能 (Yiliu Intelligent) company website, an AI solutions provider based in Shenzhen, China.