### PR TITLE
Register julien-boucher.is-a.dev

### DIFF
--- a/domains/julien-boucher.json
+++ b/domains/julien-boucher.json
@@ -1,0 +1,9 @@
+{
+  "description": "Personal website of Julien Boucher",
+  "owner": {
+    "username": "jboucherlab"
+  },
+  "records": {
+    "A": ["57.131.50.161"]
+  }
+}


### PR DESCRIPTION
Registering julien-boucher.is-a.dev for my personal website, pointing to my VPS (A record).

- [x] I have read and agree to the [Terms of Service](https://is-a.dev/terms)
- [x] The file is in the `domains` directory and follows the documented JSON structure
- [x] This domain is for personal use