### PR TITLE
Add Vercel domain verification configuration

### DIFF
--- a/domains/_vercel.abhigyan.json
+++ b/domains/_vercel.abhigyan.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "UltraBot05",
+    "email": "tlauncherati@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=abhigyan.is-a.dev,d2382b73e3282c5eb8d4"
+  }
+}


### PR DESCRIPTION
abhigyan.json is already merged. On instruction of @dragsbruh in the original PR (#43742 ), I am opening this separate PR to add the `_vercel.abhigyan.json` file required for Vercel domain verification.

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://abhigyan-site.vercel.app/
(same preview as #43742  - this PR only adds Vercel's TXT verification record, no site changes)

<img width="1439" height="830" alt="image" src="https://github.com/user-attachments/assets/2c8a8911-f827-44d4-b125-4c6db8b52b46" />

## Comment proof from #43742 
<img width="1766" height="1386" alt="image" src="https://github.com/user-attachments/assets/3cb68859-b078-4c55-ae99-d3d0bef46596" />

# Website Purpose
Personal portfolio website (see #43742 for full details).