### PR TITLE
Register dondokomon.is-a.dev

### DIFF
--- a/domains/dondokomon.json
+++ b/domains/dondokomon.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "lmattara"
+    },
+    "records": {
+        "CNAME": "lmattara.github.io"
+    }
+}


### PR DESCRIPTION
Registering dondokomon.is-a.dev to point to my GitHub Pages site (lmattara.github.io), hosting an indie game project.