### PR TITLE
Register portfolio-pauloalmeida.is-a.dev

### DIFF
--- a/domains/portfolio-pauloalmeida.json
+++ b/domains/portfolio-pauloalmeida.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "phrep",
+        "email": "ph.89.py@gmail.com"
+    },
+    "description": "Portfolio pessoal de Paulo Henrique de Almeida, Engenheiro de Dados",
+    "records": {
+        "A": ["163.176.242.62"]
+    }
+}


### PR DESCRIPTION
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
http://163.176.242.62 (domain not yet live — will resolve to the same server once this PR is merged)

# Website Purpose
Personal portfolio for Paulo Henrique de Almeida, a Data Engineer. Showcases professional experience, technical skills, and projects, including this site itself (Django + Docker + CI/CD pipeline).
<img width="1440" height="2200" alt="portfolio-preview" src="https://github.com/user-attachments/assets/904993b9-b0b2-40df-8981-635a793f1b78" />


