### PR TITLE
Register bot-devops.is-a.dev

### DIFF
--- a/domains/bot-devops.json
+++ b/domains/bot-devops.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "th4nhhuy",
+    "email": "nguyenthanhhuy0233@gmail.com"
+  },
+  "records": {
+    "A": ["103.67.184.116"]
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Registering `bot-devops.is-a.dev` (A record, proxied via Cloudflare) for a personal DevOps bot/dashboard project.