### PR TITLE
Register strong-api.is-a.dev

### DIFF
--- a/domains/strong-api.json
+++ b/domains/strong-api.json
@@ -1,0 +1,11 @@
+{
+  "description": "STRONG BSC floor-price lending API via Cloudflare Tunnel",
+  "owner": {
+    "username": "hushuning",
+    "email": "hushuning@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "0296ba00-52be-4985-8da0-a715d8c4e093.cfargotunnel.com"
+  },
+  "proxied": false
+}

--- a/domains/strong-api.json
+++ b/domains/strong-api.json
@@ -1,11 +1,11 @@
 {
-  "description": "STRONG BSC floor-price lending API via Cloudflare Tunnel",
+  "description": "STRONG BSC floor-price lending API gateway",
   "owner": {
     "username": "hushuning",
-    "email": "hushuning@users.noreply.github.com"
+    "email": "Lujunyi3@proton.me"
   },
   "records": {
-    "CNAME": "0296ba00-52be-4985-8da0-a715d8c4e093.cfargotunnel.com"
+    "CNAME": "strong-api-gateway.pages.dev"
   },
   "proxied": false
 }


### PR DESCRIPTION
## Domain
`strong-api.is-a.dev`

## Purpose
Public HTTPS API for the STRONG developer project (BSC floor-price lending market API).

## DNS
- Type: CNAME
- Target: `0296ba00-52be-4985-8da0-a715d8c4e093.cfargotunnel.com` (Cloudflare Named Tunnel)
- Proxied: false (Cloudflare Tunnel ingress)

Origin is not publicly exposed; only Cloudflare Tunnel reaches localhost.