### PR TITLE
Add mailabs.is-a.dev domain for MAI Labs

### DIFF
--- a/domains/mailabs.json
+++ b/domains/mailabs.json
@@ -1,0 +1,11 @@
+{
+  "description": "MAI Labs official website",
+  "repo": "https://github.com/MAI-Labs/mai-labs-website",
+  "owner": {
+    "username": "Mahesh-Awchar",
+    "email": "mailabs.official1@gmail.com"
+  },
+  "record": {
+    "CNAME": "mai-labs-website-afqd-tan.vercel.app"
+  }
+}


### PR DESCRIPTION
Official website domain for MAI Labs research organization.

Repository:
https://github.com/MAI-Labs/mai-labs-website

Website deployed on Vercel.