### PR TITLE
Register ignite-pr-checker.is-a.dev

### DIFF
--- a/domains/ignite-pr-checker.json
+++ b/domains/ignite-pr-checker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "anton-vinogradov",
+    "email": "av@apache.org"
+  },
+  "records": {
+    "A": ["77.246.106.206"]
+  }
+}


### PR DESCRIPTION
Registers `ignite-pr-checker.is-a.dev` → A record to my VPS.

This re-submits #42677, which the review bot auto-closed as "not related to software development" — a false positive. `ignite-pr-checker.is-a.dev` is an **open-source continuous-integration tool for [Apache Ignite](https://ignite.apache.org) contributors**: it reads the project's TeamCity CI (ci2) and shows which tests a pull request actually broke, filtering out failures already flaky or broken on master. Source: https://github.com/anton-vinogradov/ignite-pr-checker

The bot likely saw only the login screen (the app uses per-user TeamCity access tokens, so anonymous visitors get a sign-in page). I've since updated the landing page — the `<title>`, meta description and a visible line now clearly state it's a software-development / CI tool for Apache Ignite, with a link to the open-source repository. Served over HTTPS.

Happy to adjust anything if something's off — thanks for maintaining this! 🙏