### PR TITLE
Update salman-twin.is-a.dev: temporary target during AWS re-association

### DIFF
--- a/domains/salman-twin.json
+++ b/domains/salman-twin.json
@@ -4,6 +4,6 @@
     "email": "msalmansaeedch786@gmail.com"
   },
   "records": {
-    "CNAME": "d2gxmdta6ef8lc.cloudfront.net"
+    "CNAME": "msalmansaeedch786.github.io"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://main.dtogabptwtao.amplifyapp.com

# Website Purpose

Existing registration (my AI digital-twin portfolio, serverless on AWS).
This update temporarily points the CNAME at a neutral non-CloudFront target:
AWS CloudFront's alias takeover-protection refuses to re-associate the domain
with my (re-provisioned) distribution while public DNS points at a foreign
cloudfront.net hostname. Once the association is healthy I will submit one
final PR with the permanent CloudFront target.