### PR TITLE
add nilshogberg.is-a.dev

### DIFF
--- a/domains/nilshogberg.json
+++ b/domains/nilshogberg.json
@@ -1,9 +1,8 @@
 {
     "owner": {
-        "username": "Nimaho71",
-        "email": "nils.oi.hogberg@gmail.com"
+        "username": "Nimaho71"
     },
-    "record": {
+    "records": {
         "CNAME": "nilshogberg.vercel.app"
     }
 }

--- a/domains/nilshogberg.json
+++ b/domains/nilshogberg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Nimaho71",
+        "email": "nils.oi.hogberg@gmail.com"
+    },
+    "record": {
+        "CNAME": "nilshogberg.vercel.app"
+    }
+}

--- a/domains/nilshogberg.json
+++ b/domains/nilshogberg.json
@@ -1,6 +1,7 @@
 {
     "owner": {
-        "username": "Nimaho71"
+        "username": "Nimaho71",
+        "email": "nils.oi.hogberg@gmail.com"
     },
     "records": {
         "CNAME": "nilshogberg.vercel.app"


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://nilshogberg.vercel.app

![Portfolio preview](https://raw.githubusercontent.com/Nimaho71/portfolio/main/public/preview.png)

# Website Purpose

Personal developer portfolio. It presents my software projects, education, and cybersecurity/CTF work:

- **Chess engine** - Python chess AI using iterative-deepening NegaMax with alpha-beta pruning, plus a genetic algorithm that evolves piece-square tables ([repo](https://github.com/Nimaho71/chess-engine))
- **SPH fluid simulation** - real-time 2D fluid dynamics with parallel Numba JIT kernels ([repo](https://github.com/Nimaho71/Python-Fluid-Simulation))
- **Sentinel** - full-stack AI scraper using Playwright, Gemini, FastAPI and React ([repo](https://github.com/Nimaho71/sentinel-blocket))
- **Parallax gallery** - vanilla JS drag-scroll gallery built on the Web Animations API ([repo](https://github.com/Nimaho71/nature-gallery))

I am a student starting Computer Engineering at Chalmers University of Technology in autumn 2026, and this site is how I present my work to potential employers.

The site is entirely non-commercial - no ads, no paid content, no revenue of any kind. It is built with Next.js and hosted on Vercel.

Note: this replaces #40246, which I closed out after it was flagged for not using the PR template. Same domain and same CNAME target - this submission uses the template properly and includes the required preview.