### PR TITLE
Add MX and TXT records to detox-in.json

### DIFF
--- a/domains/detox-in.json
+++ b/domains/detox-in.json
@@ -7,8 +7,8 @@
     "records": {
         "CNAME": "anshulpj12.github.io",
         "MX": [
-            "mx1.improvmx.com.",
-            "mx2.improvmx.com."
+            "mx1.improvmx.com",
+            "mx2.improvmx.com"
         ],
         "TXT": "v=spf1 include:spf.improvmx.com ~all"
     }

--- a/domains/detox-in.json
+++ b/domains/detox-in.json
@@ -3,6 +3,7 @@
         "username": "Anshulpj12",
         "email": "anshulprajapati2220@gmail.com"
     },
+    "proxied": true,
     "records": {
         "CNAME": "anshulpj12.github.io",
         "MX": [

--- a/domains/detox-in.json
+++ b/domains/detox-in.json
@@ -4,6 +4,11 @@
         "email": "anshulprajapati2220@gmail.com"
     },
     "records": {
-        "CNAME": "anshulpj12.github.io"
+        "CNAME": "anshulpj12.github.io",
+        "MX": [
+            "mx1.improvmx.com.",
+            "mx2.improvmx.com."
+        ],
+        "TXT": "v=spf1 include:spf.improvmx.com ~all"
     }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
Link: http://detox-in.is-a.dev

<img width="1433" height="782" alt="image" src="https://github.com/user-attachments/assets/6bcff03a-e9d9-4149-a15b-549cdf82bdd9" />


# Website Purpose
This is an update to the existing detox-in.is-a.dev subdomain. Adding MX and SPF TXT records to enable email forwarding via ImprovMX. The website is a personal developer portfolio showcasing AI and systems engineering projects built for IITs and NITs.
