### PR TITLE
Register azimuth.is-a.dev

### DIFF
--- a/domains/azimuth.json
+++ b/domains/azimuth.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "roeigold2002"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `azimuth.is-a.dev` for **AZIMUTH** — a directional macro terminal (Next.js app hosted on Vercel).

- **Record:** CNAME → `cname.vercel-dns.com`
- **Owner:** @roeigold2002
- Live app: https://azimuth-terminal.vercel.app

Thanks for maintaining is-a.dev! 🙏