### PR TITLE
Register base-token-intel.is-a.dev

### DIFF
--- a/domains/base-token-intel.json
+++ b/domains/base-token-intel.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ostapondo",
+    "email": "ostap.belei@gmail.com"
+  },
+  "records": {
+    "CNAME": "base-token-intel.onrender.com"
+  }
+}


### PR DESCRIPTION
Registering `base-token-intel.is-a.dev` — a pay-per-call Base L2 on-chain data API for AI agents (x402 protocol). CNAME points to a Render web service.

- [x] Valid JSON
- [x] CNAME record to base-token-intel.onrender.com
- [x] I have read the docs