### PR TITLE
Register resume.is-a.dev

### DIFF
--- a/domains/resume.json
+++ b/domains/resume.json
@@ -3,8 +3,7 @@
     "username": "shangchaovo",
     "email": "shangchaoxie888@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "shangchaovo.github.io"
-  },
-  "description": "Resume builder (Resume Forge)"
+  }
 }

--- a/domains/resume.json
+++ b/domains/resume.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "shangchaovo",
+    "email": "shangchaoxie888@gmail.com"
+  },
+  "record": {
+    "CNAME": "shangchaovo.github.io"
+  },
+  "description": "Resume builder (Resume Forge)"
+}


### PR DESCRIPTION
Registering **resume.is-a.dev** → CNAME shangchaovo.github.io (a GitHub Pages site hosting my open resume-builder). Thank you for the free subdomain!