### PR TITLE
Register luisconese.is-a.dev

### DIFF
--- a/domains/luisconese.json
+++ b/domains/luisconese.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "luiserre"
+  },
+  "records": {
+    "CNAME": "602ec0de-5e5c-409e-a333-8808bf63db2e.cfargotunnel.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
## Domain
`luisconese.is-a.dev`

## Description
Registering a CNAME record pointing to a Cloudflare Tunnel that routes to a locally-hosted app, with Cloudflare proxy enabled.

## Checklist
- [x] I have read and understood the [rules](https://github.com/is-a-dev/register/blob/main/docs/rules.md).
- [x] I have read and understood the [contributing guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md).
