### PR TITLE
feat: add _vercel.jahangeershaik.is-a.dev

### DIFF
--- a/domains/_vercel.jahangeershaik.json
+++ b/domains/_vercel.jahangeershaik.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "jahangeershaik997-dev",
+        "email": "jahangeershaik997@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=jahangeershaik.is-a.dev,d160876d3e504daa4d84"
+    }
+}


### PR DESCRIPTION
Adds a TXT record for Vercel domain verification of my existing subdomain [jahangeershaik.is-a.dev](https://github.com/is-a-dev/register/blob/main/domains/jahangeershaik.json) (registered in #41572).

Vercel requires this TXT record to verify the domain and issue an SSL certificate:

```
TXT _vercel.jahangeershaik.is-a.dev = vc-domain-verify=jahangeershaik.is-a.dev,d160876d3e504daa4d84
```

- Owner: @jahangeershaik997-dev (same as parent domain)
- Site: portfolio hosted on Vercel