### PR TITLE
Add gameworld.is-a.dev

### DIFF
--- a/domains/gameworld.json
+++ b/domains/gameworld.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "realeasonliang",
+        "email": "realeasonliang@gmail.com"
+    },
+    "records": {
+        "CNAME": "cloudflare-workers-autoconfig-gameworld.realeasonliang.workers.dev"
+    }
+}


### PR DESCRIPTION
Adding my personal game site subdomain gameworld.is-a.dev (CNAME to my Cloudflare Worker).