### PR TITLE
feat: add router.is-a.dev domain

### DIFF
--- a/domains/router.json
+++ b/domains/router.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "FabianYD",
+        "email": "diazedwinyd@gmail.com"
+    },
+    "records": {
+        "A": ["130.107.18.55"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [X] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [X] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [X] My website is **reachable** and **completed**.
- [X] My website is **software development** related.
- [X] My website is **not for commercial use**.

## Description

Adding \outer.is-a.dev\ with A record pointing to \130.107.18.55\ (Azure Container Instance for OmniRoute API Gateway).

Co-Authored-By: Oz <oz-agent@warp.dev>