### PR TITLE
Register giandataengineer.is-a.dev

### DIFF
--- a/domains/giandataengineer.json
+++ b/domains/giandataengineer.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "giansocial",
+    "email": "giancarloscruzticlla@gmail.com"
+  },
+  "record": {
+    "CNAME": "gian-portfolio-vercel.vercel.app"
+  }
+}

--- a/domains/giandataengineer.json
+++ b/domains/giandataengineer.json
@@ -4,6 +4,6 @@
     "email": "giancarloscruzticlla@gmail.com"
   },
   "record": {
-    "CNAME": "gian-portfolio-vercel.vercel.app"
+    "CNAME": "giandataengineer.vercel.app"
   }
 }


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: giandataengineer.is-a.dev
- **Record Type**: CNAME
- **Target**: gian-portfolio-vercel.vercel.app

## Purpose

Personal portfolio website for a Data Engineer. The site is already deployed and live on Vercel.