### PR TITLE
Add _vercel TXT verification record for yura.is-a.dev

### DIFF
--- a/domains/_vercel.yura.json
+++ b/domains/_vercel.yura.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "RE-yura",
+        "email": "reyura.a@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=yura.is-a.dev,db921cd3c8e4353c6a66"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://yura.vercel.app

![Website preview](https://raw.githubusercontent.com/RE-yura/register/assets/site-preview.png)

# Website Purpose

Personal portfolio and tech blog of a software engineer. The site showcases my works and skills, and hosts technical articles about control engineering and web development.

The root domain `yura.is-a.dev` was approved and merged in #42868 (CNAME to Vercel). This PR adds the companion `_vercel.yura.json` TXT record required by Vercel for domain ownership verification, following the official guide: https://docs.is-a.dev/guides/vercel/#creating-the-domain