### PR TITLE
Add kaivo.is-a.dev

### DIFF
--- a/domains/_vercel.kaivo.json
+++ b/domains/_vercel.kaivo.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "radiateurdeclio-lang"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=kaivo.is-a.dev,a8782fd6f2741aefbb3e"
+  }
+}

--- a/domains/kaivo.json
+++ b/domains/kaivo.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "radiateurdeclio-lang"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
﻿## Description
Registering `kaivo.is-a.dev` for [Kaivo](https://kaivo-app.vercel.app) — an AI developer tool (chat / agent) hosted on Vercel.

**Live preview:** https://kaivo-app.vercel.app

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.

## DNS
- `domains/kaivo.json` → CNAME `cname.vercel-dns.com`
- `domains/_vercel.kaivo.json` → Vercel TXT verification
