### PR TITLE
Update salman-twin.is-a.dev CNAME to current Amplify target

### DIFF
--- a/domains/salman-twin.json
+++ b/domains/salman-twin.json
@@ -4,6 +4,6 @@
     "email": "msalmansaeedch786@gmail.com"
   },
   "records": {
-    "CNAME": "d23m4m583gvtfs.cloudfront.net"
+    "CNAME": "d3v9jw2cinucd.cloudfront.net"
   }
 }


### PR DESCRIPTION
Small follow up to my last merged PR (#44328).

I had to re-add my domain on AWS Amplify to get the SSL certificate reissued, and when Amplify does that it hands out a new CloudFront address. So this just updates the CNAME to the current target. Same domain, same owner, one line changed.