### PR TITLE
Add Vercel verification for tareqshahalam.is-a.dev

### DIFF
--- a/domains/_vercel.tareqshahalam.json
+++ b/domains/_vercel.tareqshahalam.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "Tareq905",
+    "email": "tareqshah.027@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=tareqshahalam.is-a.dev,ef398bf52bf17b7f2813",
+      "vc-domain-verify=www.tareqshahalam.is-a.dev,cf459f016e434707fa31"
+    ]
+  }
+}

--- a/domains/_vercel.tareqshahalam.json
+++ b/domains/_vercel.tareqshahalam.json
@@ -4,9 +4,6 @@
     "email": "tareqshah.027@gmail.com"
   },
   "records": {
-    "TXT": [
-      "vc-domain-verify=tareqshahalam.is-a.dev,ef398bf52bf17b7f2813",
-      "vc-domain-verify=www.tareqshahalam.is-a.dev,cf459f016e434707fa31"
-    ]
+    "TXT": "vc-domain-verify=tareqshahalam.is-a.dev,ef398bf52bf17b7f2813"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live Website:**  
https://tareq-weld.vercel.app

**Screenshot:**  
(Attach a screenshot of your website by dragging and dropping it into this PR.)

# Website Purpose

This pull request adds the required Vercel TXT verification record for my existing `tareqshahalam.is-a.dev` domain so that ownership can be verified successfully with Vercel.

My website is a personal portfolio showcasing my software development and AI engineering projects, technical skills, and professional experience. It is intended for educational and portfolio purposes only and is not used for commercial activities or revenue generation.

<img width="1646" height="857" alt="image" src="https://github.com/user-attachments/assets/0b17b475-1fa6-43e4-b9db-09e171fcbc79" />
