### PR TITLE
feat: add quiz.is-a.dev domain

### DIFF
--- a/domains/quiz.json
+++ b/domains/quiz.json
@@ -1,0 +1,12 @@
+{
+  "description": "An open-source interactive developer speed-trivia & coding arcade game for the developer community.",
+  "owner": {
+    "username": "ciroautuori",
+    "email": "ciro@studiocentos.it"
+  },
+  "records": {
+    "A": [
+      "51.89.43.46"
+    ]
+  }
+}


### PR DESCRIPTION
### Requirements

[✓] I agree to the Terms of Service https://is-a.dev/terms.
[✓] My file is following the domain structure https://docs.is-a.dev/domain-structure/.
[✓] My website is reachable and completed.
[✓] My website is software development related.
[✓] My website is not for commercial use.
[✓] I have provided contact information in the `owner` key.
[✓] I have provided a preview of my website below.

### Website Preview

Live URL: http://questdev.duckdns.org

Screenshot of the multi-track developer arcade game running in production:

Image: DevQuest Screenshot → https://raw.githubusercontent.com/ciroautuori/register/add-devquest-domain/preview.png

The app is a Next.js 15 developer trivia game served via Docker + Nginx on production server. It is fully functional and responding 200 OK directly on http://questdev.duckdns.org.

### Website Purpose

Quiz ( quiz.is-a.dev ) is a 100% free, open-source developer trivia arcade game (testing Python, TypeScript & Git syntax speed) for the developer community.

It contains NO educational courses, video lectures, enrolments, or paid content. It is 100% free, open-source, requires no login, and is built purely for developer entertainment and community contributions.