### PR TITLE
feat: register chenwei.is-a.dev

### DIFF
--- a/domains/chenwei.json
+++ b/domains/chenwei.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "thomas-zz-2626",
+    "email": "19124164774tzz@gmail.com"
+  },
+  "record": {
+    "CNAME": "thomas-zz-2626.github.io"
+  }
+}


### PR DESCRIPTION
Register chenwei.is-a.dev for portfolio website.

- Points to thomas-zz-2626.github.io (GitHub Pages)
- Used for industrial designer portfolio