### PR TITLE
Add webhookinspector.is-a.dev

### DIFF
--- a/domains/webhookinspector.json
+++ b/domains/webhookinspector.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Damarnadh18814",
+    "email": "damarnadh18814@gmail.com"
+  },
+  "records": {
+    "CNAME": "webhook-inspector-production-aff7.up.railway.app"
+  }
+}


### PR DESCRIPTION
Requesting a free subdomain for Webhook Inspector, a webhook debugging/testing tool. CNAME points to the app's Railway deployment.

- [x] I have read and understood the Terms and Conditions
- [x] I have chosen a domain that respects the Domain Rules
- [x] My domain does not point to a webpage/service that is offensive, illegal, or violates any laws
- [x] I have not registered this domain to sell or auction it
