### PR TITLE
Add ghostpool.is-a.dev

### DIFF
--- a/domains/_vercel.ghostpool.json
+++ b/domains/_vercel.ghostpool.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MurakamiRyujirou",
+        "email": "murakami.ryujirou+isadev@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=ghostpool.is-a.dev,25f934018b549e98432d"
+    }
+}

--- a/domains/ghostpool.json
+++ b/domains/ghostpool.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "MurakamiRyujirou",
+        "email": "murakami.ryujirou+isadev@gmail.com"
+    },
+    "records": {
+        "A": ["216.198.79.1"]
+    }
+}


### PR DESCRIPTION
Registering ghostpool.is-a.dev for GhostPool, a billiards match platform hosted on Vercel.

- domains/ghostpool.json (A record)
- domains/_vercel.ghostpool.json (TXT record for Vercel domain verification)