### PR TITLE
Add andrew-book.is-a.dev

### DIFF
--- a/domains/andrew-book.json
+++ b/domains/andrew-book.json
@@ -3,7 +3,7 @@
     "username": "andrew37673",
     "email": "stan.mario007@gmail.com"
   },
-  "record": {
+  "records": {
     "NS": [
       "eleanor.ns.cloudflare.com",
       "syeef.ns.cloudflare.com"

--- a/domains/andrew-book.json
+++ b/domains/andrew-book.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "andrew37673",
+    "email": "stan.mario007@gmail.com"
+  },
+  "record": {
+    "NS": [
+      "eleanor.ns.cloudflare.com",
+      "syeef.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
* **Current Live Link:** https://andrew-book.pages.dev/
* **Screenshot:*
<img width="3608" height="6055" alt="image" src="https://github.com/user-attachments/assets/039ba15a-1e8a-47b6-8c48-41842c191435" />
* 

# Website Purpose
This is a personal portfolio and developer utilities website (Hugo arsenal) currently hosted on Cloudflare Pages. 

I am requesting NS records to point `andrew-book.is-a.dev` to my own Cloudflare dashboard. This will allow me to fully manage advanced caching, toggle Crawler Hints (IndexNow), and create subdomains for future development.