### PR TITLE
Register protivon.is-a.dev

### DIFF
--- a/domains/protivon.json
+++ b/domains/protivon.json
@@ -1,0 +1,15 @@
+{
+  "owner": {
+    "username": "protivon",
+    "email": "protivon26@gmail.com"
+  },
+  "records": {
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  }
+}


### PR DESCRIPTION
Adds DNS records for protivon.is-a.dev with ImprovMX MX records and SPF TXT for email forwarding.