### PR TITLE
Add Vercel TXT verification for luhaodai.is-a.dev

### DIFF
--- a/domains/_vercel.luhaodai.json
+++ b/domains/_vercel.luhaodai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "luhaodai",
+    "email": "1510316628@qq.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=luhaodai.is-a.dev,86493ab727ed59cb91f1"
+  }
+}


### PR DESCRIPTION
## Adding Vercel TXT verification record

As requested by @notamitgamer in previous PR, adding the Vercel TXT verification record for luhaodai.is-a.dev.

Reference: https://docs.is-a.dev/guides/vercel/