### PR TITLE
Update webora.is-a.dev to Cloudflare NS records

### DIFF
--- a/domains/webora.json
+++ b/domains/webora.json
@@ -4,6 +4,6 @@
     "email": "talhasiddiqui433@gmail.com"
   },
   "records": {
-    "CNAME": "webora-398.netlify.app"
+    "NS": ["clint.ns.cloudflare.com", "ophelia.ns.cloudflare.com"]
   }
 }


### PR DESCRIPTION
Switching webora.is-a.dev from a CNAME to Netlify to NS delegation via Cloudflare (clint.ns.cloudflare.com, ophelia.ns.cloudflare.com). Cloudflare zone is set up with matching CNAME records pointing to webora-398.netlify.app so the site continues resolving to the same origin.