### PR TITLE
Register nejatino.is-a.dev

### DIFF
--- a/domains/nejatino.json
+++ b/domains/nejatino.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "omidadli",
+    "email": "omidadli@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/nejatino.json
+++ b/domains/nejatino.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "omidadli",
-    "email": "omidadli@users.noreply.github.com"
+    "email": "omidadli78@gmail.com"
   },
   "records": {
     "CNAME": "cname.vercel-dns.com"


### PR DESCRIPTION
Registering nejatino.is-a.dev with a CNAME record pointing to Vercel (cname.vercel-dns.com) for an animal rescue charity website.