### PR TITLE
Register open-application.is-a.dev

### DIFF
--- a/domains/open-application.json
+++ b/domains/open-application.json
@@ -1,0 +1,11 @@
+{
+  "description": "Open Application — open-source job application tracker",
+  "repo": "https://github.com/SilasFr/open-application",
+  "owner": {
+    "username": "SilasFr",
+    "email": "silas23.fr@gmail.com"
+  },
+  "records": {
+    "CNAME": "open-application-frontend.onrender.com"
+  }
+}


### PR DESCRIPTION
### Requesting a domain

- Domain: `open-application.is-a.dev`
- Purpose: hosting the frontend of [Open Application](https://github.com/SilasFr/open-application), an open-source job application tracker.
- CNAME target: `open-application-frontend.onrender.com` (Render static/web service).

I confirm I have read and understood the [terms of service](https://is-a.dev/terms).