### PR TITLE
Register playpark.is-a.dev and mc.playpark.is-a.dev

### DIFF
--- a/domains/mc.playpark.json
+++ b/domains/mc.playpark.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "Yash00241",
+    "email": "whenlegendsings@gmail.com"
+  },
+  "records": {
+    "AAAA": [
+      "2a01:4f9:3a:276e::1265"
+    ]
+  }
+}

--- a/domains/playpark.json
+++ b/domains/playpark.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Yash00241",
+    "email": "whenlegendsings@gmail.com"
+  },
+  "records": {
+    "CNAME": "playpark-six.vercel.app"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live Website:**
https://playpark-six.vercel.app

**Screenshot:**
<img width="1335" height="633" alt="image" src="https://github.com/user-attachments/assets/9f3b720f-c756-41d9-8a7c-d4331684d564" />
<img width="1337" height="630" alt="image" src="https://github.com/user-attachments/assets/ae721882-4923-4d9a-97df-beda86d10889" />
<img width="1325" height="617" alt="image" src="https://github.com/user-attachments/assets/422b267f-6e27-4f19-95d6-4476ba23040f" />


# Website Purpose

PlayPark is a personal Minecraft project for me and my friends. The website serves as the official landing page for the server, providing server information, status, community links, and future add-ons (Mincraft Server Map, which would be added later as its of no use right now). It is a non-commercial software development project hosted on Vercel.