### PR TITLE
Register vamshikrishna.is-a.dev

### DIFF
--- a/domains/_vercel.vamshikrishna.json
+++ b/domains/_vercel.vamshikrishna.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "vamshikrishnachatla",
+    "email": "vamshikrishnachatla@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=vamshikrishna.is-a.dev,366cf69411d2ae52e030"
+  }
+}

--- a/domains/vamshikrishna.json
+++ b/domains/vamshikrishna.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "vamshikrishnachatla",
+    "email": "vamshikrishnachatla@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview: https://portfolio-puce-one-80.vercel.app/

# Website Purpose

Personal developer portfolio for a Java backend / GenAI software engineer — showcasing skills, work experience, and engineering case studies. Hosted on Vercel.

# Records

- `domains/vamshikrishna.json` — CNAME to `cname.vercel-dns.com`
- `domains/_vercel.vamshikrishna.json` — TXT record for Vercel domain ownership verification

Both files are owned by the same GitHub user.