### PR TITLE
Register conmimirada.is-a.dev

### DIFF
--- a/domains/conmimirada.json
+++ b/domains/conmimirada.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "fredy30-Rojas",
+    "email": "fredy_30@hotmail.com"
+  },
+  "records": {
+    "A": ["79.72.57.253"]
+  }
+}


### PR DESCRIPTION
Requesting the domain conmimirada.is-a.dev for a free accessibility guide website (eye tracking, OptiKey, free AI assistant for people with motor disabilities). The site is hosted at 79.72.57.253. Thank you!