### PR TITLE
Add briefly.is-a.dev

### DIFF
--- a/domains/_vercel.briefly.json
+++ b/domains/_vercel.briefly.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "skdiane",
+    "email": "kone.safia@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=briefly.is-a.dev,cab83fd0bd1d159c5b6e"
+  }
+}

--- a/domains/briefly.json
+++ b/domains/briefly.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "skdiane",
+    "email": "kone.safia@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
Adding `briefly.is-a.dev` for **Briefly**, a SEO content-brief management app I built, deployed on Vercel.

- `domains/briefly.json` — A record pointing to Vercel (`216.198.79.1`)
- `domains/_vercel.briefly.json` — TXT record required by Vercel to verify domain ownership

Both records were taken directly from the Vercel dashboard, following the official [Vercel guide](https://docs.is-a.dev/guides/vercel/).

Thanks for maintaining this service!