### PR TITLE
Register gpsimpro.is-a.dev

### DIFF
--- a/domains/gpsimpro.json
+++ b/domains/gpsimpro.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "otabek-platform",
+    "email": "otabek.platform@gmail.com"
+  },
+  "record": {
+    "CNAME": "disrupt-rink-playable.ngrok-free.dev"
+  }
+}


### PR DESCRIPTION
Registering gpsimpro.is-a.dev for GPS tracking service.
CNAME points to ngrok tunnel for Traccar server.