### PR TITLE
Register btr.is-a.dev

### DIFF
--- a/domains/btr.json
+++ b/domains/btr.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "FLEXIY0",
+    "discord": "flexiy0"
+  },
+  "records": {
+    "CNAME": "flexiy0.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live website: https://flexiy0.github.io/btr-reindev/

![BTR ReIndev website preview](https://raw.githubusercontent.com/FLEXIY0/btr-reindev/main/preview.png)

# Website Purpose

BTR is a non-commercial Russian-language hub for ReIndev and its open-source FoxLoader modding ecosystem. The website collects verified installation documentation, links to FoxLoader, its example mod, WorldEdit and other community-developed utilities, and provides support for Russian-speaking players and aspiring mod developers.
