### PR TITLE
Register soccerai.is-a.dev

### DIFF
--- a/domains/soccerai.json
+++ b/domains/soccerai.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "phenomenoy"
+  },
+  "records": {
+    "URL": "https://github.com/phenomenoy"
+  }
+}


### PR DESCRIPTION
Adds soccerai.is-a.dev for @phenomenoy.\n\nInitial record uses a URL redirect to the owner's GitHub profile; this can be updated later when the SoccerAI site is ready.