### PR TITLE
Register gramcare + email DNS records (DKIM/SPF/DMARC via Resend)

### DIFF
--- a/domains/_dmarc.gramcare.json
+++ b/domains/_dmarc.gramcare.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "anishas1523-1415"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/gramcare.json
+++ b/domains/gramcare.json
@@ -3,6 +3,6 @@
     "username": "anishas1523-1415"
   },
   "records": {
-    "TXT": "GramCare AI - rural healthcare platform (in development)"
+    "URL": "https://github.com/anishas1523-1415"
   }
 }

--- a/domains/gramcare.json
+++ b/domains/gramcare.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "anishas1523-1415"
+  },
+  "records": {
+    "TXT": "GramCare AI - rural healthcare platform (in development)"
+  }
+}

--- a/domains/resend._domainkey.gramcare.json
+++ b/domains/resend._domainkey.gramcare.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "anishas1523-1415"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDbUmicmJlpvcOqREj5/ALkqkCu+/fqp//7K17ZpUQmACnMUnh2uiO1+URQVF404z+Z4H5+9b6GkyVTvDvXrewKR+OwNtZ3c+qhY780Bxu/GcetYkH4X5zDivoP8m/ICfng5hhfYJHgKpHp/4cd9Jmuqw450ZrLvo36pdSUy/pd/QIDAQAB"
+  }
+}

--- a/domains/send.gramcare.json
+++ b/domains/send.gramcare.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "anishas1523-1415"
+  },
+  "records": {
+    "MX": [
+      { "target": "feedback-smtp.ap-northeast-1.amazonses.com", "priority": 10 }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
Registering `gramcare.is-a.dev` for GramCare AI, a rural healthcare platform I'm building. Four files:

- `gramcare.json` - base domain claim (placeholder TXT record, no site hosted here yet)
- `resend._domainkey.gramcare.json` - DKIM TXT record for Resend (transactional email)
- `send.gramcare.json` - SPF (MX + TXT) records for Resend
- `_dmarc.gramcare.json` - DMARC policy (p=none, monitoring only)

All four records were copied directly from my Resend dashboard's domain verification page for `gramcare.is-a.dev`. Happy to make any changes requested.