### PR TITLE
Register kopilka.is-a.dev

### DIFF
--- a/domains/kopilka.json
+++ b/domains/kopilka.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "solarka892",
+    "email": "solarcrew688@gmail.com"
+  },
+  "records": {
+    "CNAME": "kopilka-482.pages.dev"
+  }
+}


### PR DESCRIPTION
Registering `kopilka.is-a.dev` — a personal expense-tracker PWA hosted on Cloudflare Pages.

- **CNAME** → `kopilka-482.pages.dev`
- Owner: @solarka892

Thanks!