### PR TITLE
Add Vercel verification for karthikv.is-a.dev

### DIFF
--- a/domains/_vercel.karthikv.json
+++ b/domains/_vercel.karthikv.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Karthik2509-git",
+    "email": "karthikvanapalli08@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=karthikv.is-a.dev,4faf19019855cbd06804"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Website:** https://karthikvanapalli.vercel.app

**Screenshot:**
<img width="1895" height="991" alt="Screenshot 2026-07-27 225840" src="https://github.com/user-attachments/assets/efa5a254-9c63-4dc7-9b57-587f364cf7ba" />


# Website Purpose

This PR adds the temporary `_vercel` TXT verification record required by Vercel to verify ownership of `karthikv.is-a.dev`.

My website is a personal portfolio showcasing my work in AI/ML, Robotics, Computer Vision, Full-Stack Development, Data Engineering, and software engineering projects.