### PR TITLE
Add www.herlen.is-a.dev

### DIFF
--- a/domains/www.herlen.json
+++ b/domains/www.herlen.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "jebastinherlen",
+    "email": "herlenjebastin@gmail.com"
+  },
+  "records": {
+    "CNAME": "35de36f89cadc442.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
Requirements

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

## Website Preview

Website:
https://herlen-portfolio.vercel.app/

Screenshot:
(Drag and drop a screenshot of your portfolio here.)

## Website Purpose

This pull request adds the CNAME record for `www.herlen.is-a.dev` required to connect the `www` subdomain to my Vercel-hosted portfolio.
<img width="1920" height="1080" alt="Screenshot (527)" src="https://github.com/user-attachments/assets/0752d668-60d9-4122-80df-0821fe0a5871" />
