### PR TITLE
Register kumsuk-books.is-a.dev

### DIFF
--- a/domains/kumsuk-books.json
+++ b/domains/kumsuk-books.json
@@ -2,7 +2,7 @@
   "owner": {
     "username": "pinkpink4949-droid"
   },
-  "record": {
+  "records": {
     "CNAME": "pinkpink4949-droid.github.io"
   }
 }

--- a/domains/kumsuk-books.json
+++ b/domains/kumsuk-books.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "pinkpink4949-droid"
+  },
+  "record": {
+    "CNAME": "pinkpink4949-droid.github.io"
+  }
+}


### PR DESCRIPTION
**Website preview:** https://pinkpink4949-droid.github.io/kumsuk-books/

Registering `kumsuk-books.is-a.dev` for a small-business accounting & production web app (KUMSUK Books), hosted on GitHub Pages.

- [x] I have read and understood the [documentation](https://docs.is-a.dev) and the terms of registration.
- The site is live and functional at the preview link above.