### PR TITLE
Register nowon-energy-monitor.is-a.dev

### DIFF
--- a/domains/nowon-energy-monitor.json
+++ b/domains/nowon-energy-monitor.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "parksh1236",
+    "email": "parksh1236@gmail.com"
+  },
+  "records": {
+    "CNAME": "02630f11-6777-4ade-bc96-180b3185fb46.cfargotunnel.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
### Description
Registering a subdomain to point to a personal Cloudflare Tunnel for a small energy-monitoring dashboard (Node.js/Express + SQLite, read-only usage/CO2 charts for public-institution facilities).

### Checklist
- [x] I have read and understand the [Terms of Service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md).
- [x] I have starred this repository.
- [x] My domain follows the [naming convention](https://github.com/is-a-dev/register#naming-guidelines).