### PR TITLE
Register deepak0x.is-a.dev

### DIFF
--- a/domains/deepak0x.json
+++ b/domains/deepak0x.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "deepak0x",
+    "email": "deepak988088@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `deepak0x.is-a.dev` for my personal developer portfolio (React/Vite, hosted on Vercel). CNAME points to `cname.vercel-dns.com`.