### PR TITLE
Add Google site verification TXT record for looped.is-a.dev

### DIFF
--- a/domains/looped.json
+++ b/domains/looped.json
@@ -4,6 +4,7 @@
     "email": "nonlooped@gmail.com"
   },
   "records": {
-    "A": ["216.198.79.1"]
+    "A": ["216.198.79.1"],
+    "TXT": ["google-site-verification=BmvyiReTSU8P8Lczrgtz9MUAefVY2O1_lbQL4e3UJNo"]
   }
 }


### PR DESCRIPTION
## What
Adds a Google Search Console domain verification TXT record for `looped.is-a.dev`.

## Records
- Existing: A → 216.198.79.1
- New: TXT → `google-site-verification=BmvyiReTSU8P8Lczrgtz9MUAefVY2O1_lbQL4e3UJNo`

Owner: @nonlooped