### PR TITLE
feat: update vercel verification token for divyaraj.is-a.dev

### DIFF
--- a/domains/_vercel.divyaraj.json
+++ b/domains/_vercel.divyaraj.json
@@ -4,6 +4,6 @@
         "email": "divyarajkathi11@gmail.com"
     },
     "records": {
-        "TXT": "vc-domain-verify=divyaraj.is-a.dev,eee654bb947d225d769a"
+        "TXT": "vc-domain-verify=www.divyaraj.is-a.dev,7f7143bbf3f885fa69dc"
     }
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://divyaraj-portfolio.vercel.app (Temporary Vercel link while domain connects)

<img width="1920" height="1080" alt="Screenshot (41)" src="https://github.com/user-attachments/assets/f7d6da18-04d6-441b-a22a-475b3e81f720" />


# Website Purpose
Updating the Vercel ownership verification TXT token to the latest value (`7f7143bbf3f885fa69dc`) to verify ownership and connect the `www` subdomain of my personal Web Developer & Chatbot Specialist portfolio.
