### PR TITLE
Update salman-twin.is-a.dev: point CNAME to my Amplify site

### DIFF
--- a/domains/salman-twin.json
+++ b/domains/salman-twin.json
@@ -4,6 +4,6 @@
     "email": "msalmansaeedch786@gmail.com"
   },
   "records": {
-    "CNAME": "msalmansaeedch786.github.io"
+    "CNAME": "d23m4m583gvtfs.cloudfront.net"
   }
 }


### PR DESCRIPTION
This updates the CNAME for salman-twin.is-a.dev.

I run my site on AWS Amplify. A while back I had this pointing at a GitHub Pages placeholder while I was still setting things up, and I forgot to move it once the real site was ready. This PR just repoints the existing CNAME to my Amplify CloudFront target so the domain resolves to the actual site and the SSL certificate can be issued.

It is a single record change, one CNAME, nothing else.

- [x] I have read and understood the docs
- [x] This PR only changes records for a domain I own