### PR TITLE
Register traceline.is-a.dev

### DIFF
--- a/domains/traceline.json
+++ b/domains/traceline.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "99CIPHON99",
+    "email": "tenisbre@gmail.com"
+  },
+  "records": {
+    "CNAME": "99CIPHON99.github.io"
+  }
+}


### PR DESCRIPTION
## Info

- Subdomain: `traceline.is-a.dev`
- Purpose: marketing/docs site for Traceline, an open-source AGPL-3.0 test case management app: https://github.com/99CIPHON99/traceline
- Target: GitHub Pages (`99CIPHON99.github.io`), custom domain already configured on the repo with a matching `CNAME` file.