### PR TITLE
fix vikashv: use A record for root and add root TXT verification

### DIFF
--- a/domains/_vercel.vikashv.json
+++ b/domains/_vercel.vikashv.json
@@ -4,6 +4,9 @@
     "email": "hatb5609@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=www.vikashv.is-a.dev,3a25d79520faaee0b85b"
+    "TXT": [
+      "vc-domain-verify=vikashv.is-a.dev,a87f01d28c7907acd891",
+      "vc-domain-verify=www.vikashv.is-a.dev,3a25d79520faaee0b85b"
+    ]
   }
 }

--- a/domains/vikashv.json
+++ b/domains/vikashv.json
@@ -4,6 +4,6 @@
     "email": "hatb5609@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "A": ["216.198.79.1"]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://portfolio-blond-kappa-65.vercel.app

# Website Purpose

Fixing DNS records for `vikashv.is-a.dev`:
- Changed root from `CNAME` to `A` record (`216.198.79.1`) — CNAME at apex is invalid
- Added root domain TXT verification required by Vercel alongside the existing www TXT