### PR TITLE
Added DKIM, SPF/MX, and DMARC records for Resend email sending on root-om.is-a.dev.

### DIFF
--- a/domains/_dmarc.root-om.json
+++ b/domains/_dmarc.root-om.json
@@ -1,0 +1,6 @@
+{
+  "owner": { "username": "darshanuniversity17", "email": "darshanuniversity792@gmail.com" },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/resend._domainkey.root-om.json
+++ b/domains/resend._domainkey.root-om.json
@@ -1,0 +1,6 @@
+{
+  "owner": { "username": "darshanuniversity17", "email": "darshanuniversity792@gmail.com" },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDOk0V3+d7UYns3U0qgPjqNQi6F3semJoIvlQPI+CofOSh3j/c7QaTV5zcQhtcMPOv8kN4dBvLUIzmUvdWKeG2QgRXXzVQJC770EtC1zKB9t03N0bNIsrYjGmwHattUpq9T1j00ymjxosESPOTk12xFHfwEmUYDt8UWAxQUG5RZSQIDAQAB"
+  }
+}

--- a/domains/send.root-om.json
+++ b/domains/send.root-om.json
@@ -1,0 +1,7 @@
+{
+  "owner": { "username": "darshanuniversity17", "email": "darshanuniversity792@gmail.com" },
+  "records": {
+    "MX": [{ "target": "feedback-smtp.ap-northeast-1.amazonses.com", "priority": 10 }],
+    "TXT": ["v=spf1 include:amazonses.com ~all"]
+  }
+}


### PR DESCRIPTION
Added DKIM, SPF/MX, and DMARC records for Resend email sending on root-om.is-a.dev.

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://root-om.is-a.dev

<img width="2487" height="1210" alt="image" src="https://github.com/user-attachments/assets/9331d7bf-c481-434e-9e42-dd2aa29d35cb" />


# Website Purpose
Personal portfolio site showcasing my software development projects. This PR adds DNS records to enable transactional email sending via Resend alongside the existing Zoho Mail setup.