### PR TITLE
feat(ranveer.json): add Google Search Console domain verification TXT

### DIFF
--- a/domains/ranveer.json
+++ b/domains/ranveer.json
@@ -4,6 +4,8 @@
         "email": "ranveergour781@gmail.com"
     },
     "records": {
-        "CNAME": "ranveersingh1997.github.io"
-    }
+        "CNAME": "ranveersingh1997.github.io",
+        "TXT": "google-site-verification=nKoEiD8mhnvf8fc6TU7-8GXYc6sdysw818KRWF3z7f4"
+    },
+    "proxied": true
 }


### PR DESCRIPTION
## Summary
- Adds the Google Search Console domain-property TXT verification record for `ranveer.is-a.dev`, needed to set it up as a verified publisher on pub.dev.
- Since the schema doesn't allow `CNAME` + `TXT` together unless proxied (see `tests/records.test.js`), this sets `"proxied": true` (same pattern used by `domains/af.json`).
- `CNAME` still points at `ranveersingh1997.github.io`, unchanged from #43412.

## Test plan
- [x] Verified against `tests/records.test.js` validation rules (CNAME + TXT allowed together only when `proxied: true`, no A/AAAA present)
- [ ] After merge, confirm Search Console can verify the TXT record and `https://ranveer.is-a.dev` still resolves correctly