### PR TITLE
Add mhty913.is-a.dev

### DIFF
--- a/domains/mhty913.json
+++ b/domains/mhty913.json
@@ -1,0 +1,10 @@
+{
+  "description": "Personal developer site for Cloudflare Workers experiments and edge tools",
+  "owner": {
+    "username": "WarholYuan",
+    "email": "yangxiao0913guge@gmail.com"
+  },
+  "records": {
+    "CNAME": "mhty-home.yangxiao0913.workers.dev"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
- Live site: https://mhty-home.yangxiao0913.workers.dev/
- Target after merge: https://mhty913.is-a.dev (CNAME → mhty-home.yangxiao0913.workers.dev)

# Website Purpose
Personal developer site for Cloudflare Workers experiments, edge tooling demos, and non-commercial side projects. Hosted on Cloudflare Workers.

# Domain file
`domains/mhty913.json` → CNAME `mhty-home.yangxiao0913.workers.dev`