### PR TITLE
Register smly.is-a.dev

### DIFF
--- a/domains/smly.json
+++ b/domains/smly.json
@@ -1,0 +1,10 @@
+﻿{
+  "owner": {
+    "username": "2045109515",
+    "email": "a9966990319@163.com"
+  },
+  "records": {
+    "CNAME": "smly.duckdns.org"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Register smly.is-a.dev for my personal API gateway and development services.

Records:
- CNAME: smly.duckdns.org
- Proxied: true