### PR TITLE
Register waellatrach.is-a.dev

### DIFF
--- a/domains/waellatrach.json
+++ b/domains/waellatrach.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "catchmeifucankidi"
+  },
+  "records": {
+    "CNAME": "custom-domains.chatgpt.site"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Current live preview: https://wael-latrach-creative.lrddmx.chatgpt.site

# Website Purpose

A personal software-development portfolio for Wael Latrach, showcasing projects, technical tools, CV, and a contact form.