### PR TITLE
fix: update minurjoy.is-a.dev to A record for Vercel

### DIFF
--- a/domains/minurjoy.json
+++ b/domains/minurjoy.json
@@ -1,9 +1,1 @@
-{
-    "owner": {
-        "username": "MJ0121",
-        "email": "minurrahmanjoy1@gmail.com"
-    },
-    "records": {
-        "CNAME": "portfolio-iota-weld-33.vercel.app"
-    }
-}
+{"owner":{"username":"MJ0121","email":"minurrahmanjoy1@gmail.com"},"records":{"A":["216.198.79.1"]}}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

# Website Preview

https://minurjoy.is-a.dev

![Portfolio Website](https://portfolio-iota-weld-33.vercel.app)

# Website Purpose

Personal portfolio website showcasing my projects, skills, and experience as a creative technologist and filmmaker. Built with Next.js 16, Sanity CMS, and Tailwind CSS.

# Changes

- Changed `CNAME` record to `A` record pointing to `216.198.79.1` (Vercel edge IP)
- Fixes SSL certificate provisioning for apex domain
- `www.minurjoy.is-a.dev` already works with CNAME to `6c2e9f77dffb4fa5.vercel-dns-017.com`
- `_vercel.minurjoy.is-a.dev` TXT verification records already merged in PR #44493