### PR TITLE
Register preflar.is-a.dev

### DIFF
--- a/domains/preflar.json
+++ b/domains/preflar.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/is-a-dev/register/main/schema.json",
   "owner": {
-    "username": "jshapiro318-cyber",
-    "email": "jshapiro318@gmail.com"
+    "username": "jshapiro318-cyber"
   },
   "records": {
     "CNAME": "vibecheck-e2oe.onrender.com"

--- a/domains/preflar.json
+++ b/domains/preflar.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/is-a-dev/register/main/schema.json",
+  "owner": {
+    "username": "jshapiro318-cyber",
+    "email": "jshapiro318@gmail.com"
+  },
+  "records": {
+    "CNAME": "vibecheck-e2oe.onrender.com"
+  }
+}


### PR DESCRIPTION
Registering `preflar.is-a.dev` for **Preflar** — a free, plain-English security & ship-readiness scanner for apps built with AI tools (Lovable, v0, Bolt, Cursor, Replit).

- Record: `CNAME` → `vibecheck-e2oe.onrender.com` (my live deployment)
- Owner: @jshapiro318-cyber

Thanks for maintaining this project! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)