### PR TITLE
Register gurbaj.is-a.dev

### DIFF
--- a/domains/_vercel.gurbaj.json
+++ b/domains/_vercel.gurbaj.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "singh26gurbaj-lab",
+    "email": "singh26gurbaj@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=gurbaj.is-a.dev,24c4af8b6154738efbfa"
+  }
+}

--- a/domains/gurbaj.json
+++ b/domains/gurbaj.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "singh26gurbaj-lab",
+    "email": "singh26gurbaj@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `gurbaj.is-a.dev` for my personal web design portfolio, hosted on Vercel.

- `gurbaj.json` — CNAME to `cname.vercel-dns.com` (my Vercel deployment)
- `_vercel.gurbaj.json` — TXT record Vercel requires to verify domain ownership

Thanks for the great free service! ⭐