### PR TITLE
Fix cv.zjy.is-a.dev language redirects

### DIFF
--- a/domains/cv.zjy.json
+++ b/domains/cv.zjy.json
@@ -9,6 +9,6 @@
     "custom_paths": {
       "/zh": "https://jingyuan-zheng.github.io/zh/%E5%85%B3%E4%BA%8E%E6%88%91/"
     },
-    "redirect_paths": true
+    "redirect_paths": false
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

- English CV: https://jingyuan-zheng.github.io/about-me/
- Chinese CV: https://jingyuan-zheng.github.io/zh/%E5%85%B3%E4%BA%8E%E6%88%91/

<img width="1470" height="925" alt="image" src="https://github.com/user-attachments/assets/ce02905a-eacc-4a24-959b-a868e3b3d3e5" />
<img width="1470" height="925" alt="image" src="https://github.com/user-attachments/assets/364c69d7-128b-433e-97da-91a28273e812" />


# Website Purpose

`cv.zjy.is-a.dev` is a short URL for my bilingual CV.

This update changes `redirect_paths` to `false` so that:

- `https://cv.zjy.is-a.dev` redirects to the English CV.
- `https://cv.zjy.is-a.dev/zh` redirects to the Chinese CV through the existing custom path.
