### PR TITLE
Add Vercel domain configuration for alwin

### DIFF
--- a/domains/_vercel.alwin.json
+++ b/domains/_vercel.alwin.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "alwin-1107",
+    "email": "alwinmathew1107@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=alwin.is-a.dev,c64c2eb5f6f78dfbb24a"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a-dev.terms).
- [x] My file is following the [domain structure](https://docs.is-a-dev.domain-structure).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://portfolio-silk-alpha-12vybn52ty.vercel.app

<img width="1919" height="900" alt="image" src="https://github.com/user-attachments/assets/98ec06a8-8b6d-4b43-957d-4a4f3c5bb4e7" />

# Website Purpose

This file adds a Vercel domain verification (TXT) record for my personal developer portfolio at alwin.is-a.dev, which is already registered via a previous merged PR.