### PR TITLE
add nathapon.is-a.dev

### DIFF
--- a/domains/nathapon.json
+++ b/domains/nathapon.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "solomild",
+    "email": "Solomild@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "dakota.ns.cloudflare.com",
+      "julissa.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
# reason for NS
I want to use Cloudflare DNS to manage multiple subdomains (e.g., nested subdomains like a.nathapon.is-a.dev) for my personal projects and coding portfolio.

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
(Note: Using custom NS delegation to Cloudflare. Website will be configured once the domain delegation propagates.)

# Website Purpose
This domain will be used for hosting my software development projects, personal coding portfolio, and playground apps.