### PR TITLE
Add Vercel TXT verification for alonhalawi.is-a.dev

### DIFF
--- a/domains/_vercel.alonhalawi.json
+++ b/domains/_vercel.alonhalawi.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "AlonHal",
+    "email": "alonhmaster@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=alonhalawi.is-a.dev,8cd977100a06576f5599"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live: https://alon-halawi-portfolio.vercel.app

Follow-up to #42810 (already merged) — adding the `_vercel.alonhalawi` TXT verification record required by the [Vercel setup guide](https://docs.is-a.dev/guides/vercel/) to complete domain verification on Vercel's side. No change to the existing `alonhalawi.json` file.

# Website Purpose

Personal portfolio/resume site for a senior software engineer, showcasing career history, skills, and contact info.