### PR TITLE
Register roc.is-a.dev and rocspace.is-a.dev

### DIFF
--- a/domains/roc.json
+++ b/domains/roc.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ivansslo",
+    "email": "ivansslo@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "roc-site.certveis.workers.dev"
+  }
+}

--- a/domains/rocspace.json
+++ b/domains/rocspace.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ivansslo",
+    "email": "ivansslo@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "roc-site.certveis.workers.dev"
+  }
+}


### PR DESCRIPTION
## Domain Registration

Registering subdomains for RoadFX AI infrastructure dashboard.

- **roc.is-a.dev** → RocSpace AI Dashboard
- **rocspace.is-a.dev** → RocSpace Hub

Both CNAME to `roc-site.certveis.workers.dev` (Cloudflare Workers).

### Services
- AI Chat (170+ models)
- Solace PubSub+ Event Mesh
- Aiven PostgreSQL
- Cloud Run backend
- CF Workers Gateway

GitHub: @ivansslo