### PR TITLE
Update jorge-solis.is-a.dev for Vercel verification

### DIFF
--- a/domains/_vercel.jorge-solis.json
+++ b/domains/_vercel.jorge-solis.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Darck-irso",
+    "email": "sophiairis.solutions@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=jorge-solis.is-a.dev,84589d788aed58b7e5f6"
+  }
+}

--- a/domains/jorge-solis.json
+++ b/domains/jorge-solis.json
@@ -4,6 +4,6 @@
     "email": "sophiairis.solutions@gmail.com"
   },
   "records": {
-    "CNAME": "portafolio-jsolis.vercel.app"
+    "A": ["216.198.79.1"]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

# Website Preview

[https://portafolio-jsolis.vercel.app](https://portafolio-jsolis.vercel.app)

![Jorge Solís portfolio preview](https://portafolio-jsolis.vercel.app/assets/social-preview.png)

# Website Purpose

This updates the existing jorge-solis.is-a.dev registration to use Vercel's current recommended A record and adds the TXT ownership verification required to connect the domain to the portfolio's production deployment. The site is Jorge Solís's personal software development portfolio.
