### PR TITLE
Add allianceconsultoria.is-a.dev

### DIFF
--- a/allianceconsultoria.is-a.dev.json
+++ b/allianceconsultoria.is-a.dev.json
@@ -1,0 +1,17 @@
+{
+  "owner": {
+    "username": "AllianceConsultoria",
+    "email": "allianceconsultoriaal@gmail.com"
+  },
+  "records": {
+    "A": [
+      "185.199.108.153",
+      "185.199.109.153",
+      "185.199.110.153",
+      "185.199.111.153"
+    ],
+    "CNAME": [
+      "allianceconsultoria.github.io"
+    ]
+  }
+}


### PR DESCRIPTION
Requesting is-a.dev subdomain for Website Prospector project.