### PR TITLE
Register barbu-george.is-a.dev

### DIFF
--- a/domains/barbu-george.json
+++ b/domains/barbu-george.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "barbugeorgedev",
+    "email": "barbu.george.dev@gmail.com"
+  },
+  "records": {
+    "A": ["75.2.60.5"]
+  }
+}

--- a/domains/www.barbu-george.json
+++ b/domains/www.barbu-george.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "barbugeorgedev",
+    "email": "barbu.george.dev@gmail.com"
+  },
+  "records": {
+    "CNAME": "barbu-george-is-a-dev.netlify.app"
+  }
+}


### PR DESCRIPTION
## Subdomain
- `barbu-george.is-a.dev`
- `www.barbu-george.is-a.dev`

## Owner
- GitHub: `barbugeorgedev`
- Email: barbu.george.dev@gmail.com

## Records
- Apex `A` → Netlify load balancer `75.2.60.5` (per [Netlify guide](https://docs.is-a.dev/guides/netlify/))
- `www` `CNAME` → `barbu-george-is-a-dev.netlify.app`

## Preview
Live site: https://barbu-george-is-a-dev.netlify.app

Repo: https://github.com/george-barbu-es/barbu-george.is-a.dev


Made with [Cursor](https://cursor.com)