### PR TITLE
Register alonhalawi.is-a.dev

### DIFF
--- a/domains/alonhalawi.json
+++ b/domains/alonhalawi.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AlonHal",
+    "email": "alonhmaster@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live: https://alon-halawi-portfolio.vercel.app

![website preview](https://raw.githubusercontent.com/AlonHal/register/pr-assets/site-preview.png)

# Website Purpose

Personal portfolio/resume site for a senior software engineer, showcasing career history, skills, and contact info.