### PR TITLE
Register grimoire.is-a.dev

### DIFF
--- a/domains/grimoire.json
+++ b/domains/grimoire.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "AdwaitPro"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Registering grimoire.is-a.dev for my project, a handwriting web app. Points via CNAME to Vercel. Single file, no other changes.