### PR TITLE
Register nexora.is-a.dev subdomain

### DIFF
--- a/domains/nexora.json
+++ b/domains/nexora.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "NickDev24"
+  },
+  "records": {
+    "CNAME": "c7012caf-665a-486e-b1bd-db9729353bfb.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
## Subdomain Registration

- **Subdomain**: nexora
- **Owner**: NickDev24
- **CNAME**: c7012caf-665a-486e-b1bd-db9729353bfb.cfargotunnel.com (Cloudflare Tunnel)
- **Purpose**: Autonomous digital product factory — AI-driven content pipeline with 2D office UI

The site is live on a Cloudflare Tunnel and ready to serve traffic once DNS is configured.