### PR TITLE
Register birkdale.is-a.dev

### DIFF
--- a/domains/birkdale.json
+++ b/domains/birkdale.json
@@ -1,0 +1,11 @@
+{
+  "description": "Birkdale Partners - email forwarding domain",
+  "owner": {
+    "username": "durexvssiccors",
+    "email": "jceasington@gmail.com"
+  },
+  "records": {
+    "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
+    "TXT": "v=spf1 include:spf.improvmx.com ~all"
+  }
+}


### PR DESCRIPTION
Registering `birkdale.is-a.dev`.

- **Purpose:** email forwarding for Birkdale Partners
- **Records:** MX (ImprovMX) + TXT (SPF)
- File: `domains/birkdale.json`

Thanks for the great service!