### PR TITLE
feat(pranjal): change record to URL redirect to psbhatnagar.in

### DIFF
--- a/domains/pranjal.json
+++ b/domains/pranjal.json
@@ -1,9 +1,9 @@
 {
   "owner": {
     "username": "Pranjal-SB",
-    "email": "psbhatnagar.in@gmal.com"
+    "email": "psbhatnagar.in@gmail.com"
   },
   "records": {
-    "CNAME": "pranjal-sb.github.io"
+    "URL": "https://psbhatnagar.in"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live site:** https://psbhatnagar.in

![Preview of psbhatnagar.in](https://raw.githubusercontent.com/Pranjal-SB/register-is-a-dev/assets/psbhatnagar-preview.png)

# Website Purpose

This is my personal developer portfolio — projects, skills, write-ups on things I've
built, and contact links. Non-commercial; it exists to showcase my software work as a
CSE & cybersecurity student.

# Note on this change

`pranjal.is-a.dev` is an **existing** domain of mine. This PR updates it rather than
registering a new one:

- **Before:** `"CNAME": "pranjal-sb.github.io"` (pointed at my GitHub Pages profile readme)
- **After:** `"URL": "https://psbhatnagar.in"` (redirects to my main portfolio site)

I've since moved my portfolio to its own domain, so the subdomain should redirect there
instead of serving the old Pages site. I've already removed the custom domain from the
GitHub Pages repo, so nothing else claims the name.

Also corrected a typo in my `owner.email` (`gmal.com` → `gmail.com`).
