### PR TITLE
feat: add router.is-a.dev domain

### DIFF
--- a/domains/router.json
+++ b/domains/router.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "FabianYD",
+        "email": "diazedwinyd@gmail.com"
+    },
+    "records": {
+        "A": ["130.107.18.55"]
+    }
+}


### PR DESCRIPTION
Adding \outer.is-a.dev\ with A record pointing to \130.107.18.55\ (Azure Container Instance for OmniRoute).

Co-Authored-By: Oz <oz-agent@warp.dev>