### PR TITLE
Update manasrai.is-a.dev: CNAME to GitHub Pages

### DIFF
--- a/domains/manasrai.json
+++ b/domains/manasrai.json
@@ -4,6 +4,6 @@
     "email": "rai.manas12@gmail.com"
   },
   "records": {
-    "CNAME": "manas-rai-portfolio.pages.dev"
+    "CNAME": "manas-rai.github.io"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live at: https://manas-rai-portfolio.pages.dev (moving to GitHub Pages — see purpose below)

![Website preview](https://raw.githubusercontent.com/manas-rai/register/assets/site-preview.png)

# Website Purpose

**Record update for my existing domain** (registered in #44351): changing the CNAME target from `manas-rai-portfolio.pages.dev` to `manas-rai.github.io`.

Reason: Cloudflare Pages cannot attach an is-a.dev subdomain (cross-account zone — the domain currently returns Cloudflare error 1014 "CNAME Cross-User Banned"), as noted in [your Cloudflare Pages guide](https://docs.is-a.dev/guides/cloudflare-pages/). The site now deploys to GitHub Pages, and the repo's Pages custom domain is already configured as `manasrai.is-a.dev`. Same personal portfolio site, same owner.