### PR TITLE
Add TXT record for domain verification (_vercel.ankit-negi)

### DIFF
--- a/domains/_vercel.ankit-negi.json
+++ b/domains/_vercel.ankit-negi.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ankitnegi-dev",
+    "email": "ank12it11@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=ankit-negi.is-a.dev,1e03259bb19d2a43ac6d"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
https://portfolio-inky-delta-25cipm8ebc.vercel.app

(This is a TXT-only verification file for `_vercel.ankit-negi.is-a.dev`, required by Vercel to verify ownership of my already-registered `ankit-negi.is-a.dev` domain from PR #44732. The link above is my live portfolio site, currently served from Vercel while domain verification completes.)

# Website Purpose
Personal portfolio site showcasing my software development projects — full-stack web apps and AI agent systems built with Next.js, TypeScript, Python, and LangGraph.