### PR TITLE
Register nexusapi.is-a.dev

### DIFF
--- a/domains/nexusapi.json
+++ b/domains/nexusapi.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "jangidpranshu1989-create"
+    },
+    "records": {
+        "CNAME": "nexusapi-ka6p.onrender.com"
+    }
+}


### PR DESCRIPTION
This PR registers nexusapi.is-a.dev for my project NexusAPI - an open-source hub for ready-to-deploy backend systems, built for developers to browse, download, and use working backend code without starting from scratch.

Website: https://nexusapi-ka6p.onrender.com

This is a personal/non-commercial software development project.