### PR TITLE
Add para.is-a.dev

### DIFF
--- a/domains/para.json
+++ b/domains/para.json
@@ -1,0 +1,13 @@
+{
+  "description": "Domain for self-hosted services, dynamic DNS, Cloudflare Tunnel, and homelab multi-service routing",
+  "owner": {
+    "username": "pzx521521",
+    "email": "pzx521521@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "gigi.ns.cloudflare.com",
+      "john.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your JSON file is in the domains directory, the name is valid, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. -->
- [x] I have provided contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [x] I have provided a preview of my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
The target services are self-hosted and will be reachable under `para.is-a.dev` only after NS delegation is active. This domain will be used with Cloudflare Tunnel for my personal developer homelab and multiple non-commercial services.

# Website Purpose
`para.is-a.dev` is for my personal developer homelab. I need NS delegation because I plan to route multiple self-hosted services through Cloudflare Tunnel, use dynamic DNS, and manage several service subdomains. Managing those records through individual PRs is impractical because the tunnel and homelab service endpoints may change during testing. The domain is non-commercial and will be used for software development and infrastructure experiments.