### PR TITLE
jfc: migrate root to Vercel and add nested dash.jfc subdomain

### DIFF
--- a/domains/_vercel.jfc.json
+++ b/domains/_vercel.jfc.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "juanfranciscocis",
+    "email": "jfcisnerosg@icloud.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=jfc.is-a.dev,786b2ee28e4117d82448",
+      "vc-domain-verify=dash.jfc.is-a.dev,c8f77e23081b937e5b47"
+    ]
+  }
+}

--- a/domains/dash.jfc.json
+++ b/domains/dash.jfc.json
@@ -4,7 +4,7 @@
     "email": "jfcisnerosg@icloud.com"
   },
   "records": {
-    "CNAME": "e62c10e88c5d1aa6.vercel-dns-017.com"
+    "CNAME": "afb3cb3ff26b675f.vercel-dns-017.com"
   },
   "proxied": false
 }


### PR DESCRIPTION
# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Root — `jfc.is-a.dev`** (my software development portfolio, live now): https://jfc.is-a.dev

<img width="1440" alt="jfc.is-a.dev — developer portfolio" src="https://jfc-portfolio.vercel.app/previews/preview-desktop.png" />

**Nested — `dash.jfc.is-a.dev`** (personal dashboard, nested under my root): https://personal-dashboard-ten-omega.vercel.app

<img width="1488" alt="dash.jfc.is-a.dev — personal dashboard" src="https://github.com/user-attachments/assets/e5be4862-6ba0-4015-b7f1-16f6cd6c1ca9" />

# Website Purpose

I **already own the root subdomain** `jfc.is-a.dev` (`domains/jfc.json`, registered under this same GitHub account and email). It serves my software development portfolio — I'm a computer science engineer working in web/mobile development, QA and DevOps.

This PR does two things:

1. **Migrates my existing root** `jfc.is-a.dev` from Firebase hosting to Vercel (CNAME update in `domains/jfc.json`). Same portfolio site, new host.
2. **Adds a nested subdomain** `dash.jfc.is-a.dev` under my root for my personal dashboard. Per the rules, nested subdomains under an owned root may be used for anything ToS-compliant.

The `_vercel.jfc.json` TXT records are Vercel's required domain-ownership verification for both hostnames.

*Context: my previous PR #40823 was closed as "not software development related" — I believe the nested `dash` subdomain was mistakenly evaluated as a root registration. The root `jfc.is-a.dev` is mine (same `owner` in `domains/jfc.json`) and is dev-related, as shown above.*
