### PR TITLE
Add _vercel.ansh-chaturmohta TXT record (Vercel verification)

### DIFF
--- a/domains/_vercel.ansh-chaturmohta.json
+++ b/domains/_vercel.ansh-chaturmohta.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ansh-chaturmohta",
+        "email": "ansh.chaturmohta@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=ansh-chaturmohta.is-a.dev,36914521d87d54acffbe"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This PR only adds a `_vercel` ownership TXT record. It does **not** create a new user-facing subdomain. It is the verification record for my existing subdomain `ansh-chaturmohta.is-a.dev` (approved in an earlier merged PR), which Vercel requires to complete domain verification.

The `ansh-chaturmohta.is-a.dev` domain is not resolving yet **precisely because this TXT record is missing** — Vercel is holding it at "Verification Required" until it can read this record. Once this merges and propagates, that domain will point to the live site below.

The finished, live website is reachable now at: **https://star-chart-three.vercel.app**

<!-- screenshot added below -->

# Website Purpose

The site is my personal software engineering portfolio, built as an interactive "constellation atlas" star map of my work, projects, and self-built developer tools. This file only adds the `_vercel` TXT record so Vercel can verify ownership of the already-approved `ansh-chaturmohta.is-a.dev` subdomain. No new subdomain is being introduced.
