### PR TITLE
fix: update maykonvasconceloz.is-a.dev CNAME to Cloudflare Tunnel

### DIFF
--- a/domains/maykonvasconceloz.json
+++ b/domains/maykonvasconceloz.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Maykonvasconceloz-dev"
+  },
+  "records": {
+    "CNAME": "maykonvasconceloz.github.io"
+  }
+}

--- a/domains/maykonvasconceloz.json
+++ b/domains/maykonvasconceloz.json
@@ -3,6 +3,7 @@
     "username": "Maykonvasconceloz-dev"
   },
   "records": {
-    "CNAME": "maykonvasconceloz.github.io"
-  }
+    "CNAME": "72dbe338-4592-41e4-bc48-609d7e8803c.cfargotunnel.com"
+  },
+  "proxied": true
 }


### PR DESCRIPTION
# Update CNAME Record

## Changes
- Updated CNAME from placeholder to Cloudflare Tunnel target: `72dbe338-4592-41e4-bc48-609d7e8803c.cfargotunnel.com`

## Reason
Domain is now configured with Cloudflare Tunnel to expose local n8n instance.

## Checklist
- [x] I have read and followed the [documentation](https://docs.is-a.dev)
- [x] The file I am adding is in the `domains` directory
- [x] The file name is correct (lowercase, alphanumeric, .json extension)
- [x] The JSON file is valid
- [x] The owner username matches my GitHub username

## Notes
- Cloudflare Tunnel is running and healthy
- n8n instance will be accessible at https://maykonvasconceloz.is-a.dev after DNS propagation