### PR TITLE
salman-twin.is-a.dev: drop CNAME, authorize Amazon CA (CAA)

### DIFF
--- a/domains/salman-twin.json
+++ b/domains/salman-twin.json
@@ -4,6 +4,16 @@
     "email": "msalmansaeedch786@gmail.com"
   },
   "records": {
-    "CNAME": "d2gxmdta6ef8lc.cloudfront.net"
+    "TXT": "digital-twin: pending AWS Amplify domain association",
+    "CAA": [
+      {
+        "tag": "issue",
+        "value": "amazontrust.com"
+      },
+      {
+        "tag": "issue",
+        "value": "amazon.com"
+      }
+    ]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://main.dtogabptwtao.amplifyapp.com

# Website Purpose

Existing registration (AI digital-twin portfolio, serverless on AWS). Follow-up
to #43959: the github.io placeholder's CAA policy blocks Amazon's CA from
issuing my SSL certificate (CAA follows CNAMEs). This replaces the CNAME with a
TXT placeholder and adds CAA records authorizing Amazon, so AWS ACM can issue
the certificate and the Amplify domain association can complete. One final PR
will then set the permanent CloudFront CNAME.