### PR TITLE
Add zuud.is-a.dev

### DIFF
--- a/domains/zuud.json
+++ b/domains/zuud.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "Gankhulug1998",
+        "email": "geregevending@gmail.com"
+    },
+    "records": {
+        "A": ["84.247.165.220"]
+    },
+    "proxied": false
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live preview (server IP, pre-DNS): http://84.247.165.220:8090/

Once this PR is merged, the server's nginx is already configured to serve `zuud.is-a.dev` on this A record and will obtain a Let's Encrypt certificate for HTTPS.

Landing page:

![Zuud landing page](http://84.247.165.220:8090/screenshot-landing.png)

Admin dashboard login:

![Zuud admin dashboard login](http://84.247.165.220:8090/screenshot-admin-login.png)

# Website Purpose

Zuud ("Зүүд" — "dream" in Mongolian) is my free personal sleep-regimen app: sleep logging, a 28-day step-by-step schedule adjustment plan, evening wind-down routines, statistics, and sleep-hygiene tips in Mongolian. The domain serves the project's web side — a landing page, the Go/PostgreSQL REST API, and a Next.js admin dashboard — which the SwiftUI iOS client also talks to.

