### PR TITLE
Register jobyn.is-a.dev

### DIFF
--- a/domains/jobyn.json
+++ b/domains/jobyn.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Ganesh-0509",
+    "email": "ganesh957kumar@gmail.com"
+  },
+  "records": {
+    "CNAME": "getjobyn.pages.dev"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://getjobyn.pages.dev
Open-source code: https://github.com/Ganesh-0509/Jobyn

![Jobyn preview](https://getjobyn.pages.dev/og-image.png)

# Website Purpose

Jobyn is a free, non-commercial, open-source project built for engineering / computer-science students. It is a software-development tool, not a business or a job board — there is no paid tier, no ads, and no commercial offering.

# Re: previous review (software-development relevance)

A previous submission (#43788) was closed as "not related to software development." I believe this was a misread of the landing page, so here is concrete, checkable evidence that Jobyn is a developer-focused software project:

- **Fully open source** — codebase is public at https://github.com/Ganesh-0509/Jobyn (Python **FastAPI** backend + **scikit-learn / ONNX** ML pipeline + **React/TypeScript** SPA).
- **Developer-facing features**, not HR/recruiting:
  - **GitHub project verification** — inspects a student's public repos to validate their engineering work.
  - **In-browser ML inference** — runs an ONNX model client-side via `onnxruntime-web` for privacy-preserving resume scoring.
  - **Dependency-aware coding study plans** — generates skill-gap graphs and curricula for software-engineering roles.
  - **RAG-backed study/AI tutor** for programming and CS topics.
- This is analogous to other developer-tooling and coding-education projects hosted on `is-a.dev`.

Please reconsider — happy to adjust anything needed to comply. Thank you for your time reviewing volunteer submissions.

**Record:** `CNAME` -> `getjobyn.pages.dev` (Cloudflare Pages), `proxied: false` so Pages serves its own TLS certificate.
