### PR TITLE
Add stackup-lfg.is-a.dev

### DIFF
--- a/domains/_vercel.stackup-lfg.json
+++ b/domains/_vercel.stackup-lfg.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "1tsRajOwO",
+    "email": "8cjfp2vgkd@privaterelay.appleid.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=stackup-lfg.is-a.dev,da46524c206a3bfcbe85"
+  }
+}

--- a/domains/stackup-lfg.json
+++ b/domains/stackup-lfg.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "1tsRajOwO",
+    "email": "8cjfp2vgkd@privaterelay.appleid.com"
+  },
+  "records": {
+    "A": ["216.198.79.1", "64.29.17.1"]
+  }
+}


### PR DESCRIPTION
## Domain confirmation

- [x] I have read and agree to the [Terms of Service](https://is-a.dev/terms)
- [x] I have checked that the subdomain is available
- [x] My domain is related to software development (StackUp — multi-game LFG / stack finder web app)

## Domain

`stackup-lfg.is-a.dev` → Vercel (`A` to Vercel edge) + `_vercel` TXT ownership verification

## Project

https://github.com/1tsRajOwO/stackup  
Live: https://stackup-three.vercel.app


Made with [Cursor](https://cursor.com)