### PR TITLE
Add rpbuilder.is-a.dev

### DIFF
--- a/domains/rpbuilder.json
+++ b/domains/rpbuilder.json
@@ -1,0 +1,9 @@
+﻿{
+  "owner": {
+    "username": "offjext",
+    "email": "276336429+offjext@users.noreply.github.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
## Description
Registering **rpbuilder.is-a.dev** for a free Minecraft resource pack builder.

- Site: https://rpbuilder.vercel.app
- Records: A -> 216.198.79.1 (Vercel)

Will add Vercel TXT verification file after domain is added in Vercel dashboard if required.

Made with [Cursor](https://cursor.com)