### PR TITLE
Add signal-tower-archive.json with owner details

### DIFF
--- a/signal-tower-archive.json
+++ b/signal-tower-archive.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "winkeysed",
+    "email": "daniilchentsov16@gmail.com"
+  },
+  "record": {
+    "CNAME": "winkeysed.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: https://winkeysed.github.io/ARCHIVE-7-SIGNAL-TOWER-SCHEMATICS/

<img width="1920" height="954" alt="image" src="https://github.com/user-attachments/assets/5e5298c6-e234-4e93-bebc-14b6d090a437" />

<img width="1918" height="952" alt="image2" src="https://github.com/user-attachments/assets/79593fa7-e8e9-4c0e-bc35-0c13571a152f" />

<img width="1920" height="948" alt="image3" src="https://github.com/user-attachments/assets/7019714d-f43b-481c-a865-5bf05cd668fc" />

<img width="1920" height="952" alt="image4" src="https://github.com/user-attachments/assets/b0b0bf2e-66f5-4361-aefd-1dd80aaaf394" />

<img width="1920" height="958" alt="image5" src="https://github.com/user-attachments/assets/82e69ba1-3d7d-47d2-bcfd-df443fa8c22a" />


# Website Purpose

Terminal-style archive page for a Minecraft server project. Built with HTML/CSS/JS. Displays construction schematics, coordinate cipher reference, and links to open-source Python decoder tools. Frontend dev exercise with a retro terminal aesthetic. No ads, no revenue.