### PR TITLE
Register luhaodai.is-a.dev

### DIFF
--- a/domains/luhaodai.json
+++ b/domains/luhaodai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "luhaodai",
+    "email": "1510316628@qq.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/luhaodai.json
+++ b/domains/luhaodai.json
@@ -3,7 +3,7 @@
     "username": "luhaodai",
     "email": "1510316628@qq.com"
   },
-  "record": {
+  "records": {
     "CNAME": "cname.vercel-dns.com"
   }
 }


### PR DESCRIPTION
## Domain Registration

### Subdomain
luhaodai.is-a.dev

### Website Preview
https://my-resume-sand-three.vercel.app/

![Website Preview](https://my-resume-sand-three.vercel.app/)

### Purpose
个人技术简历网站，展示 AI 数据开发工程师的技能、项目经历和教育背景。

### Requirements
- [x] 我已阅读 [注册要求文档](https://github.com/is-a-dev/register/blob/main/docs/PR_REQUIREMENTS.md)
- [x] 我的网站有实际内容（不是空页面）
- [x] 我不会将此域名用于商业用途
- [x] 我不会将此域名用于违法内容
- [x] 我的域名文件格式正确（`domains/luhaodai.json`）
- [x] 我已配置正确的 DNS 记录指向我的网站
- [x] 我确认此域名不侵犯任何商标或版权

### Website Description
- 个人简历（AI 数据开发方向）
- 技术栈：LangChain、LangGraph、Hadoop、Spark、Flink 等
- 项目展示：数据治理智能助手、公交司机健康大数据治理平台
- 部署平台：Vercel