### PR TITLE
Register marginalia.is-a.dev

### DIFF
--- a/domains/marginalia.json
+++ b/domains/marginalia.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "VforVitorio",
+    "email": "victorvegasobral@gmail.com"
+  },
+  "records": {
+    "CNAME": "vforvitorio.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

marginalia is an open-source tool that turns handwritten Kindle Scribe notebooks into Obsidian Markdown (local or cloud OCR, side-by-side review, folder-mirroring export). MIT-licensed, non-commercial, developer tooling.

- Live site: https://vforvitorio.github.io/marginalia/
- Repo: https://github.com/VforVitorio/marginalia

![marginalia website preview](https://raw.githubusercontent.com/VforVitorio/marginalia/main/docs/demo/marginalia-landing-en.png)
