### PR TITLE
Add _vercel.vinaykumar.is-a.dev (TXT verification)

### DIFF
--- a/domains/_vercel.vinaykumar.json
+++ b/domains/_vercel.vinaykumar.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Itsvkid",
+        "email": "kumarvsvinay@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=vinaykumar.is-a.dev,75d16a375dbdd8b7aa56"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://vinaykumar-venkateshkumar.vercel.app

**Source code:** https://github.com/Itsvkid/portfolio (public repository)

![Website preview](https://raw.githubusercontent.com/Itsvkid/portfolio/main/docs/preview.png)

# Website Purpose

Follow-up to #44304 (merged — thank you!). This adds the `_vercel` TXT record for domain verification, as suggested by @FWEEaaaa1 in the review and documented in the [Vercel guide](https://docs.is-a.dev/guides/vercel/).

The `CNAME` from #44304 has propagated correctly and already resolves to my Vercel deployment, but Vercel additionally requires the `_vercel` TXT challenge before it will issue a certificate and serve the domain. This record contains only that verification token.

Same owner and same site as the parent `vinaykumar.is-a.dev`: a personal portfolio for my aerospace propulsion / CFD engineering work. The site is an open-source Next.js application, and the research it documents involves building a pyOCC / OpenCASCADE parametric geometry workflow in Python. Non-commercial.
