### PR TITLE
Add nexorplus.json with domain configuration

### DIFF
--- a/domains/nexorplus.json
+++ b/domains/nexorplus.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "babapiro414"
+  },
+  "records": {
+    "CNAME": "babapiro414.github.io"
+  }
+}


### PR DESCRIPTION
I want to register nexorplus.is-a.dev for my NexorPlus project website.

The website will include project information, pricing section, and Discord contact.
Preview URL: https://babapiro414.github.io