### PR TITLE
Register seiri-list.is-a.dev (+ Resend email records)

### DIFF
--- a/domains/_dmarc.seiri-list.json
+++ b/domains/_dmarc.seiri-list.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — DMARC policy.",
+    "records": {
+        "TXT": [
+            "v=DMARC1; p=none;"
+        ]
+    }
+}

--- a/domains/resend._domainkey.seiri-list.json
+++ b/domains/resend._domainkey.seiri-list.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — Resend DKIM public key.",
+    "records": {
+        "TXT": [
+            "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCTuxgS4QqNZ98UGlXdN4VfmbdauV3AKy/FIntpLQ54XMmBwLE3saFBSTIhDH8ynJlE+RiRtHMmkeB+9wPqnDxpKxvso4kpBRviHMY7hMFU/qg2qsmYClRWrWL3oze+az9ZMyk9RRV7Dz9q0xAod2aYoy12UurkMrDrWtJq6QyhnQIDAQAB"
+        ]
+    }
+}

--- a/domains/seiri-list.json
+++ b/domains/seiri-list.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — catálogo de revistas, cómics y mangas (app en Vercel).",
+    "repo": "https://github.com/ToroFelipe/Seiri",
+    "records": {
+        "URL": "https://seiri-list.vercel.app"
+    }
+}

--- a/domains/send.seiri-list.json
+++ b/domains/send.seiri-list.json
@@ -1,0 +1,15 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — Resend sending subdomain (SPF + return-path MX).",
+    "records": {
+        "MX": [
+            { "target": "feedback-smtp.sa-east-1.amazonses.com", "priority": 10 }
+        ],
+        "TXT": [
+            "v=spf1 include:amazonses.com ~all"
+        ]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

<img width="897" height="864" alt="image" src="https://github.com/user-attachments/assets/197af906-06ae-40b3-aee0-853425e18c4f" />


Live preview: https://seiri-list.vercel.app

![Seiri preview](https://seiri-list.vercel.app/og.jpg)

# Website Purpose

Seiri is a personal, non-commercial, open-source web app I built to catalog a physical collection of magazines, comics and manga: you photograph a cover, AI extracts the metadata, and you validate and organize your catalog. Built with React + TypeScript + Hono, deployed on Vercel. Source: https://github.com/ToroFelipe/Seiri

This PR also adds transactional-email DNS records (Resend) for the app's password-reset flow (SPF/DKIM/DMARC + return-path).
