### PR TITLE
Add libra-flow.is-a.dev subdomain

### DIFF
--- a/domains/libra-flow.json
+++ b/domains/libra-flow.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CodersPro1234",
+        "email": "codeurspro@gmail.com"
+    },
+    "records": {
+        "URL": "https://libra-flow-officiel.vercel.app"
+    }
+}

--- a/domains/libraflow.json
+++ b/domains/libraflow.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "CodersPro1234",
+        "email": "codeurspro@gmail.com"
+    },
+    "records": {
+        "URL": "https://libra-flow-officiel.vercel.app"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a-dev.terms).
- [x] My file is following the [domain structure](https://docs.is-a-dev.domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://libra-flow-officiel.vercel.app
<img width="1297" height="640" alt="image" src="https://github.com/user-attachments/assets/6a085f81-0f98-4a9b-b5fd-ad048dbb4f41" />

# Website Purpose

LibraFlow is a library management web app built for a student hackathon project. This subdomain will be used to authenticate our transactional email sending (Brevo) via SPF/DKIM/DMARC records.
