### PR TITLE
Register aiferry.is-a.dev

### DIFF
--- a/domains/_vercel.aiferry.json
+++ b/domains/_vercel.aiferry.json
@@ -3,6 +3,6 @@
     "username": "gaodaqiang237-cyber"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "TXT": "vc-domain-verify=aiferry.is-a.dev,11c880d10f84a345ac0f"
   }
 }

--- a/domains/aiferry.json
+++ b/domains/aiferry.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "gaodaqiang237-cyber"
+  },
+  "records": {
+    "CNAME": "underlying-unsubscribe-breakfast-accessible.trycloudflare.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Link: https://underlying-unsubscribe-breakfast-accessible.trycloudflare.com/login

Screenshot:

![Website preview](https://image.thum.io/get/width/1200/crop/800/noanimate/https://underlying-unsubscribe-breakfast-accessible.trycloudflare.com/login)

# Website Purpose

This subdomain is for my personal developer dashboard and OpenAI-compatible API testing dashboard. It is used for development/testing and is not for commercial use.
