### PR TITLE
fix: add apex domain A record for minurjoy.is-a.dev

### DIFF
--- a/domains/minurjoy.json
+++ b/domains/minurjoy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MJ0121",
+        "email": "minurrahmanjoy1@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
Adds domains/minurjoy.json with A record pointing to 216.198.79.1 (Vercel IP) to enable SSL certificate provisioning for the apex domain.