### PR TITLE
Register memzy.is-a.dev

### DIFF
--- a/domains/memzy.json
+++ b/domains/memzy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "alexkun4-lgtm",
+        "email": "alexkun4@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live at: https://memzy-pearl.vercel.app

Sign-in (landing):

![memzy sign-in](https://raw.githubusercontent.com/alexkun4-lgtm/register/memzy-assets/assets/memzy-signin.png)

Inside the app (demo data):

![memzy dashboard](https://raw.githubusercontent.com/alexkun4-lgtm/register/memzy-assets/assets/memzy-dashboard.png)

# Website Purpose

memzy is a personal software project I built and actively develop — an open, self-hosted "second brain" PWA (Next.js 15 / React 19 / Drizzle / Postgres) with AI-assisted note capture, a calendar, and share-target ingestion from Android. It is completely non-commercial: it's used by me and my partner as our shared note vault, and it doubles as the main portfolio piece of my development work.

The subdomain will point at the existing Vercel deployment (CNAME to `cname.vercel-dns.com`). A stable domain lets the app move its authentication to a production instance (auth providers don't issue production credentials for `*.vercel.app`), which is the last step to making the PWA fully reliable as an installed app.
