### PR TITLE
Add torch.is-a.dev

### DIFF
--- a/domains/torch.json
+++ b/domains/torch.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "thebagworker",
+        "email": "thebagworker@users.noreply.github.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://torch-sable.vercel.app

![Torch homepage](https://raw.githubusercontent.com/thebagworker/DUX/mobile-ready/docs/torch-preview.png)

# Website Purpose

Torch is a **free, open-source (MIT)** developer tool and reference implementation. It provides a free, **key-less, CORS-enabled public API** (with a published OpenAPI spec) plus a React/TypeScript web client and self-hostable Supabase edge functions. Developers can consume the API directly from the browser to add enhanced token info to their own frontends, and the docs page ships copy-paste JavaScript `fetch` integration examples.

It is **not for commercial use**: there are no fees, no ads, no paywall, no accounts, and no keys — the entire project is open source at https://github.com/thebagworker/DUX and is intended as a free public good and integration reference for developers.
