### PR TITLE
Register teddyai.is-a.dev

### DIFF
--- a/domains/teddyai.json
+++ b/domains/teddyai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "harish-ai-engineer",
+    "email": "teddy.ai@outlook.com"
+  },
+  "records": {
+    "CNAME": "teddy-ai-lab.github.io"
+  }
+}


### PR DESCRIPTION
Registering `teddyai.is-a.dev` for the teddy.ai developer-tools site.- Site: https://github.com/teddy-ai-lab/teddy.ai (static site, GitHub Pages via Actions)- CNAME target: `teddy-ai-lab.github.io`- Contact: teddy.ai@outlook.comI have read and agree to the terms of registration.