### PR TITLE
Add poketest.is-a.dev

### DIFF
--- a/domains/poketest.json
+++ b/domains/poketest.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "Dotoria",
+    "email": "dotless13@gmail.com"
+  },
+  "description": "포켓몬 타입 성격 테스트",
+  "repo": "https://github.com/Dotoria/web_programming",
+  "records": {
+    "URL": "https://poketest-app.dotless13.workers.dev"
+  }
+}


### PR DESCRIPTION
포켓몬 타입 성격 테스트 사이트(https://github.com/Dotoria/web_programming)의 짧은 무료 서브도메인 등록입니다. Cloudflare Worker(*.workers.dev)로 배포되어 있어 URL 레코드로 리다이렉트합니다.