### PR TITLE
Register fin-control.is-a.dev + api.fin-control.is-a.dev

### DIFF
--- a/domains/api.fin-control.json
+++ b/domains/api.fin-control.json
@@ -1,0 +1,10 @@
+{
+  "description": "Backend do fin-control, API REST em Laravel do app pessoal de controle financeiro (hospedado no Render).",
+  "owner": {
+    "username": "AndreAntunesBarros",
+    "email": "antunes.cidiz@gmail.com"
+  },
+  "records": {
+    "CNAME": "finance-api-w2yp.onrender.com"
+  }
+}

--- a/domains/fin-control.json
+++ b/domains/fin-control.json
@@ -1,0 +1,10 @@
+{
+  "description": "fin-control, app pessoal de controle financeiro (React + Vite, hospedado no Vercel).",
+  "owner": {
+    "username": "AndreAntunesBarros",
+    "email": "antunes.cidiz@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain
- `fin-control.is-a.dev` — frontend of a personal finance tracking app (React + Vite), hosted on Vercel
- `api.fin-control.is-a.dev` — backend REST API (Laravel), hosted on Render

Both records point to the respective platform's CNAME target. Needed as a shared parent domain so the API's session cookie (Sanctum SPA auth) can be scoped across both subdomains.

Ran `npm test` locally — all 13 tests pass.