### PR TITLE
Redirect techxtreme.is-a.dev to techxtreme.me

### DIFF
--- a/domains/techxtreme.json
+++ b/domains/techxtreme.json
@@ -4,6 +4,6 @@
     "email": "techxtremebuisness@gmail.com"
   },
   "records": {
-    "CNAME": "its-techxtreme.github.io"
+    "URL": "https://techxtreme.me"
   }
 }


### PR DESCRIPTION
## Summary
- Update `domains/techxtreme.json` from a GitHub Pages `CNAME` to a `URL` redirect
- Portfolio primary domain is now `https://techxtreme.me`
- Keep `techxtreme.is-a.dev` working by redirecting visitors to the new domain

## Why
GitHub Pages only supports one primary custom domain. After moving the site to `techxtreme.me`, the old `CNAME` to `its-techxtreme.github.io` started returning 404 for `techxtreme.is-a.dev`.

## Test plan
- [ ] Confirm JSON validates
- [ ] After merge, visit `https://techxtreme.is-a.dev` and verify redirect to `https://techxtreme.me`