### PR TITLE
Add laon.is-a.dev

### DIFF
--- a/domains/laon.json
+++ b/domains/laon.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "incipienstation",
+    "email": "jinanjeong@snu.ac.kr"
+  },
+  "records": {
+    "CNAME": "incipienstation.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live:** https://incipienstation.github.io/image-resizer/
**Source:** https://github.com/incipienstation/image-resizer

Once this PR is merged and DNS resolves, I will point the repository's GitHub Pages custom domain at `laon.is-a.dev`.

![Image Resizer — an image loaded, showing output size, aspect-ratio lock, scale presets, format and quality controls](https://raw.githubusercontent.com/incipienstation/register/pr-assets/image-resizer-preview.png)

# Website Purpose

**Image Resizer** is a mobile-first, browser-only image resizing tool I built and maintain.

It resizes images by pixel dimensions while preserving aspect ratio, supports upscale and downscale with 50/100/200/400% presets and a scale slider, and exports to PNG, JPEG, or WebP with quality control.

It is deliberately server-less and privacy-preserving:

- Image bytes never leave the browser — there is no upload API, and all work happens on a Canvas.
- No analytics, ads, trackers, external fonts, third-party scripts, or external API calls.
- A strict Content Security Policy blocks network connections outright (`connect-src 'none'`).
- Output is re-encoded through Canvas, so EXIF/GPS metadata is not carried into the result.
- SVG input is rejected to reduce active-content risk.

It is a personal utility with no monetization of any kind — no revenue, no commercial intent.
