### PR TITLE
Register nishalcr.is-a.dev

### DIFF
--- a/domains/nishalcr.json
+++ b/domains/nishalcr.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "nishalcr",
+    "email": "nishalcr@gmail.com"
+  },
+  "records": {
+    "CNAME": "nishalcr.pages.dev"
+  }
+}

--- a/domains/nishalcr.json
+++ b/domains/nishalcr.json
@@ -4,6 +4,6 @@
     "email": "nishalcr@gmail.com"
   },
   "records": {
-    "CNAME": "nishalcr.pages.dev"
+    "CNAME": "nishalcr.github.io"
   }
 }


### PR DESCRIPTION
Registering `nishalcr.is-a.dev` for my personal developer portfolio (GitHub Pages).

- **Record:** `CNAME` → `nishalcr.github.io`
- **Live preview:** https://nishalcr.pages.dev
- Single file added: `domains/nishalcr.json`
- I've read and followed the documentation at docs.is-a.dev.