### PR TITLE
Fix dlzk verification TXT

### DIFF
--- a/domains/_vercel.dlzk.json
+++ b/domains/_vercel.dlzk.json
@@ -4,6 +4,6 @@
         "email": "joaopedrodelazzari2@gmail.com"
     },
     "records": {
-        "TXT": "vc-domain-verify=dlzk.is-a.dev,4213179b4O41f2652229"
+        "TXT": "vc-domain-verify=dlzk.is-a.dev,4213179b4041f2652229"
     }
 }


### PR DESCRIPTION
Fixes the verification TXT for dlzk.is-a.dev. The previous value used an O instead of 0, which kept Vercel stuck on verification.\n\nUpdated record:\n- TXT -> vc-domain-verify=dlzk.is-a.dev,4213179b4041f2652229\n\nValidation:\n- npm test