### PR TITLE
Remove 'proxied' field from vividrue.json

### DIFF
--- a/domains/vividrue.json
+++ b/domains/vividrue.json
@@ -6,5 +6,5 @@
     "records": {
         "CNAME": "ghs.googlehosted.com",
         "TXT": "google-site-verification=NF638heI6H9KHkiCL_s1vlxKilHa80-IE2loFJyRLQg"
-    },
+    }
 }

--- a/domains/vividrue.json
+++ b/domains/vividrue.json
@@ -7,5 +7,4 @@
         "CNAME": "ghs.googlehosted.com",
         "TXT": "google-site-verification=NF638heI6H9KHkiCL_s1vlxKilHa80-IE2loFJyRLQg"
     },
-    "proxied": true
 }


### PR DESCRIPTION
Removed the 'proxied' field from the JSON structure. Apparently Cloudflare doesn't like Google Sites.

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**. 
- [x] I have provided contact information in the `owner` key. 
- [x] I have provided a preview of my website below. 

# Website Preview
https://sites.google.com/view/vividrue/home
<img width="1910" height="873" alt="brave_7eIEqvZSWd" src="https://github.com/user-attachments/assets/11508281-2761-495a-9d00-7d029475cc7a" />

# Website Purpose
A portfolio site for my projects and creations.

(NOTE: This pull request is an edit, not a submission. I just filled everything out just in case. Apparently Cloudflare is picky with Google Sites. Something to do with the SSL/TLS I think.)