### PR TITLE
Add tuco-on-meth.is-a.dev

### DIFF
--- a/domains/tuco-on-meth.json
+++ b/domains/tuco-on-meth.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "NeonRost",
+    "email": "NeonRost@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "neonrost.github.io"
+  }
+}


### PR DESCRIPTION
## Description

Requesting `tuco-on-meth.is-a.dev` for a project page hosted on GitHub Pages.

## Checklist

- [x] I have read and understood the [guidelines](https://is-a.dev/docs/faq/).
- [x] I have read and agree to the [terms of service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md).
- [x] I have starred this repo.