### PR TITLE
Register lesignal.is-a.dev (email sending via Resend)

### DIFF
--- a/domains/lesignal.json
+++ b/domains/lesignal.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "dolslucas2003-byte",
+    "email": "291834406+dolslucas2003-byte@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "le-signal.vercel.app"
+  }
+}

--- a/domains/resend._domainkey.lesignal.json
+++ b/domains/resend._domainkey.lesignal.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "dolslucas2003-byte",
+    "email": "291834406+dolslucas2003-byte@users.noreply.github.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCr2lyL1YV2nOI4L1dtFGNUwAjseIbyAU4TCiDJ9C2prDyl4gERUETMm58axvbyb0KeWc8ccsDUz9UeZQe9PfTU8WPuwbYl8sLcExHMy1ZjOkHM6OrePf6ivNm53hmqGA9DVYgCkiF2LhLZ/ueK/m8Deg2iEXRGYIpkv/brLCB3/QIDAQAB"
+  }
+}

--- a/domains/send.lesignal.json
+++ b/domains/send.lesignal.json
@@ -1,0 +1,17 @@
+{
+  "owner": {
+    "username": "dolslucas2003-byte",
+    "email": "291834406+dolslucas2003-byte@users.noreply.github.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.eu-west-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": [
+      "v=spf1 include:amazonses.com ~all"
+    ]
+  }
+}


### PR DESCRIPTION
Registering `lesignal.is-a.dev` for a personal side project (a small newsletter). Adds:
- `domains/lesignal.json` — base registration, CNAME to my Vercel app.
- `domains/send.lesignal.json` — SPF (TXT) + MX records required by Resend to send email.
- `domains/resend._domainkey.lesignal.json` — DKIM (TXT) record required by Resend.

No website hosting needed beyond the CNAME, this is purely for email sending authentication.