### PR TITLE
Add hix.is-a.dev

### DIFF
--- a/domains/_vercel.hix.json
+++ b/domains/_vercel.hix.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HixDr",
+        "email": "eftihisdrakakis@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=hix.is-a.dev,6d3d01cb26d2fce03d66"
+    }
+}

--- a/domains/hix.json
+++ b/domains/hix.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "HixDr",
+        "email": "eftihisdrakakis@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live site: https://hix-dev.vercel.app/

_Screenshot:_
<img width="2535" height="1266" alt="image" src="https://github.com/user-attachments/assets/b9bc1d95-59b7-434a-9982-23f8ba196895" />


# Website Purpose

My personal developer portfolio. It lists my projects — a real-time Athens transit app, a Google Summer of Code 2025 project (govdoc-scanner), and this site — plus an about page and contact links. I'm requesting `hix.is-a.dev`.

Two files: `domains/hix.json` (A record to Vercel) and `domains/_vercel.hix.json` (Vercel ownership TXT).
