### PR TITLE
Add _vercel.sneha.is-a.dev TXT record

### DIFF
--- a/domains/_vercel.sneha.json
+++ b/domains/_vercel.sneha.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "snehassan",
+        "email": "snehahassan7920@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=sneha.is-a.dev,93c291df180674b3768a"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://sneha-portfolio-271e-snehassans-projects.vercel.app

<img width="1442" height="870" alt="Sneha Hassan portfolio landing page" src="https://github.com/user-attachments/assets/d19139e4-e066-4452-bc84-3cf3d9d081fa" />

# Website Purpose

Follow-up to #44118, which registered `sneha.is-a.dev` (already merged, thank you).

This adds the `_vercel` TXT record Vercel requires to verify ownership before it will serve the domain. `sneha.is-a.dev` already points at `cname.vercel-dns.com`, but Vercel reports "This domain is linked to another Vercel account" and asks for a TXT record at `_vercel.sneha.is-a.dev` before it will attach the hostname to my project.

Same site and same owner as #44118: my personal portfolio as a software and AI/ML engineer, covering my projects, writing, and experience. Entirely non-commercial.
