### PR TITLE
feat(domain): add _vercel TXT verification for yura.is-a.dev

### DIFF
--- a/domains/_vercel.yura.json
+++ b/domains/_vercel.yura.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RE-yura",
+        "email": "reyura.a@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=yura.is-a.dev,db921cd3c8e4353c6a66"
+    }
+}


### PR DESCRIPTION
Adds the Vercel domain-ownership TXT record for the already-merged `yura.is-a.dev` (#42868).

Since `is-a.dev` is on the Public Suffix List, Vercel treats `yura.is-a.dev` as an apex domain and requires a `_vercel.<domain>` TXT verification record, as described in the official guide: https://docs.is-a.dev/guides/vercel/#creating-the-domain

```json
{
    "owner": { "username": "RE-yura", "email": "reyura.a@gmail.com" },
    "records": { "TXT": "vc-domain-verify=yura.is-a.dev,..." }
}
```