### PR TITLE
Migrate kumarprince.is-a.dev to Vercel

### DIFF
--- a/domains/_vercel.kumarprince.json
+++ b/domains/_vercel.kumarprince.json
@@ -4,6 +4,6 @@
     "email": "kumar.prince7428@gmail.com"
   },
   "records": {
-    "A": ["216.198.79.1"]
+    "TXT": "vc-domain-verify=kumarprince.is-a.dev,d4847c0c4f818bf7d2b2"
   }
 }


### PR DESCRIPTION
## Migration from GitHub Pages to Vercel

- Updated : CNAME → A record (216.198.79.1)
- Created  with Vercel TXT verification

Domain: kumarprince.is-a.dev
Owner: @Prince000101