### PR TITLE
Register memzy.is-a.dev

### DIFF
--- a/domains/memzy.json
+++ b/domains/memzy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "alexkun4-lgtm",
+        "email": "alexkun4@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Registering **memzy.is-a.dev** for my personal app **memzy** — a small second-brain / note-keeping PWA I built and use with my partner (Next.js on Vercel, currently at https://memzy-pearl.vercel.app).

- CNAME → `cname.vercel-dns.com` (Vercel hosting)
- Site is live today at the Vercel URL above and will be served from this subdomain once merged.