### PR TITLE
feat: add vercel domain verification record for dhairyadarji.is-a.dev

### DIFF
--- a/domains/_vercel.dhairyadarji.json
+++ b/domains/_vercel.dhairyadarji.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Dhairya0707",
+    "email": "dhairyadarji7867@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=dhairyadarji.is-a.dev,3d8267a1faae32db8f07"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live Preview:** https://dhairya-rosy.vercel.app

> **Note:** This PR only adds the `_vercel.dhairyadarji.json` verification file required by Vercel. The root domain configuration was added and merged in PR #44742.

*(Attach the same screenshot of your portfolio homepage that you used in the previous PR.)*

# Website Purpose

This website is my personal software developer portfolio. It showcases my projects, technical skills, open-source contributions, and experience. This PR only adds the Vercel TXT verification record required to verify ownership of `dhairyadarji.is-a.dev`.