### PR TITLE
Register wayne.is-a.dev

### DIFF
--- a/domains/_vercel.wayne.json
+++ b/domains/_vercel.wayne.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "waynehacking8",
+        "email": "waynehacking8@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=prs.wayne.is-a.dev,4808805215644814d489"
+    }
+}

--- a/domains/prs.wayne.json
+++ b/domains/prs.wayne.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "waynehacking8",
+        "email": "waynehacking8@gmail.com"
+    },
+    "records": {
+        "CNAME": "2dbdd9618d47974c.vercel-dns-017.com"
+    }
+}

--- a/domains/wayne.json
+++ b/domains/wayne.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "waynehacking8",
+        "email": "waynehacking8@gmail.com"
+    },
+    "records": {
+        "CNAME": "waynehacking8.github.io"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**`wayne.is-a.dev`** → https://waynehacking8.github.io/ — personal portfolio (GitHub Pages / MkDocs)

![portfolio preview](https://raw.githubusercontent.com/waynehacking8/waynehacking8.github.io/main/docs/assets/previews/portfolio-preview.png)

**`prs.wayne.is-a.dev`** → https://wayne-prs.vercel.app/ — live wall of my upstream open-source pull requests (Vercel; `_vercel.wayne.json` carries the TXT verification record)

![PR wall preview](https://raw.githubusercontent.com/waynehacking8/waynehacking8.github.io/main/docs/assets/previews/pr-wall-preview.png)

# Website Purpose

Portfolio site for my work as a GPU/ML systems engineer: experience, publications, projects, talks, blog, and a "Patches" page tracking my upstream contributions (FlashInfer, vLLM, PyTorch, LMDeploy, etc. — 17 merged, ~60 in review). The `prs` subdomain hosts an auto-updating feed of those pull requests.
