### PR TITLE
Register fegbrands.is-a.dev

### DIFF
--- a/domains/fegbrands.json
+++ b/domains/fegbrands.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "fernandawinders1979-png"
+    },
+    "records": {
+        "CNAME": "fernandawinders1979-png.github.io"
+    }
+}


### PR DESCRIPTION
### Description
Register `fegbrands.is-a.dev` to point to my GitHub Pages site (a customer support dashboard for FEG Brands).

### Domain
- **Subdomain:** fegbrands.is-a.dev
- **Record:** CNAME -> fernandawinders1979-png.github.io