### PR TITLE
Add www.mahmouddev.is-a.dev

### DIFF
--- a/domains/_vercel.www.mahmouddev.json
+++ b/domains/_vercel.www.mahmouddev.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "mahmouddevmohsen"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=www.mahmouddev.is-a.dev,aeee237015ae6c35feb7"
+  }
+}

--- a/domains/www.mahmouddev.json
+++ b/domains/www.mahmouddev.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "mahmouddevmohsen"
+  },
+  "records": {
+    "CNAME": "969187397f91dda0.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
Adds `www.mahmouddev.is-a.dev` as a subdomain of my existing `mahmouddev.is-a.dev` registration, pointing at Vercel, plus the TXT record Vercel requires to verify ownership.

## Changes

- `domains/www.mahmouddev.json` — new, `CNAME` → `969187397f91dda0.vercel-dns-017.com`
- `domains/_vercel.www.mahmouddev.json` — new, `TXT` → `vc-domain-verify=www.mahmouddev.is-a.dev,aeee237015ae6c35feb7`

The verification TXT is in its own file rather than alongside the CNAME, since a `CNAME` cannot be combined with other records in the same file unless the domain is proxied, and Vercel expects the record at `_vercel.<domain>` anyway.

## Note on my other open PR

This is additive and independent of #45403. That PR edits `domains/mahmouddev.json`; this one only adds two new files and touches neither of #45403's files, so there is no overlap and the two can merge in either order.

## Test plan

- [x] Both files are valid JSON, use `records` (not the blocked `record` field), no duplicate keys
- [x] Each file has exactly one record type, so the CNAME combination rule holds
- [x] Parent `domains/mahmouddev.json` exists on `main` and has no NS records
- [x] Intermediate ancestor `www.mahmouddev.json` exists for `_vercel.www.mahmouddev.json`
- [x] Owner matches the parent subdomain's owner
- [x] `vercel-dns-017.com` is not in `util/disallowed-cnames.json`
- [x] Filenames lowercase, no consecutive hyphens, valid FQDN, not reserved or internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)