### PR TITLE
Add GitHub Pages verification TXT for sid.is-a.dev

### DIFF
--- a/domains/sid.json
+++ b/domains/sid.json
@@ -5,6 +5,9 @@
   },
   "proxied": true,
   "records": {
-    "CNAME": "11sid11.github.io"
+    "CNAME": "11sid11.github.io",
+    "TXT": [
+      "_github-pages-challenge-11sid11.sid.is-a.dev=3ee5f5a1c7920d09e2e2cf4699bbc2"
+    ]
   }
 }


### PR DESCRIPTION
Adds a DNS TXT record required by GitHub Pages to release the custom-domain lock on sid.is-a.dev so it can be assigned to 11sid11/11sid11.github.io.

The verification code is obtained from the GitHub Pages domain verification flow (https://github.com/settings/pages).

Reference format used in another is-a.dev domain: _github-pages-challenge-<username>.<subdomain>.is-a.dev=<code>.