### PR TITLE
Register grimoire.is-a.dev

### DIFF
--- a/domains/grimoire.json
+++ b/domains/grimoire.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "AdwaitPro",
+        "email": "tripathiyatharth257@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Registering grimoire.is-a.dev for Grimoire, a living notebook web app where you handwrite and the book writes back. Live at https://grimoirebook.vercel.app. CNAME to Vercel (cname.vercel-dns.com). Uses the correct records schema.