### PR TITLE
Register proofbattle.is-a.dev

### DIFF
--- a/domains/proofbattle.json
+++ b/domains/proofbattle.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "abdulhaqsayar93-cmd",
+    "email": "build@nexora.local"
+  },
+  "records": {
+    "CNAME": "proofbattle-ai.netlify.app"
+  }
+}


### PR DESCRIPTION
I would like to register the domain proofbattle.is-a.dev for my ProofBattle AI app - a social accountability app where users prove their daily goals. The app is deployed at https://proofbattle-ai.netlify.app. Thank you!