### PR TITLE
Register ucammurciabaloncesto.is-a.dev

### DIFF
--- a/domains/_vercel.ucammurciabaloncesto.json
+++ b/domains/_vercel.ucammurciabaloncesto.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "gestionucambasket"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=ucammurciabaloncesto.is-a.dev,7ed42976c995756348a6"
+  }
+}

--- a/domains/ucammurciabaloncesto.json
+++ b/domains/ucammurciabaloncesto.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "gestionucambasket"
+  },
+  "records": {
+    "CNAME": "04c9600b58ab9e14.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
Registering `ucammurciabaloncesto.is-a.dev` as the temporary public domain for UCAM Murcia Baloncesto's youth-academy management app, pointed at our Vercel deployment via CNAME + the required Vercel ownership-verification TXT record.