### PR TITLE
Add Vercel domain configuration for Rayyan Ahmed

### DIFF
--- a/domains/_vercel.rayyanahmed.json
+++ b/domains/_vercel.rayyanahmed.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Ray7498",
+    "email": "rayyanahmed292001@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=rayyanahmed.is-a.dev,3f6cc970343df2edf3e3"
+  }
+}


### PR DESCRIPTION
> Follow-up PR: adds the TXT record Vercel requires to verify ownership of rayyanahmed.is-a.dev, as instructed in the merge email and the is-a.dev Vercel guide.

- [x] I agree to the Terms of Service (https://is-a.dev/terms)
- [x] My file follows the domain structure (https://docs.is-a.dev/domain-structure/)
- [x] My website is reachable and completed
- [x] My website is software development related
- [x] My website is not for commercial use
- [x] I have provided contact information in the owner key
- [x] I have provided a preview of my website below
# Website Preview

Live: https://portfolio-rouge-two-ll7locv12k.vercel.app (same site as PR #43811, no changes to the site itself, just adding a required Vercel verification record)

# Website Purpose

Personal portfolio for an AI researcher / PhD candidate. Showcases research projects, publications, technical skills, and experience in computer vision, deep learning, and generative AI.