### PR TITLE
Register skim.is-a.dev

### DIFF
--- a/domains/skim.json
+++ b/domains/skim.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "nikserg",
+        "email": "nikitadimitrov@gmail.com"
+    },
+    "records": {
+        "CNAME": "nikserg.github.io"
+    }
+}


### PR DESCRIPTION
Registering skim.is-a.dev for Skim - a free & open-source (MIT) native email client for Windows.

**Live preview:** https://nikserg.github.io/skim
**Source:** https://github.com/nikserg/skim

The subdomain points a CNAME to nikserg.github.io (GitHub Pages), which currently serves the site.