### PR TITLE
Update CNAME for jivanzine.is-a.dev

### DIFF
--- a/domains/jivanzine.json
+++ b/domains/jivanzine.json
@@ -6,6 +6,6 @@
     "email": "jeevanzine2052@gmail.com"
   },
   "records": {
-    "CNAME": "jivan-zine-portfolio.vercel.app"
+    "CNAME": "jivan-zine-portfolio-bgye-orpin.vercel.app"
   }
 }


### PR DESCRIPTION
# Purpose

This PR updates the CNAME target for my `jivanzine.is-a.dev` subdomain after redeploying my portfolio on Vercel.

The new deployment URL is:

https://jivan-zine-portfolio-bgye-orpin.vercel.app