### PR TITLE
Register matthewcalabia.is-a.dev

### DIFF
--- a/domains/_vercel.matthewcalabia.json
+++ b/domains/_vercel.matthewcalabia.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "matcalabs002-sketch",
+        "email": "calabiamatthew@live.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=matthewcalabia.is-a.dev,30cedddc94cc84bf9f43"
+    }
+}

--- a/domains/matthewcalabia.json
+++ b/domains/matthewcalabia.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "matcalabs002-sketch",
+        "email": "calabiamatthew@live.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Registering `matthewcalabia.is-a.dev` for my personal developer portfolio.

- Site: personal portfolio (Next.js), hosted on Vercel — currently at https://matthew-calabia.vercel.app
- `domains/matthewcalabia.json`: CNAME to `cname.vercel-dns.com`
- `domains/_vercel.matthewcalabia.json`: Vercel domain verification TXT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tc9nSQLmUaRH59NanH1nf3