### PR TITLE
add sergioparissi.is-a.dev

### DIFF
--- a/domains/sergioparissi.json
+++ b/domains/sergioparissi.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"sparissiasap"},"records":{"CNAME":"sparissiasap.github.io"}}


### PR DESCRIPTION
Registering `sergioparissi.is-a.dev` → CNAME to `sparissiasap.github.io` for a personal CV/portfolio site.