### PR TITLE
Register pinloc.is-a.dev

### DIFF
--- a/domains/pinloc.json
+++ b/domains/pinloc.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AmanKabra1",
+    "email": "AmanKabra1@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "live-location-share-yph1.onrender.com"
+  }
+}

--- a/domains/pinloc.json
+++ b/domains/pinloc.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "AmanKabra1",
-    "email": "AmanKabra1@users.noreply.github.com"
+    "email": "amankabra.it24@gmail.com"
   },
   "records": {
     "CNAME": "live-location-share-yph1.onrender.com"


### PR DESCRIPTION
Registering `pinloc.is-a.dev` with a CNAME to my Render deployment (PinLoc — a free, privacy-first live location-sharing PWA).

- Subdomain: pinloc
- Record: CNAME -> live-location-share-yph1.onrender.com
- Purpose: custom domain for my open side-project

Thanks for maintaining is-a.dev! 🙏