### PR TITLE
salman-twin.is-a.dev: drop CNAME, authorize Amazon CA (CAA) — v2, conflict-free

### DIFF
--- a/domains/salman-twin.json
+++ b/domains/salman-twin.json
@@ -4,6 +4,10 @@
     "email": "msalmansaeedch786@gmail.com"
   },
   "records": {
-    "CNAME": "msalmansaeedch786.github.io"
+    "TXT": "digital-twin: pending AWS Amplify domain association",
+    "CAA": [
+      { "tag": "issue", "value": "amazontrust.com" },
+      { "tag": "issue", "value": "amazon.com" }
+    ]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://main.dtogabptwtao.amplifyapp.com

# Website Purpose

Fresh, conflict-free replacement for #44055 (closed due to a merge conflict
with #43959, which had already merged and changed this file in the meantime).
I confirmed ownership and explained the change history in a comment on #44055.

This is my existing registration (AI digital-twin portfolio, serverless on
AWS). The previous CNAME placeholder (github.io) carries a CAA policy that
blocks Amazon's certificate authority from issuing my SSL certificate for this
domain (CAA restrictions follow CNAMEs). This PR drops the CNAME and adds an
explicit CAA record authorizing Amazon, so AWS ACM can issue the certificate
and my Amplify custom-domain association can complete. Once that succeeds I
will submit one final PR with the permanent CloudFront CNAME.