### PR TITLE
Register ligapy.is-a.dev

### DIFF
--- a/domains/_vercel.ligapy.json
+++ b/domains/_vercel.ligapy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "DAW1BSergiomg26",
+    "email": "menu2informatico@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=ligapy.is-a.dev,4f6546a2c3b4b42f6668"
+  }
+}

--- a/domains/ligapy.json
+++ b/domains/ligapy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "DAW1BSergiomg26",
+    "email": "menu2informatico@gmail.com"
+  },
+  "records": {
+    "CNAME": "frontend-ten-swart-85.vercel.app"
+  }
+}


### PR DESCRIPTION
Registering \ligapy.is-a.dev\ for the **Liga Paraguaya de Fútbol** project.

### Website
Live preview: https://frontend-ten-swart-85.vercel.app

### Records
- \CNAME\ → \rontend-ten-swart-85.vercel.app\ (Vercel deployment)
- \TXT\ → Vercel domain verification record in \_vercel.ligapy.json\

### Screenshot
![Liga Paraguaya de Fútbol](https://frontend-ten-swart-85.vercel.app/og-image.png)

### Checklist
- [x] Domain not already registered
- [x] Valid JSON syntax
- [x] CI checks passed
- [x] Vercel TXT verification included