### PR TITLE
Add Vercel domain configuration for yashdev

### DIFF
--- a/domains/_vercel.www.yashdev.json
+++ b/domains/_vercel.www.yashdev.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "yash-pokiya",
+    "email": "yashpokiya44@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=www.yashdev.is-a.dev,3804ee4050aab79de162"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Website:** https://yashdev.is-a.dev

**Screenshot:**

<img width="1920" height="961" alt="Portfolio Preview" src="https://github.com/user-attachments/assets/a2449ebf-f291-4751-8545-ef299b6c5388" />

# Website Purpose

This pull request adds the DNS verification record required for the **www.yashdev.is-a.dev** subdomain. The website is my personal portfolio showcasing my MERN Stack projects, backend development skills, technical blogs, experience, and contact information. It is intended for learning, professional networking, and demonstrating my software development work. It is not used for commercial purposes.