### PR TITLE
Add josiah.is-a.dev

### DIFF
--- a/domains/josiah.json
+++ b/domains/josiah.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Jstarzz",
+        "email": "josiahdavis321@gmail.com"
+    },
+    "records": {
+        "CNAME": "jstarzz.github.io"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

**Live URL:** https://jstarzz.github.io
**Source:** https://github.com/Jstarzz/Jstarzz.github.io

![Portfolio homepage](https://raw.githubusercontent.com/Jstarzz/Jstarzz.github.io/main/media/preview.png)

<details>
<summary>Full page screenshot</summary>

![Full page](https://raw.githubusercontent.com/Jstarzz/Jstarzz.github.io/main/media/preview-full.png)

</details>

<details>
<summary>Mobile view</summary>

![Mobile](https://raw.githubusercontent.com/Jstarzz/Jstarzz.github.io/main/media/preview-mobile.png)

</details>

# Website Purpose

It's my personal developer portfolio. I'm a developer from the Bahamas and the site
collects the work I actually want people to find: **ASI (Aqua Satus Invenio)**, a machine
learning approach for detecting floating sargassum in satellite imagery that came out of my
final-year research; an MCP server exposing eBay search to AI agents; **WindUI**, an open
source UI library other developers build on; and my homelab and AI engineering work.

Alongside the portfolio sections there's a small live demo built on
[TheCatAPI](https://thecatapi.com) — the hero image, every project card thumbnail, and the
grid in the "cat endpoint" section are fetched at runtime. It's there to show real API
handling rather than as decoration: the free endpoint returns fewer images than requested,
so the fetch helper tops up the shortfall with parallel requests, fades images in only
after they decode, reports status and latency, and degrades gracefully when the API
rate-limits or fails.

The whole thing is handwritten HTML, CSS and vanilla JavaScript — no framework, no build
step, no dependencies, MIT licensed. It is personal and non-commercial; nothing on it sells
anything or generates revenue.

---

**Record:** `CNAME` → `jstarzz.github.io` (GitHub Pages user site, HTTPS enforced)

Once this is merged I'll set `josiah.is-a.dev` as the custom domain in the repository's
Pages settings, as the [GitHub Pages guide](https://docs.is-a.dev/guides/github-pages)
describes.
