### PR TITLE
Register kapildas.is-a.dev

### DIFF
--- a/domains/kapildas.json
+++ b/domains/kapildas.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dasparov",
+        "email": "135219299+dasparov@users.noreply.github.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}

--- a/domains/kapildas.json
+++ b/domains/kapildas.json
@@ -4,6 +4,7 @@
         "email": "135219299+dasparov@users.noreply.github.com"
     },
     "records": {
-        "CNAME": "cname.vercel-dns.com"
+        "CNAME": "cname.vercel-dns.com",
+        "TXT": "vc-domain-verify=kapildas.is-a.dev,c199da0047647bb2c40b"
     }
 }


### PR DESCRIPTION
Registering `kapildas.is-a.dev` for a fine-art photography portfolio (static site hosted on Vercel). CNAME → cname.vercel-dns.com.