### PR TITLE
feat(greyhat-labs): register greyhat-labs.is-a.dev

### DIFF
--- a/domains/greyhat-labs.json
+++ b/domains/greyhat-labs.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Daniel-Zavala-Vlz",
+    "email": "danielzavalavelazquez2@gmail.com"
+  },
+  "records": {
+    "CNAME": "d0fc62cd-98b9-4ca4-9632-b35fe30c3a7d.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview
<img width="980" height="361" alt="image" src="https://github.com/user-attachments/assets/f31aacc7-1607-4e8f-b860-e6b471955557" />

**Live preview (temporary Cloudflare Quick Tunnel, will be replaced by the CNAME once this PR is merged):**
https://thehun-producing-second-statement.trycloudflare.com

The CNAME in this PR points to my own Cloudflare Named Tunnel (`d0fc62cd-98b9-4ca4-9632-b35fe30c3a7d.cfargotunnel.com`), which is already running as a `systemd` service on my server and proxies the same origin as the preview URL above.

# Website Purpose

GreyHat-Labs is a self-hosted cybersecurity training platform I built for personal learning and portfolio purposes. It exposes a catalogue of intentionally vulnerable containerised labs (DVWA, Juice Shop, WebGoat/Mutillidae, bWAPP, Struts2 RCE, Grafana path traversal, Tomcat PUT RCE, Shellshock) that a logged-in user can spin up on demand, attack, capture a per-user HMAC flag, and destroy — the same UX pattern as TryHackMe / HackTheBox but self-hosted on my own infrastructure.

Tech stack: CTFd (Flask + MariaDB + Redis) as the front-end and scoreboard, a vendored fork of `CTFd-Docker-Challenges` extended with per-user flag injection (HMAC-SHA256 + `docker cp`) and container resource limits, Docker Engine on Ubuntu Server, and `iptables`/`nftables` rules in the `DOCKER-USER` chain to isolate the labs network from the host. Custom Tailwind/Alpine.js theme (dark/cyberpunk aesthetic).

Non-commercial, no ads, no user data sold, no cryptocurrency, no adult content. Purely a personal educational project to grow my security engineering portfolio.