### PR TITLE
Register x402-seller.is-a.dev

### DIFF
--- a/domains/x402-seller.json
+++ b/domains/x402-seller.json
@@ -1,0 +1,4 @@
+{
+  "owner": { "username": "wyattpalm2-eng" },
+  "records": { "CNAME": "x402-seller-m8nx.onrender.com" }
+}


### PR DESCRIPTION
Adds x402-seller.is-a.dev (CNAME -> x402-seller-m8nx.onrender.com). Live x402 pay-per-call crypto data API for AI agents.