### PR TITLE
Register amato.is-a.dev

### DIFF
--- a/domains/amato.json
+++ b/domains/amato.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "amatokurusu",
+    "email": "amatokurusu@gmail.com"
+  },
+  "records": {
+    "CNAME": "amatokurusu.github.io"
+  }
+}


### PR DESCRIPTION
### Description
Requesting `amato.is-a.dev` for my personal Vtuber activity homepage, hosted on GitHub Pages.

- Site: https://amato.is-a.dev/ (once merged)
- CNAME target: amatokurusu.github.io