### PR TITLE
Delete domains/andrew-book.json

### DIFF
--- a/domains/andrew-book.json
+++ b/domains/andrew-book.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "andrew37673",
-    "email": "annonim.mario19@gmail.com"
-  },
-  "records": {
-    "CNAME": "andrew37673.github.io"
-  }
-}


### PR DESCRIPTION
Reason for removal:
I have successfully migrated my project to a dedicated custom domain (andrew-blog.dev). Consequently, the andrew-book.is-a.dev subdomain is no longer in use and can be released back into the pool for others to utilize.

Gratitude:
Thank you for providing this service. It was an invaluable starting point for my project’s development and I truly appreciate the support provided by the community.