### PR TITLE
Add esp32-assistant.is-a.dev

### DIFF
--- a/domains/esp32-assistant.json
+++ b/domains/esp32-assistant.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "hniman135",
+    "email": "hniman135@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "27763e19-1e40-4fd9-a5f7-f0185fb198fc.cfargotunnel.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
## Domain Request

- **Domain:** `esp32-assistant.is-a.dev`
- **GitHub:** [@hniman135](https://github.com/hniman135)

### What is this?

Personal open-source hobby project: **ESP32 local English voice assistant**.
Laptop runs the backend (Whisper ASR + LLM + Piper TTS); the board streams mic audio and plays replies with an expressive face UI on the LCD.

### Preview / links

- Project repo: https://github.com/hniman135 (account)
- Public landing (via Cloudflare Tunnel once DNS is live): will serve at `https://esp32-assistant.is-a.dev/` (health: `/health`, dashboard: `/dashboard`)
- DNS: CNAME → Cloudflare Tunnel `27763e19-1e40-4fd9-a5f7-f0185fb198fc.cfargotunnel.com`

### Checklist

- [x] I have read the documentation
- [x] This is a personal / non-commercial software project
- [x] Domain JSON follows the required structure
- [x] Owner username matches my GitHub account

Not a commercial product — learning / home lab use only.