### PR TITLE
Register skindish.is-a.dev

### DIFF
--- a/domains/skindish.json
+++ b/domains/skindish.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ibnweb3",
+    "email": "ibnweb3@gmail.com"
+  },
+  "records": {
+    "A": ["13.63.158.175"]
+  }
+}


### PR DESCRIPTION
## New domain

skindish.is-a.dev

## Reason

For SkinDish, an autonomous AI agent (OKX.AI Onchain OS Agent Service Provider #5810) that scans a food label and hires two other on-chain agents to score its nutrition and check skin safety. Points to the project's own AWS EC2 host, which already serves HTTPS via Caddy/Let's Encrypt.

## Checklist

- [x] My PR follows the [naming convention](https://is-a.dev/docs/naming-convention/)
- [x] My domain does not conflict with any existing domain
- [x] I have read and understood the [terms of service](https://www.is-a.dev/docs/terms/)