### PR TITLE
Register megilan.is-a.dev subdomain

### DIFF
--- a/domains/megilan.json
+++ b/domains/megilan.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Fiqiefendiahmad",
+    "email": "fiqiefendi13@gmail.com"
+  },
+  "records": {
+    "A": ["192.0.2.1"]
+  },
+  "proxied": true
+}


### PR DESCRIPTION
### Domain
megilan.is-a.dev

### Email
fiqiefendi13@gmail.com

### GitHub Username
Fiqiefendiahmad

### Reason
Personal Pi-hole monitoring dashboard and landing page, served through Cloudflare Tunnel.

### Website Preview
The domain will serve a modern landing page at `/` and a Pi-hole admin dashboard at `/admin`. The Pi-hole web interface is already running and accessible locally. Due to the domain not being live yet, a live preview is unavailable until the DNS is configured.

### Checklist
- [x] I have read and agree to the is-a.dev [Terms of Service](https://is-a.dev/terms)
- [x] I have checked the domain is available
- [x] The JSON file is in the correct format