### PR TITLE
Update Vercel TXT verification for www.nix.is-a.dev

### DIFF
--- a/domains/_vercel.nix.json
+++ b/domains/_vercel.nix.json
@@ -5,7 +5,7 @@
   "records": {
     "TXT": [
       "vc-domain-verify=nix.is-a.dev,2e7f5f625469478687e0",
-      "vc-domain-verify=www.nix.is-a.dev,e989a63cb9e3b5b75f36"
+      "vc-domain-verify=www.nix.is-a.dev,5102987054027f9a3921"
     ]
   }
 }


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://nix-web.vercel.app

# Website Purpose

Portfolio personal de desarrollo de software.

---

**Nota:** Este PR solo actualiza el token TXT de verificación de Vercel para `www.nix.is-a.dev` en `domains/_vercel.nix.json`. El dominio ya está registrado en #42827; `nix.json` y `www.nix.json` no cambian. Vercel regeneró el token y el anterior ya no valida.

Made with [Cursor](https://cursor.com)