### PR TITLE
Register tradercockpit.is-a.dev

### DIFF
--- a/domains/tradercockpit.json
+++ b/domains/tradercockpit.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "javin23863",
+    "email": "joshuajacob2386@gmail.com"
+  },
+  "records": {
+    "CNAME": "javin23863.github.io"
+  }
+}


### PR DESCRIPTION
Registering **tradercockpit.is-a.dev** → CNAME `javin23863.github.io` (GitHub Pages).

Site: honest trading-strategy backtesting tool landing page with an interactive in-browser demo — currently live at https://javin23863.github.io/tradercockpit/

- [x] I have read and agree to the terms
- [x] The site is reachable and my own