### PR TITLE
Register htcnews.is-a.dev

### DIFF
--- a/domains/htcnews.json
+++ b/domains/htcnews.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "weblrsolutions"
+  },
+  "records": {
+    "CNAME": "weblrsolutions.github.io"
+  }
+}


### PR DESCRIPTION
Registering `htcnews.is-a.dev` for HTC News, a health-tech news reader hosted on GitHub Pages.

- Record: CNAME -> weblrsolutions.github.io
- Site repo: https://github.com/weblrsolutions/htcnews