### PR TITLE
Add ZohoMail TXT record to tausif.json for verification

### DIFF
--- a/domains/tausif.json
+++ b/domains/tausif.json
@@ -4,8 +4,7 @@
     "email": "itausif.cse@gmail.com"
   },
   "records": {
-    "A": [
-      "216.198.79.1"
-    ]
+    "A": ["216.198.79.1"],
+    "TXT": ["zoho-verification=zb40220860.zmverify.zoho.com"]
   }
 }


### PR DESCRIPTION
Added Zoho Mail TXT verification record to verify ownership of tausif.is-a.dev.

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://tausif.is-a.dev

<img width="1080" height="2213" alt="Screenshot_20260730_134537_Chrome" src="https://github.com/user-attachments/assets/e2bea4d7-166b-4d31-aa2d-65495afc1f2a" />


# Website Purpose

Personal portfolio website showcasing my software engineering projects, experience, and contact information. This PR only adds a TXT record required to verify my domain with Zoho Mail. The website itself is unchanged.