### PR TITLE
fix(ranveer.json): use CNAME instead of A records for GitHub Pages

### DIFF
--- a/domains/ranveer.json
+++ b/domains/ranveer.json
@@ -4,12 +4,6 @@
         "email": "ranveergour781@gmail.com"
     },
     "records": {
-        "A": [
-            "185.199.108.153",
-            "185.199.109.153",
-            "185.199.110.153",
-            "185.199.111.153"
-        ],
-        "TXT": "google-site-verification=nKoEiD8mhnvf8fc6TU7-8GXYc6sdysw818KRWF3z7f4"
+        "CNAME": "ranveersingh1997.github.io"
     }
 }


### PR DESCRIPTION
## Summary
- `ranveer.is-a.dev` was pointed at GitHub Pages via static `A` records, which GitHub Pages flags as `InvalidARecordError` for custom domains and is also part of why this domain was caught by #43271 (disconnected GitHub Pages domain, subdomain-takeover risk).
- Switches to a `CNAME` record pointing at `ranveersingh1997.github.io`, matching the setup recommended in the [GitHub Pages guide](https://docs.is-a.dev/guides/github-pages/).
- Custom domain `ranveer.is-a.dev` is already configured in the Pages settings for `RanveerSingh1997/RanveerSingh1997.github.io`; this just fixes the DNS record type it complained about.

## Test plan
- [x] Verified against `tests/records.test.js` validation rules (CNAME record alone, valid hostname, not self-referential, not in `disallowed-cnames.json`)
- [ ] After merge, confirm `https://ranveer.is-a.dev` serves over HTTPS with a domain-matching cert