### PR TITLE
Redirect divyakush.is-a.dev to www.divyakush.com (URL record)

### DIFF
--- a/domains/divyakush.json
+++ b/domains/divyakush.json
@@ -4,6 +4,6 @@
     "email": "divyakushpunjabi@gmail.com"
   },
   "records": {
-    "CNAME": "divyakush2006.github.io"
+    "CNAME": "cname.vercel-dns.com"
   }
 }

--- a/domains/divyakush.json
+++ b/domains/divyakush.json
@@ -4,6 +4,6 @@
     "email": "divyakushpunjabi@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "URL": "https://www.divyakush.com"
   }
 }


### PR DESCRIPTION
I've moved my portfolio to a new primary domain, **www.divyakush.com**. This changes my existing `divyakush.is-a.dev` entry to a native `URL` redirect pointing there, so the old subdomain permanently forwards to the new site. Ownership (Divyakush2006) is unchanged.