### PR TITLE
Register sparkiq.is-a.dev

### DIFF
--- a/domains/sparkiq.json
+++ b/domains/sparkiq.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "MidhunAkash",
+    "email": "sparkiq.dummy@example.com"
+  },
+  "records": {
+    "CNAME": "sparkiq.ezil.work"
+  }
+}


### PR DESCRIPTION
### Purpose of your domain
Hosting the SparkIQ frontend app (dev preview) via a Cloudflare Tunnel.

### Domain
sparkiq.is-a.dev -> CNAME sparkiq.ezil.work