### PR TITLE
Add andrew-book.is-a.dev

### DIFF
--- a/domains/andrew-book.json
+++ b/domains/andrew-book.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "andrew37673",
-    "email": "126502137+andrew37673@users.noreply.github.com"
+    "email": "annonim.mario19@gmail.com"
   },
   "records": {
     "NS": [

--- a/domains/andrew-book.json
+++ b/domains/andrew-book.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "andrew37673",
+    "email": "126502137+andrew37673@users.noreply.github.com"
+  },
+  "records": {
+    "NS": [
+      "eleanor.ns.cloudflare.com",
+      "syeef.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
* **Current Live Link:** https://andrew-book.pages.dev/
* **Screenshot:*
<img width="3837" height="1992" alt="image" src="https://github.com/user-attachments/assets/0b126e12-d332-4719-81c2-07702013380a" />
* 

# Website Purpose
This is a personal portfolio and developer utilities website (Hugo arsenal) currently hosted on Cloudflare Pages. 

I am requesting NS records to point `andrew-book.is-a.dev` to my own Cloudflare dashboard. This will allow me to fully manage advanced caching, toggle Crawler Hints (IndexNow), and create subdomains for future development.