### PR TITLE
Register rebecca.is-a.dev

### DIFF
--- a/domains/_vercel.rebecca.json
+++ b/domains/_vercel.rebecca.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "rebeccaKil",
+        "email": "rebeccakil8615@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=rebecca.is-a.dev,6dbcd9b40d2c1a13da69"
+    }
+}

--- a/domains/rebecca.json
+++ b/domains/rebecca.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "rebeccaKil",
+        "email": "rebeccakil8615@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live site:** https://portfolio-eosin-five-51.vercel.app

The site is a fully built, reachable deployment (Next.js / React / TypeScript). Screenshot of the live homepage:

![Portfolio homepage screenshot](https://portfolio-eosin-five-51.vercel.app/opengraph-image)

# Website Purpose

A personal **product & software portfolio** built with Next.js, React, and TypeScript. It documents software-development work — front-end architecture (a "Page API" for composing the front end without code deploys), component/API design, and an AI-assisted development workflow (Cursor, Claude Code, MCP) with direct commits and Vercel deployments. Non-commercial; it exists to share engineering case studies and development practices. Records point `rebecca.is-a.dev` to Vercel (CNAME) plus a `_vercel` TXT for domain-ownership verification.
