### PR TITLE
Add xcheck.is-a.dev

### DIFF
--- a/domains/xcheck.json
+++ b/domains/xcheck.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "junoedibagyo",
+    "email": "junoedibagyo@gmail.com"
+  },
+  "records": {
+    "CNAME": "48df8f73-4c02-4772-9a02-51ce289383de.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
## Subdomain Registration

- **Subdomain:** xcheck.is-a.dev
- **CNAME:** 48df8f73-4c02-4772-9a02-51ce289383de.cfargotunnel.com (Cloudflare Tunnel)
- **Purpose:** Twitter shadowban checker dashboard — public tool for checking Twitter/X account shadowban status, ghost tweet detection, and tweet management
- **Owner:** @junoedibagyo

The subdomain points to a Cloudflare Tunnel (cfargotunnel.com) hosting a self-hosted Twitter analytics dashboard.