### PR TITLE
Register alae.is-a.dev

### DIFF
--- a/domains/alae.json
+++ b/domains/alae.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "alae-eddinee",
+    "email": "eddine.dahane@gmail.com"
+  },
+  "records": {
+    "CNAME": "alae-eddine-dahane.netlify.app"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Live: https://alae-eddine-dahane.netlify.app (will resolve at https://alae.is-a.dev once merged)

<img width="1680" height="913" alt="Screenshot of alae-eddine-dahane.netlify.app" src="https://github.com/user-attachments/assets/7a5b881e-0814-475b-a3c8-e0bbdc487307" />

# Website Purpose
Personal developer portfolio for Alae-Eddine Dahane, a data scientist and developer in Kenitra, Morocco. Styled as a working spreadsheet UI; lists real software projects (Next.js/Supabase apps, Python/Streamlit data tools, automation pipelines) with a contact form.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>