### PR TITLE
Register forfavwb.is-a.dev

### DIFF
--- a/domains/forfavwb.json
+++ b/domains/forfavwb.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "geniusonmorion-collab"
+  },
+  "records": {
+    "CNAME": "geniusonmorion-collab.github.io"
+  }
+}


### PR DESCRIPTION
### Description

Registering **forfavwb.is-a.dev** ("for favorite WB") — a landing page for the RWB conference for Wildberries marketplace sellers («Архитектура роста бизнеса для селлеров», Feb 14).

The site is live on GitHub Pages: https://geniusonmorion-collab.github.io/

The CNAME record points to `geniusonmorion-collab.github.io`; the owner username matches the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)