### PR TITLE
Register grimoire.is-a.dev

### DIFF
--- a/domains/grimoire.json
+++ b/domains/grimoire.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AdwaitPro"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering grimoire.is-a.dev for Grimoire, a living notebook web app: you handwrite on a page and the book writes back in its own hand. Live at https://grimoirebook.vercel.app. CNAME to Vercel.