### PR TITLE
Register luhaodai.is-a.dev

### DIFF
--- a/domains/luhaodai.json
+++ b/domains/luhaodai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "luhaodai",
+    "email": "1510316628@qq.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain Registration

### Subdomain
luhaodai.is-a.dev

### Website Preview
https://my-resume-sand-three.vercel.app/

### Purpose
个人技术简历网站，展示 AI 数据开发工程师的技能、项目经历和教育背景。

### Website Description
- 个人简历（AI 数据开发方向）
- 技术栈：LangChain、LangGraph、Hadoop、Spark、Flink 等
- 项目展示：数据治理智能助手、公交司机健康大数据治理平台
- 部署平台：Vercel

---

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://my-resume-sand-three.vercel.app/

![Website Screenshot](https://github.com/user-attachments/assets/0fc0ec6b-a243-4558-bf1e-2e6482f2bdbf)

# Website Purpose
个人技术简历网站，用于求职展示。包含 AI 数据开发方向的技能描述、项目经历（数据治理智能助手、公交司机健康大数据治理平台）、教育背景和荣誉奖项。使用 Next.js 开发，部署在 Vercel 上。