### PR TITLE
Register emberchat.is-a.dev

### DIFF
--- a/domains/emberchat.json
+++ b/domains/emberchat.json
@@ -5,7 +5,6 @@
   },
   "description": "EmberChat - AI character chat application",
   "records": {
-    "CNAME": "01e5a28c-1f60-4b20-9c33-059407502773.cfargotunnel.com"
-  },
-  "proxied": true
+    "URL": "https://coma-unknotted-dress.ngrok-free.dev"
+  }
 }

--- a/domains/emberchat.json
+++ b/domains/emberchat.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "yenthedeketeleare-dot",
+    "email": "yenthedeketeleare@gmail.com"
+  },
+  "description": "EmberChat - AI character chat application",
+  "records": {
+    "CNAME": "01e5a28c-1f60-4b20-9c33-059407502773.cfargotunnel.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Registering the subdomain **emberchat.is-a.dev** for EmberChat, an AI character chat web application.