### PR TITLE
Register ella.is-a.dev

### DIFF
--- a/domains/_vercel.ella.json
+++ b/domains/_vercel.ella.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ellashteier-byte",
+        "email": "ellashteier@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=ella.is-a.dev,15d45a27c69210e4fb9b"
+    }
+}

--- a/domains/ella.json
+++ b/domains/ella.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ellashteier-byte",
+        "email": "ellashteier@gmail.com"
+    },
+    "records": {
+        "CNAME": "0f2f21cd3e37c933.vercel-dns-017.com"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://ella-site-blush.vercel.app/

![Website preview](https://ella-site-blush.vercel.app/opengraph-image)

# Website Purpose

Personal portfolio and developer site. It showcases my projects and case studies (built with Next.js 15 + Tailwind CSS 4, deployed on Vercel), my development/design tool stack, and how to contact me. The `_vercel.ella.json` file contains the TXT record required by Vercel for domain verification, per the [Vercel guide](https://docs.is-a.dev/guides/vercel/).
