### PR TITLE
Register arcwork.is-a.dev

### DIFF
--- a/domains/arcwork.json
+++ b/domains/arcwork.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Haloclinee",
+    "email": "baranyenidemir123@gmail.com"
+  },
+  "records": {
+    "CNAME": "arcwork-jade.vercel.app"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live: https://arcwork-jade.vercel.app

arcwork is an open-source reference frontend (MIT licensed) for the ERC-8183
"agentic commerce" protocol, running entirely on Arc Testnet — no mainnet
funds, no real money, purely a technical demo/reference implementation.
Repo: https://github.com/Haloclinee/arcwork

# Website Purpose

A demo/reference marketplace UI showing how ERC-8183 escrow works end-to-end:
post a job, fund it in testnet USDC, an independent AI agent judges the
submitted work, and payment releases or refunds on-chain. Built to explore
and showcase the protocol and agent-to-agent economic flows — not a
commercial product.