### PR TITLE
Add cocinasferri.is-a.dev

### DIFF
--- a/_domains/cocinasferri.json
+++ b/_domains/cocinasferri.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "matemendoza417-jpg",
+    "email": "cocinasferri@users.noreply.github.com",
+    "kind": "user"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Point cocinasferri.is-a.dev to Vercel (cname.vercel-dns.com) for the Cocinas Ferri website.