### PR TITLE
Register astroweb.is-a.dev

### DIFF
--- a/domains/astroweb.json
+++ b/domains/astroweb.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Ast2001fr"
+  },
+  "records": {
+    "CNAME": "astroweb-55l.pages.dev"
+  }
+}


### PR DESCRIPTION
Registering `astroweb.is-a.dev` — a `CNAME` to a Cloudflare Pages site.

- **Subdomain:** astroweb.is-a.dev
- **Record:** CNAME → astroweb-55l.pages.dev
- **Use:** a free open web planetarium (stars, deep-sky, planets, ISS/satellites, eclipses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)