### PR TITLE
Add scapta.is-a.dev

### DIFF
--- a/domains/scapta.json
+++ b/domains/scapta.json
@@ -3,7 +3,7 @@
     "username": "ArchJunior",
     "email": "archjunior@proton.me"
   },
-  "record": {
+  "records": {
     "URL": "https://github.com/ArchJunior"
   }
 }

--- a/domains/scapta.json
+++ b/domains/scapta.json
@@ -1,6 +1,9 @@
 {
-  "owner": "archjunior@proton.me",
+  "owner": {
+    "username": "ArchJunior",
+    "email": "archjunior@proton.me"
+  },
   "record": {
-    "URL": "https://discord.gg/UsJvDUSuU"
+    "URL": "https://github.com/ArchJunior"
   }
 }

--- a/domains/scapta.json
+++ b/domains/scapta.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ArchJunior",
+    "email": "archjunior@proton.me"
+  },
+  "records": {
+    "URL": "https://discord.gg/UsJvDUSuU"
+  }
+}

--- a/domains/scapta.json
+++ b/domains/scapta.json
@@ -1,9 +1,6 @@
 {
-  "owner": {
-    "username": "ArchJunior",
-    "email": "archjunior@proton.me"
-  },
-  "records": {
+  "owner": "archjunior@proton.me",
+  "record": {
     "URL": "https://discord.gg/UsJvDUSuU"
   }
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev).
- [x] My file is following the [domain structure](https://is-a.dev).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://github.com/ArchJunior

# Website Purpose
This domain officially belongs to "Scapta Development." We are actively engaged in software development, cybersecurity, and penetration testing. Currently, this domain serves as the main hub redirecting to our official GitHub profile to showcase the open-source projects we are actively developing, such as our Python-based tool "ScaptanaX".


<img width="1659" height="929" alt="image" src="https://github.com/user-attachments/assets/6d003364-39de-4e72-aabd-80b52efd6d90" />
