### PR TITLE
Add risxportal.is-a.dev

### DIFF
--- a/domains/risxportal.json
+++ b/domains/risxportal.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "madhurgod",
+    "email": "madhurtiwari539@gmail.com"
+  },
+  "description": "RISX GTI Official Website",
+  "repo": "https://github.com/madhurgod/risx",
+  "records": {
+    "CNAME": "madhurgod.github.io"
+  }
+}


### PR DESCRIPTION
Requesting risxportal.is-a.dev for my GitHub Pages website.

Website:
https://madhurgod.github.io/risx/