### PR TITLE
Add Vercel verification record for vs.is-a.dev

### DIFF
--- a/domains/_vercel.vs.json
+++ b/domains/_vercel.vs.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "vaisax",
+    "email": "vaibhavsxn15@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=vs.is-a.dev,1d554e1dd9031eab8e47"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://vaibhav-saxena.vercel.app/

![Website preview](https://vaibhav-saxena.vercel.app/preview.png)

# Website Purpose

Adds the Vercel TXT domain-verification record for `vs.is-a.dev` (domain registered in #44415, merged). Required per the [is-a.dev Vercel guide](https://docs.is-a.dev/guides/vercel/) so Vercel will serve the site on this subdomain.
