### PR TITLE
Register neoclassic.is-a.dev

### DIFF
--- a/domains/_dmarc.neoclassic.json
+++ b/domains/_dmarc.neoclassic.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Tempohh",
+    "email": "03costa.andrea@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/neoclassic.json
+++ b/domains/neoclassic.json
@@ -1,0 +1,6 @@
+{
+  "owner": {
+    "username": "Tempohh",
+    "email": "03costa.andrea@gmail.com"
+  }
+}

--- a/domains/resend._domainkey.neoclassic.json
+++ b/domains/resend._domainkey.neoclassic.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Tempohh",
+    "email": "03costa.andrea@gmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDDexJXW6JbMK9r1ktt7baZuRiinplYOaFLh1b9RP8hu/7Hz8bw3P5Zqq7Jyy337Qp1BtNYIS8BYrOQEzwEltCmfr6+hXlbw93AE4eFzpEV0tNwmqnDx07jP7xmBL664mWQjxZCrlHS2qPRKDy2YkwrId8TYWU4KnGuMwqqkSkFcQIDAQAB"
+  }
+}

--- a/domains/send.neoclassic.json
+++ b/domains/send.neoclassic.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "Tempohh",
+    "email": "03costa.andrea@gmail.com"
+  },
+  "records": {
+    "MX": ["feedback-smtp.eu-west-1.amazonses.com"],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live at: https://neoclassic.duckdns.org

<img width="1917" height="989" alt="screenshotNeoclassic" src="https://github.com/user-attachments/assets/ceb3612b-4c44-4e47-81c1-aa64fcb61895" />

# Website Purpose

Personal full stack side project (self-hosted, Next.js + FastAPI + Postgres/PostGIS, web scraping pipeline, CI/CD via GitHub Actions to a free-tier Oracle Cloud VM) built for learning and personal use — used by myself to track cinema screenings. 
Not commercial, no monetization. This subdomain is used for DNS records only (email sending domain verification via Resend), not for hosting the site itself, which runs on its own domain.