### PR TITLE
Register kidora.is-a.dev

### DIFF
--- a/domains/kidora.json
+++ b/domains/kidora.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "HazemuH"
+  },
+  "records": {
+    "A": ["8.229.130.9"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [v] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [v] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [v] My website is **reachable** and **completed**.
- [v] My website is **software development** related.
- [v] My website is **not for commercial use**.
- [v] I have provided contact information in the `owner` key.
- [v] I have provided a preview of my website below.

# Website Preview

Live site: http://8.229.130.9

<!-- Drag & drop a screenshot of the KIDORA login/dashboard here in the GitHub PR editor -->

# Website Purpose

KIDORA is an academic Decision Support System (DSS) web application built as part of
a university thesis project. It demonstrates the AHP (Analytic Hierarchy Process) and
SAW multi-criteria decision-making methods applied to product ranking, with a React +
TypeScript frontend and a Spring Boot REST API backend. The subdomain will host the
live demo of this open, non-commercial educational project so it can be referenced in
the thesis and shown to reviewers. It is not used to sell anything or generate revenue.

<img width="1512" height="663" alt="image" src="https://github.com/user-attachments/assets/8167ccb7-120d-4be4-93ca-fcb2edba4bbe" />
