### PR TITLE
Register zushi.is-a.dev

### DIFF
--- a/domains/zushi.json
+++ b/domains/zushi.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "lelenotlikeus",
+    "discord": "tergiversare"
+  },
+  "proxied": true,
+  "records": {
+    "A": ["162.243.65.125"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview: http://162.243.65.125/

![Zushi website preview](http://162.243.65.125/assets/zushi-site-preview.png)

# Website Purpose

Zushi is a non-commercial WhatsApp bot software project. This website is its interactive control surface and live project showcase, presenting bot status, telemetry, music features, arcade sessions and realtime web minigames. The requested domain will replace the raw server address with a stable project hostname.