### PR TITLE
Register personalityswarm.is-a.dev

### DIFF
--- a/domains/personalityswarm.json
+++ b/domains/personalityswarm.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "swaggy",
+    "email": "swaggy@Shubhams-Mac-mini.local"
+  },
+  "records": {
+    "CNAME": "fd2d4a02-56ff-4829-be32-bd1fd5436ac4.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
## Register `personalityswarm.is-a.dev`

Registering the subdomain `personalityswarm.is-a.dev` which points to a Cloudflare Tunnel hosting a multi-agent AI simulation app (Personality Swarm — a real-time debate room for 16 MBTI personality AIs).

### Checklist
- [x] I have read and agreed to the [Terms of Service](https://is-a.dev/terms)
- [x] My domain file follows the correct format
- [x] I am not using this for commercial purposes
- [x] My subdomain points to my own project