### PR TITLE
Register quantos.is-a.dev

### DIFF
--- a/domains/quantos.json
+++ b/domains/quantos.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Clappedbytxger",
+    "email": "robinhumberg@gmx.de"
+  },
+  "records": {
+    "CNAME": "clappedbytxger.github.io"
+  }
+}


### PR DESCRIPTION
Registering **quantos.is-a.dev** for Quant OS — a quant research & backtesting desktop app. CNAME points to the GitHub Pages landing site (clappedbytxger.github.io). Site is live and self-hosted; will add the CNAME file on the Pages repo once merged. Thanks!