### PR TITLE
Register tgtylab.is-a.dev and redteam-ops.is-a.dev

### DIFF
--- a/domains/redteam-ops.json
+++ b/domains/redteam-ops.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "793303326",
+        "email": "l793303326@gmail.com"
+    },
+    "records": {
+        "URL": "https://github.com/793303326"
+    }
+}

--- a/domains/tgtylab.json
+++ b/domains/tgtylab.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "793303326",
+        "email": "l793303326@gmail.com"
+    },
+    "records": {
+        "URL": "https://github.com/793303326"
+    }
+}


### PR DESCRIPTION
## Domains
- `tgtylab.is-a.dev`
- `redteam-ops.is-a.dev`

## Owner
- GitHub: @793303326
- Email: l793303326@gmail.com

## Records
URL redirect → https://github.com/793303326

## Checklist
- [x] I have read the documentation
- [x] Personal / non-commercial developer profile
- [x] owner.username matches my GitHub account

## Preview
https://github.com/793303326
