### PR TITLE
Register cesar.is-a.dev + www.cesar.is-a.dev

### DIFF
--- a/domains/cesar.json
+++ b/domains/cesar.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "PreciadoCaesar"
+  },
+  "records": {
+    "A": ["75.2.60.5"]
+  },
+  "proxied": true
+}

--- a/domains/www.cesar.json
+++ b/domains/www.cesar.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "PreciadoCaesar"
+  },
+  "records": {
+    "CNAME": "marvelous-monstera-f64e7c.netlify.app"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
### Subdomain
`cesar.is-a.dev` and `www.cesar.is-a.dev`

### Owner
GitHub: @PreciadoCaesar

### Website preview
The site is deployed on Netlify at [marvelous-monstera-f64e7c.netlify.app](https://marvelous-monstera-f64e7c.netlify.app)

### Records
- `cesar.is-a.dev` → A record to `75.2.60.5` (Netlify shared IP)
- `www.cesar.is-a.dev` → CNAME to `marvelous-monstera-f64e7c.netlify.app`

### Reason
Personal portfolio site for César Preciado, a software developer.