### PR TITLE
Add GitHub Pages verification TXT for sid.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-11sid11.sid.json
+++ b/domains/_github-pages-challenge-11sid11.sid.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "11sid11",
+    "email": "sid6117828@gmail.com"
+  },
+  "records": {
+    "TXT": "3ee5f5a1c7920d09e2e2cf4699bbc2"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). The file is a separate JSON under `domains/` at the verification hostname path (`_github-pages-challenge-11sid11.sid.json`), following the same pattern as other verified subdomains.
- [x] My website is **reachable** and **completed**. Live at https://11sid11.github.io (will resolve to https://sid.is-a.dev once this TXT record is merged and the custom domain is assigned on GitHub Pages).
- [x] My website is **software development** related. Personal portfolio for a software developer.
- [x] My website is **not for commercial use**. Personal landing page only; no ads, no revenue, no commercial activity.
- [x] I have provided contact information in the `owner` key. Email: `sid6117828@gmail.com`.
- [x] I have provided a preview of my website below.

# Website Preview

- Live URL: https://11sid11.github.io
- Screenshot: https://11sid11.github.io/preview.png

![preview](https://11sid11.github.io/preview.png)

# Website Purpose

Personal portfolio / landing page. The site is reachable, completed, and serves as a developer profile (contact, about, skills, experience, projects, education). The CNAME for `sid.is-a.dev` → `11sid11.github.io` is already in place in `domains/sid.json` (merged via PR #44344). This PR adds the TXT record GitHub Pages requires to verify domain ownership and release the "custom domain already taken" lock on `sid.is-a.dev`.

The TXT record hostname is `_github-pages-challenge-11sid11.sid.is-a.dev` (file `domains/_github-pages-challenge-11sid11.sid.json`) with the verification code obtained from the GitHub Pages domain verification flow.