### PR TITLE
Add eva.is-a.dev subdomain for Eva landing page

### DIFF
--- a/domains/eva.json
+++ b/domains/eva.json
@@ -1,9 +1,9 @@
 {
   "owner": {
-    "username": "mowatermelon",
-    "email": "neefoxmo@gmail.com"
+    "username": "rimonp",
+    "email": "rimonp3@gmail.com"
   },
   "records": {
-    "URL": "https://t.iiwhy.cn"
+    "A": ["216.198.79.1"]
   }
 }


### PR DESCRIPTION
Adding eva.is-a.dev subdomain pointing to Vercel (216.198.79.1). For Eva AI model landing page.