### PR TITLE
gluonverse.is-a.dev

### DIFF
--- a/domains/gluonverse.json
+++ b/domains/gluonverse.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "elTeketek",
+    "email": "fernando.sanjuan@uc.cl"
+  },
+  "records": {
+    "CNAME": "gluonverse-frontend.ambitiousmeadow-271656f4.brazilsouth.azurecontainerapps.io"
+  }
+}


### PR DESCRIPTION
Registering gluonverse.is-a.dev as a CNAME to our Azure Container Apps frontend deployment.