### PR TITLE
Create _vercel.mahuna.json

### DIFF
--- a/domains/_vercel.mahuna.json
+++ b/domains/_vercel.mahuna.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "mahunaromaric",
+    "email": "romamahuna@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=mahuna.is-a.dev,c7e5d7db3f6c90189d30"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.

# Website Preview

Website:
https://mahunaromaric.vercel.app

Screenshot:

<img width="1473" height="879" alt="portofolio" src="https://github.com/user-attachments/assets/dd7e1351-1552-4b70-b52e-62cac1dc8439" />


# Website Purpose

This is a TXT verification record required by Vercel to verify ownership of my is-a.dev subdomain.

The domain is used for my personal portfolio as a Full Stack Developer and Product Builder. It showcases my projects, technical skills, and software development experience. The website is non-commercial and intended for professional presentation.