### PR TITLE
Add Google SPF include for soloappsstudio.is-a.dev

### DIFF
--- a/domains/soloappsstudio.json
+++ b/domains/soloappsstudio.json
@@ -6,7 +6,7 @@
   "records": {
     "CNAME": "solo-apps-studio-website.web.app",
     "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
-    "TXT": ["v=spf1 include:spf.improvmx.com ~all"]
+    "TXT": ["v=spf1 include:spf.improvmx.com include:_spf.google.com ~all"]
   },
   "proxied": true
 }


### PR DESCRIPTION
Adding `include:_spf.google.com` to the SPF record so Gmail is authorized to send as an address on this domain, alongside the existing ImprovMX forwarding include.