### PR TITLE
Register tidewatch.is-a.dev

### DIFF
--- a/domains/tidewatch.json
+++ b/domains/tidewatch.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "difik-hub",
+    "email": "sandrakaran@onet.pl"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `tidewatch.is-a.dev` for **TideWatch** — an open-source crypto market tracker.

- **Site:** https://tidewatchi.vercel.app
- **Repo:** https://github.com/difik-hub/TideWatch
- **Hosting:** Vercel (CNAME → cname.vercel-dns.com)

Real-time crypto prices (Binance WebSocket), plain-language market summaries, portfolio & alerts, PWA + Telegram Mini App. Built with React + Vite.