### PR TITLE
Create _openai-site-verification.kosma.json

### DIFF
--- a/domains/_openai-site-verification.kosma.json
+++ b/domains/_openai-site-verification.kosma.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "KosmicznyNomad"
+  },
+  "records": {
+    "TXT": "openai-site-verification=HxlenDBzmXUUpg9ZoHxXeix9_sjDszeVUFeNkZmiEJ8"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live website: https://kosma-zalewski-portfolio.kosma-komunikacja.chatgpt.site/

![Kosma Zalewski portfolio preview](https://kosma-zalewski-portfolio.kosma-komunikacja.chatgpt.site/og.png)

# Website Purpose

This PR adds the OpenAI Sites TXT verification record required to connect the already registered `kosma.is-a.dev` domain to my personal software development portfolio.

Related registration PR: https://github.com/is-a-dev/register/pull/45076