### PR TITLE
Update tanseer.is-a.dev owner to Sirius0x

### DIFF
--- a/domains/tanseer.json
+++ b/domains/tanseer.json
@@ -1,8 +1,8 @@
 {
   "owner": {
-    "username": "sheiktanseer"
+    "username": "Sirius0x"
   },
   "records": {
-    "URL": "https://github.com/sheiktanseer"
+    "URL": "https://github.com/Sirius0x"
   }
 }


### PR DESCRIPTION
My GitHub account was renamed from `sheiktanseer` to `Sirius0x`. The old username no longer resolves (github.com/sheiktanseer now 404s), which breaks the URL redirect in `domains/tanseer.json`.

This updates `owner.username` and the `URL` record to `Sirius0x` so the redirect works again. No other changes.