### PR TITLE
feat: redirect pranjal.is-a.dev to psbhatnagar.in

### DIFF
--- a/domains/pranjal.json
+++ b/domains/pranjal.json
@@ -1,9 +1,9 @@
 {
   "owner": {
     "username": "Pranjal-SB",
-    "email": "psbhatnagar.in@gmal.com"
+    "email": "psbhatnagar.in@gmail.com"
   },
   "records": {
-    "CNAME": "pranjal-sb.github.io"
+    "URL": "https://psbhatnagar.in"
   }
 }


### PR DESCRIPTION
Changes my existing `pranjal.is-a.dev` from a CNAME (GitHub Pages) to a `URL` redirect record pointing to my main site https://psbhatnagar.in. Also fixed a typo in my owner email.