### PR TITLE
Register shift24.is-a.dev (email DNS)

### DIFF
--- a/domains/_dmarc.shift24.json
+++ b/domains/_dmarc.shift24.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dfv1663-eng",
+        "email": "dfv1663@gmail.com"
+    },
+    "records": {
+        "TXT": "v=DMARC1; p=none;"
+    }
+}

--- a/domains/resend._domainkey.shift24.json
+++ b/domains/resend._domainkey.shift24.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dfv1663-eng",
+        "email": "dfv1663@gmail.com"
+    },
+    "records": {
+        "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDNBYby0W1U9Rdm7pb1HasKpYTwHddXJ99oxO3ntgUMJvDx0xSW4/fN6GjgkDvf8HuTMiWz8Fp1Fc2nxSePQCrXpYg1Z/vjSHOqvyzy7D/rr535zl6Mdkf7jcO8b5pM7S5kliGtV2lGOPUxbBHtl4U2ZD2x8fmPihvnjSkUd92mhQIDAQAB"
+    }
+}

--- a/domains/send.shift24.json
+++ b/domains/send.shift24.json
@@ -1,0 +1,15 @@
+{
+    "owner": {
+        "username": "dfv1663-eng",
+        "email": "dfv1663@gmail.com"
+    },
+    "records": {
+        "MX": [
+            {
+                "target": "feedback-smtp.sa-east-1.amazonses.com",
+                "priority": 10
+            }
+        ],
+        "TXT": "v=spf1 include:amazonses.com ~all"
+    }
+}

--- a/domains/shift24.json
+++ b/domains/shift24.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "dfv1663-eng",
+        "email": "dfv1663@gmail.com"
+    },
+    "records": {
+        "URL": "https://github.com/dfv1663-eng"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

The root subdomain redirects to my GitHub profile: https://github.com/dfv1663-eng

![preview](https://avatars.githubusercontent.com/dfv1663-eng)

# Website Purpose

This registration is primarily for **transactional email DNS** (following the same pattern as your Zoho Mail / ImprovMX guides): the nested records configure Resend (DKIM at `resend._domainkey`, SPF + MX at `send`, and DMARC) for a non-commercial shift-management app I am developing (Next.js + Prisma, currently in a private repo while in development). The root subdomain redirects to my GitHub profile where the development work lives. No revenue is generated by this project.

---
