### PR TITLE
Add tito.is-a.dev

### DIFF
--- a/domains/tito.json
+++ b/domains/tito.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "TitoNicolaDrugman",
+        "email": "tito.drugman.dev@gmail.com"
+    },
+    "records": {
+        "CNAME": "titonicoladrugman.github.io"
+    }
+}


### PR DESCRIPTION
### Description of the domain

Personal portfolio site for my MSc Computer Science & Engineering studies at Politecnico di Milano — experience, projects, and technical background.

### Preview

https://titonicoladrugman.github.io

<img width="1872" height="850" alt="image" src="https://github.com/user-attachments/assets/966c2b3e-ad42-42da-ba45-c0ecd503a573" />

### Checklist

- [x] I have read the [documentation](https://docs.is-a.dev)
- [x] The JSON file is in the `domains` directory and is valid
- [x] The site is publicly available at the preview link above
- [x] The CNAME points to my GitHub Pages user site