### PR TITLE
feat: add kirana.is-a.dev

### DIFF
--- a/domains/kirana.json
+++ b/domains/kirana.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "0xN404T",
+    "email": "0xN404T@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "0xn404t.github.io"
+  }
+}


### PR DESCRIPTION
## Adding kirana.is-a.dev

**Purpose:** Wedding invitation website for Kirana & Aditya
**Website:** https://0xn404t.github.io/wedding-kirana-aditya/
**CNAME target:** 0xn404t.github.io

This domain will host a premium wedding invitation page.