### PR TITLE
Add Vercel configuration for domain verification

### DIFF
--- a/domains/_vercel.samipevekar.json
+++ b/domains/_vercel.samipevekar.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "samipevekar"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=samipevekar.is-a.dev,bed300c18ae9ebc628cbc"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link AND screenshot of your website below. if not provided your PR will be closed with no questions asked. -->
Portfolio Website

Live URL:
https://my-portfolio-eight-xi-89.vercel.app

Screenshot:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0fcc8655-07aa-417f-9eac-bc0e5304be09" />


# Website Purpose
<!-- Please tell us the purpose or motive behind your website. For example, it is a portfolio website, etc. -->
This is my personal full-stack developer portfolio showcasing my projects, technical skills, resume, and contact information. It serves as a professional portfolio for recruiters and potential employers.