### PR TITLE
Register jobsforge.is-a.dev

### DIFF
--- a/domains/jobsforge.json
+++ b/domains/jobsforge.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "ogungbadeshalom"
+    },
+    "records": {
+        "A": [
+            "167.233.41.251"
+        ]
+    },
+    "proxied": true
+}


### PR DESCRIPTION
## Registration Request

- **Subdomain:** jobsforge.is-a.dev
- **A record:** 167.233.41.251
- **Purpose:** Self-hosted job application tracking platform

This domain points to a self-hosted instance of a job application tracking platform.