### PR TITLE
Add lucas-nous.json for AstrBot dashboard configuration

### DIFF
--- a/domains/lucas-nous.json
+++ b/domains/lucas-nous.json
@@ -1,0 +1,10 @@
+{
+  "description": "AstrBot dashboard hosted via Cloudflare Tunnel",
+  "repo": "https://github.com/YSSYHS",
+  "owner": {
+    "username": "YSSYHS"
+  },
+  "record": {
+    "CNAME": "32c77b3d-e766-44c5-97a8-4b27aae04860.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

- Temporary URL (while waiting for DNS): https://thin-engaging-million-recommendations.trycloudflare.com
- Target domain after merge: https://lucas-nous.is-a.dev
- Screenshot: 
<img width="2517" height="1432" alt="QQ_1784734925277" src="https://github.com/user-attachments/assets/dca64d64-6bf5-4b8c-8815-4dd10815759c" />

# Website Purpose

AstrBot open-source chatbot dashboard for self-hosted bot management and development testing (QQ bot / AI chat configuration UI). Not commercial.