### PR TITLE
Register lume.is-a.dev

### DIFF
--- a/domains/lume.json
+++ b/domains/lume.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "1zapper",
+        "email": "mumomainga7@gmail.com"
+    },
+    "records": {
+        "A": ["145.241.238.133"]
+    }
+}


### PR DESCRIPTION
Registering `lume.is-a.dev` with an A record pointing to my self-hosted VPS (145.241.238.133), for a personal dashboard/site project (Lume).