### PR TITLE
Add wisesplit.is-a.dev

### DIFF
--- a/domains/_dmarc.wisesplit.json
+++ b/domains/_dmarc.wisesplit.json
@@ -1,0 +1,10 @@
+{
+  "description": "DMARC policy",
+  "owner": {
+    "username": "darpanvedi0",
+    "email": "darpanvedi0@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/resend._domainkey.wisesplit.json
+++ b/domains/resend._domainkey.wisesplit.json
@@ -1,0 +1,10 @@
+{
+  "description": "Resend DKIM",
+  "owner": {
+    "username": "darpanvedi0",
+    "email": "darpanvedi0@gmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCxRzUeVNG93V+g4HmEMCSxv+JVf2F2ZvrcRLigX+sj88zZeHuhnqUhCCqhdhZao5/7AaY7K1r70JH6/hV0mi8refHCj+SgbLLvsKeM17XfiiXK8ZICTQo5RfsZnqEsumrVqu5tNDO9QM5HEuiY/P14ITbJDvSkI4NAC7kJFeVwwIDAQAB"
+  }
+}

--- a/domains/send.wisesplit.json
+++ b/domains/send.wisesplit.json
@@ -1,0 +1,16 @@
+{
+  "description": "Resend sending subdomain",
+  "owner": {
+    "username": "darpanvedi0",
+    "email": "darpanvedi0@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.us-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}

--- a/domains/wisesplit.json
+++ b/domains/wisesplit.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "darpanvedi0",
+    "email": "darpanvedi0@gmail.com"
+  },
+  "records": {
+    "URL": "https://web-zeta-two-67.vercel.app"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live: https://wisesplit.is-a.dev once merged (currently reachable directly at https://web-zeta-two-67.vercel.app).

<img width="1408" height="1154" alt="image" src="https://github.com/user-attachments/assets/7d6d70f7-8786-469f-915c-dfdb4178fb2a" />

# Website Purpose

WiseSplit is a personal side project I built to split shared expenses with friends (an alternative to Splitwise). It's free, unmonetized, and not run as a business. This request registers the root subdomain plus three nested subdomains used purely for outbound-email DNS configuration (SPF/DKIM/DMARC via Resend), so my app's password-reset emails don't land in spam.
