### PR TITLE
Register atlascapitalk.is-a.dev for Atlas CapitalK

### DIFF
--- a/domains/atlascapitalk.json
+++ b/domains/atlascapitalk.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"DizzyAdams","email":"atlascapitalk@gmail.com"},"record":{"CNAME":"cname.vercel-dns.com"}}


### PR DESCRIPTION
Registers the free atlascapitalk.is-a.dev subdomain for Atlas CapitalK fintech SaaS (https://github.com/DizzyAdams/atlascapital). CNAME to cname.vercel-dns.com (Vercel auto-TLS). Owner: DizzyAdams. HTTPS enforced via Cloudflare since .dev is HSTS-preloaded.