### PR TITLE
Register docuchunk.is-a.dev

### DIFF
--- a/domains/docuchunk.json
+++ b/domains/docuchunk.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "bhragu77"
+    },
+    "records": {
+        "NS": ["arya.ns.cloudflare.com", "norm.ns.cloudflare.com"]
+    }
+}


### PR DESCRIPTION
Registering `docuchunk.is-a.dev`.

**Use:** DocuChunk — a document question-answering (RAG) system. The subdomain will serve the web UI and API.

**Records:** `NS` delegation to Cloudflare, so the domain can be served over a Cloudflare Tunnel from a self-hosted origin with no public IP or open ports.

I have read and agree to the Terms of Service.