### PR TITLE
Add _vercel TXT verification for deepak0x.is-a.dev

### DIFF
--- a/domains/_vercel.deepak0x.json
+++ b/domains/_vercel.deepak0x.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "deepak0x",
+    "email": "deepak988088@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=deepak0x.is-a.dev,d14c805b173b7ec4941a"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

This is a `_vercel` TXT verification record for my already-registered domain `deepak0x.is-a.dev`, which hosts my personal developer portfolio.

Live site: https://portfolio-deepak-bhagat.vercel.app

# Website Purpose

Vercel requires a `_vercel.deepak0x.is-a.dev` TXT record to verify domain ownership before it will serve my portfolio on `deepak0x.is-a.dev`. This PR only adds that verification record. The site itself is my non-commercial software-development portfolio (React/Vite).
