### PR TITLE
Add prism.is-a.dev

### DIFF
--- a/domains/prism.json
+++ b/domains/prism.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "syntaxixr"
+    },
+    "records": {
+        "A": ["188.215.31.73"]
+    }
+}


### PR DESCRIPTION
Registering `prism.is-a.dev` with an A record pointing to my VPS.

The subdomain will host PRISM — my personal developer portfolio and freelance site (Vite, vanilla JS, GSAP, three.js). The site is already live and serving over HTTPS at https://prism.188-215-31-73.sslip.io/, so the A record resolves to a working deployment from day one.

- Record: `A` → `188.215.31.73` (public IP, my own VPS running Caddy)
- No CNAME, no proxy, no wildcard
- First and only subdomain requested by this account