### PR TITLE
Register seiri-list.is-a.dev (open-source project site + Resend email records)

### DIFF
--- a/domains/_dmarc.seiri-list.json
+++ b/domains/_dmarc.seiri-list.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — DMARC policy.",
+    "records": {
+        "TXT": [
+            "v=DMARC1; p=none;"
+        ]
+    }
+}

--- a/domains/resend._domainkey.seiri-list.json
+++ b/domains/resend._domainkey.seiri-list.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — Resend DKIM public key.",
+    "records": {
+        "TXT": [
+            "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCTuxgS4QqNZ98UGlXdN4VfmbdauV3AKy/FIntpLQ54XMmBwLE3saFBSTIhDH8ynJlE+RiRtHMmkeB+9wPqnDxpKxvso4kpBRviHMY7hMFU/qg2qsmYClRWrWL3oze+az9ZMyk9RRV7Dz9q0xAod2aYoy12UurkMrDrWtJq6QyhnQIDAQAB"
+        ]
+    }
+}

--- a/domains/seiri-list.json
+++ b/domains/seiri-list.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — catálogo de revistas, cómics y mangas (app en Vercel).",
+    "repo": "https://github.com/ToroFelipe/Seiri",
+    "records": {
+        "URL": "https://seiri-list.vercel.app"
+    }
+}

--- a/domains/send.seiri-list.json
+++ b/domains/send.seiri-list.json
@@ -1,0 +1,15 @@
+{
+    "owner": {
+        "username": "ToroFelipe",
+        "email": "felipe.toro.del@gmail.com"
+    },
+    "description": "Seiri — Resend sending subdomain (SPF + return-path MX).",
+    "records": {
+        "MX": [
+            { "target": "feedback-smtp.sa-east-1.amazonses.com", "priority": 10 }
+        ],
+        "TXT": [
+            "v=spf1 include:amazonses.com ~all"
+        ]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

<img width="1878" height="2437" alt="screencapture-seiri-list-vercel-app-2026-07-14-15_46_39" src="https://github.com/user-attachments/assets/39b5e0e9-888f-40b5-ba44-f8db8dca2448" />


Live preview: https://seiri-list.vercel.app

![Seiri preview](https://seiri-list.vercel.app/og.jpg)

# Website Purpose

**Seiri is an open-source software development project** — a full-stack TypeScript web
application. Source code: https://github.com/ToroFelipe/Seiri

The root page is a **project page** documenting the software itself:

- **Tech stack:** React 18 · TypeScript · Vite · Tailwind (frontend); Hono · Node.js · Zod
  (backend, serverless on Vercel); PostgreSQL (Neon) + Drizzle ORM with migrations.
- **Engineering write-up:** a vision-provider fallback chain (Groq → Gemini → local
  Tesseract.js OCR) that survives per-provider rate limits; automatic cover-edge detection
  and perspective correction with OpenCV.js (Canny + morphological close + homography);
  an offline-capable PWA (service worker + IndexedDB); and a resilient bulk-upload queue
  with adaptive throttling and perceptual-hash (dHash) duplicate detection.
- **Auth:** JWT in an httpOnly cookie.

The application itself demonstrates the project: it uses AI vision models to catalog a
physical collection of magazines, comics and manga (photograph a cover → the model extracts
metadata → the user validates it). It is personal, free and **non-commercial**.

---

### Note re: previous review

A previous PR was closed as *"Not Related to Software Development."* That was fair: at the
time the root URL immediately redirected anonymous visitors to a **login screen**, so there
was nothing to see. That is now fixed — the root page is a public project page describing
the software, its architecture and its stack, with a link to the source repository. The raw
HTML (title, meta description and a `<noscript>` fallback) also describes the project, since
the app is a SPA.

This PR additionally adds transactional-email DNS records (Resend: SPF, DKIM, DMARC and
return-path) used by the app's password-reset flow.
