### PR TITLE
Register jobyn.is-a.dev

### DIFF
--- a/domains/jobyn.json
+++ b/domains/jobyn.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Ganesh-0509",
+    "email": "ganesh957kumar@gmail.com"
+  },
+  "records": {
+    "CNAME": "getjobyn.pages.dev"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://getjobyn.pages.dev

![Jobyn preview](https://getjobyn.pages.dev/og-image.png)

# Website Purpose

Jobyn is a free, non-commercial career-readiness platform for engineering and computer-science students. It analyzes a resume and scores it across software-engineering job roles, generates dependency-aware study plans, provides a RAG-backed study/AI tutor and mock interviews, and verifies students' GitHub projects. The `jobyn.is-a.dev` subdomain will be the project's primary shareable link.

**Record:** `CNAME` → `getjobyn.pages.dev` (hosted on Cloudflare Pages), `proxied: false` so Cloudflare Pages serves its own TLS certificate.
