### PR TITLE
fix: update minurjoy.is-a.dev CNAME to Vercel DNS proxy

### DIFF
--- a/domains/minurjoy.json
+++ b/domains/minurjoy.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MJ0121",
+        "email": "minurrahmanjoy1@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
# Fix SSL for minurjoy.is-a.dev

## Problem
The current CNAME in domains/minurjoy.json points to portfolio-iota-weld-33.vercel.app (Vercel deployment URL) instead of Vercel's DNS proxy. This prevents SSL certificate provisioning — the domain returns 403.

## Current state
- minurjoy.is-a.dev → CNAME → portfolio-iota-weld-33.vercel.app (wrong)
- www.minurjoy.is-a.dev → CNAME → 6c2e9f77dffb4fa5.vercel-dns-017.com (correct)
- _vercel.minurjoy.is-a.dev TXT records → live and verified

## Fix
Replace the CNAME with an A record pointing to Vercel's edge IP \216.198.79.1\ so SSL certificate provisioning works for the apex domain.

## Verification
- DNS resolves: \minurjoy.is-a.dev\ → A → \216.198.79.1\
- SSL cert will be auto-provisioned by Vercel after domain is added to project

## Related
Previous PR #44627 attempted this fix but was closed. This PR reopens the same fix from the fork branch.

---

- [x] Website is reachable at https://portfolio-iota-weld-33.vercel.app
- [x] File follows [domain structure](https://docs.is-a.dev/domain-structure/)
- [x] Not for commercial use
- [x] Contact info provided in owner key