### PR TITLE
Update darkdevil and tahaadnan, add mtaha

### DIFF
--- a/domains/darkdevil.json
+++ b/domains/darkdevil.json
@@ -5,7 +5,7 @@
     "discord": "LRxDark Dare Devil#0001"
   },
   "records": {
-    "A": ["185.199.109.153", "185.199.110.153", "185.199.111.153", "185.199.108.153"],
+    "A": ["75.2.60.5"],
     "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
     "TXT": "v=spf1 include:spf.improvmx.com ~all"
   }

--- a/domains/mtaha.json
+++ b/domains/mtaha.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "LRxDarkDevil",
+    "email": "tahaadnanawan@gmail.com"
+  },
+  "records": {
+    "A": ["75.2.60.5"]
+  }
+}

--- a/domains/tahaadnan.json
+++ b/domains/tahaadnan.json
@@ -4,6 +4,6 @@
     "email": "tahaadnanawan@gmail.com"
   },
   "records": {
-    "CNAME": "lrxdarkdevil.github.io"
+    "A": ["75.2.60.5"]
   }
 }


### PR DESCRIPTION
## Requirements

- [x] I have read and understood the [documentation](https://docs.is-a.dev).
- [x] The domains are being used for personal developer portfolio websites.
- [x] The destination websites are already deployed and accessible.
- [x] I own the existing `darkdevil` and `tahaadnan` domains.

## Changes

This PR migrates two existing domains from GitHub Pages to Netlify and registers one additional short domain for my portfolio.

### Updated domains

- `darkdevil.is-a.dev`
  - Previous host: GitHub Pages
  - New host: `https://darkdevil-web.netlify.app`
  - Existing MX and SPF TXT records are preserved.

- `tahaadnan.is-a.dev`
  - Previous host: GitHub Pages
  - New host: `https://tahaadnan.netlify.app`

### New domain

- `mtaha.is-a.dev`
  - Host: `https://tahaadnan.netlify.app`
  - This is a shorter alias for my Muhammad Taha portfolio.

## Reason

I am migrating the portfolio repositories from GitHub Pages to Netlify so that the source repositories can be made private while keeping the websites publicly accessible.

Both Netlify projects are already deployed, and the custom domains have been added in Netlify.

## Website URLs

- https://darkdevil-web.netlify.app
- https://tahaadnan.netlify.app

## Intended final domains

- https://darkdevil.is-a.dev
- https://tahaadnan.is-a.dev
- https://mtaha.is-a.dev