### PR TITLE
Register woofwhispers-hash.is-a.dev and thinkoutloud.woofwhispers-hash.is-a.dev

### DIFF
--- a/domains/thinkoutloud.json
+++ b/domains/thinkoutloud.json
@@ -1,0 +1,9 @@
+
+  "owner": {
+    "username": "woofwhispers-hash",
+    "email": "woofwhispers@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/thinkoutloud.json
+++ b/domains/thinkoutloud.json
@@ -1,9 +1,9 @@
 {
-    "owner": {
-          "username": "woofwhispers-hash",
-          "email": "woofwhispers@gmail.com"
-    },
-    "record": {
-          "CNAME": "cname.vercel-dns.com"
-    }
+      "owner": {
+              "username": "woofwhispers-hash",
+              "email": "woofwhispers@gmail.com"
+      },
+      "records": {
+              "CNAME": "cname.vercel-dns.com"
+      }
 }

--- a/domains/thinkoutloud.json
+++ b/domains/thinkoutloud.json
@@ -1,9 +1,9 @@
-
-  "owner": {
-    "username": "woofwhispers-hash",
-    "email": "woofwhispers@gmail.com"
-  },
-  "record": {
-    "CNAME": "cname.vercel-dns.com"
-  }
+{
+    "owner": {
+          "username": "woofwhispers-hash",
+          "email": "woofwhispers@gmail.com"
+    },
+    "record": {
+          "CNAME": "cname.vercel-dns.com"
+    }
 }

--- a/domains/thinkoutloud.json
+++ b/domains/thinkoutloud.json
@@ -1,9 +1,0 @@
-{
-      "owner": {
-              "username": "woofwhispers-hash",
-              "email": "woofwhispers@gmail.com"
-      },
-      "records": {
-              "CNAME": "cname.vercel-dns.com"
-      }
-}

--- a/domains/thinkoutloud.woofwhispers-hash.json
+++ b/domains/thinkoutloud.woofwhispers-hash.json
@@ -1,0 +1,10 @@
+{
+  "description": "Think Out Loud - AI-powered private journaling app",
+  "owner": {
+    "username": "woofwhispers-hash",
+    "email": "woofwhispers@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/woofwhispers-hash.json
+++ b/domains/woofwhispers-hash.json
@@ -1,10 +1,10 @@
 {
-      "description": "GitHub developer profile for woofwhispers-hash",
-      "owner": {
-              "username": "woofwhispers-hash",
-              "email": "woofwhispers@gmail.com"
-      },
-      "records": {
-              "A": ["185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153"]
-      }
+        "description": "Developer portfolio for woofwhispers-hash",
+        "owner": {
+                  "username": "woofwhispers-hash",
+                  "email": "woofwhispers@gmail.com"
+        },
+        "records": {
+                  "CNAME": "woofwhispers-hash.github.io"
+        }
 }

--- a/domains/woofwhispers-hash.json
+++ b/domains/woofwhispers-hash.json
@@ -1,10 +1,10 @@
-
-  "description": "Personal developer domain for woofwhispers-hash",
-  "owner": {
-    "username": "woofwhispers-hash",
-    "email": "woofwhispers@gmail.com"
-  },
-  "records": {
-    "CNAME": "woofwhispers-hash.github.io"
-  }
+{
+    "description": "Personal developer domain for woofwhispers-hash",
+    "owner": {
+          "username": "woofwhispers-hash",
+          "email": "woofwhispers@gmail.com"
+    },
+    "records": {
+          "CNAME": "woofwhispers-hash.github.io"
+    }
 }

--- a/domains/woofwhispers-hash.json
+++ b/domains/woofwhispers-hash.json
@@ -1,0 +1,10 @@
+
+  "description": "Personal developer domain for woofwhispers-hash",
+  "owner": {
+    "username": "woofwhispers-hash",
+    "email": "woofwhispers@gmail.com"
+  },
+  "records": {
+    "CNAME": "woofwhispers-hash.github.io"
+  }
+}

--- a/domains/woofwhispers-hash.json
+++ b/domains/woofwhispers-hash.json
@@ -1,10 +1,10 @@
 {
-    "description": "Personal developer domain for woofwhispers-hash",
-    "owner": {
-          "username": "woofwhispers-hash",
-          "email": "woofwhispers@gmail.com"
-    },
-    "records": {
-          "CNAME": "woofwhispers-hash.github.io"
-    }
+      "description": "GitHub developer profile for woofwhispers-hash",
+      "owner": {
+              "username": "woofwhispers-hash",
+              "email": "woofwhispers@gmail.com"
+      },
+      "records": {
+              "A": ["185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153"]
+      }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

- woofwhispers-hash.is-a.dev - developer portfolio at https://woofwhispers-hash.github.io (live GitHub Pages site showcasing software projects)
- thinkoutloud.woofwhispers-hash.is-a.dev - nested subdomain for Think Out Loud, an AI-powered journaling web app I built and deployed on Vercel, currently live at https://deployment-puce-nu.vercel.app

# Website Purpose

woofwhispers-hash.is-a.dev is my developer portfolio site. thinkoutloud.woofwhispers-hash.is-a.dev points to Think Out Loud, a personal software project (an AI-powered private journaling app) that I built and deployed myself.