### PR TITLE
Add wook.is-a.dev subdomain

### DIFF
--- a/domains/wook.json
+++ b/domains/wook.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "teddyyeo"
+  },
+  "records": {
+    "A": ["168.107.17.82"]
+  }
+}

--- a/domains/wook.json
+++ b/domains/wook.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "teddyyeo"
+    "username": "teddyyeo",
+    "email": "haribozyme@korea.ac.kr"
   },
   "records": {
     "A": ["168.107.17.82"]


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
<!-- Provide a link AND screenshot of your website below. -->
Live site: http://168.107.17.82 (will resolve at wook.is-a.dev once merged)

Note: this is a resubmission of #43438 — that PR was correctly flagged as having
placeholder/template content ("Your Name" etc.). The site has since been fully
rewritten with real personal content (education, projects, experience) and no
longer contains any placeholder text.

<!-- ADD YOUR SCREENSHOT HERE by dragging an image into this box on GitHub -->
<img width="856" height="478" alt="image" src="https://github.com/user-attachments/assets/57c0695e-91c7-4d75-a2cc-e1012d4e7b60" />

# Website Purpose
Personal CV / portfolio website (Computer Science / Cyber Security student) showcasing
my background, education (BOB, 42 Seoul, Korea University), projects, CTF work, and an
interactive force-directed knowledge graph of my experience.
