### PR TITLE
Add vinaykumar.is-a.dev

### DIFF
--- a/domains/vinaykumar.json
+++ b/domains/vinaykumar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Itsvkid",
+        "email": "kumarvsvinay@gmail.com"
+    },
+    "records": {
+        "CNAME": "496d67b97f6f1808.vercel-dns-017.com"
+    }
+}


### PR DESCRIPTION
Registering `vinaykumar.is-a.dev` for my personal portfolio site.

- **Site:** a portfolio for an aerospace propulsion / CFD engineering graduate, built with Next.js and hosted on Vercel.
- **Currently live at:** https://vinaykumar-venkateshkumar.vercel.app
- **Record:** single `CNAME` pointing to my Vercel project's DNS target.
- **Source:** https://github.com/Itsvkid/portfolio

The domain is already added to the Vercel project, so it should resolve and issue a certificate as soon as the record propagates.