### PR TITLE
Add: shangan-plan.is-a.dev

### DIFF
--- a/domains/shangan-plan.json
+++ b/domains/shangan-plan.json
@@ -1,12 +1,12 @@
 {
-    "description": "上岸计划 公考备考站",
+    "description": "上岸计划 - 公考备考刷题网站",
     "repo": "https://github.com/tong666-bit/shangan-plan",
     "owner": {
         "username": "tong666-bit",
         "email": "tong666-bit@users.noreply.github.com"
     },
-    "record": {
-        "CNAME": "shangan-web-1452195195.cos-website.ap-hongkong.myqcloud.com"
+    "records": {
+        "CNAME": "tong666-bit.github.io"
     },
-    "proxied": false
+    "proxied": true
 }

--- a/domains/shangan-plan.json
+++ b/domains/shangan-plan.json
@@ -1,0 +1,12 @@
+{
+    "description": "上岸计划 公考备考站",
+    "repo": "https://github.com/tong666-bit/shangan-plan",
+    "owner": {
+        "username": "tong666-bit",
+        "email": "tong666-bit@users.noreply.github.com"
+    },
+    "record": {
+        "CNAME": "shangan-web-1452195195.cos-website.ap-hongkong.myqcloud.com"
+    },
+    "proxied": false
+}

--- a/domains/shangan-plan.json
+++ b/domains/shangan-plan.json
@@ -1,9 +1,8 @@
 {
-    "description": "上岸计划 - 公考备考刷题网站",
+    "description": "ShangAn Plan - civil service exam prep static site",
     "repo": "https://github.com/tong666-bit/shangan-plan",
     "owner": {
-        "username": "tong666-bit",
-        "email": "tong666-bit@users.noreply.github.com"
+        "username": "tong666-bit"
     },
     "records": {
         "CNAME": "tong666-bit.github.io"


### PR DESCRIPTION
Free subdomain for Chinese-accessible static site (上岸计划 / civil service exam prep).

CNAME -> shangan-web-1452195195.cos-website.ap-hongkong.myqcloud.com
proxied: false