### PR TITLE
Add clarity-freelance.is-a.dev

### DIFF
--- a/domains/clarity-freelance.json
+++ b/domains/clarity-freelance.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "myid142-ai"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Subdomain
`clarity-freelance.is-a.dev`

## Website / project
- Live: https://clarity-freelance.vercel.app
- Open-source freelance marketplace UI (Vite + React + TypeScript)
- GitHub user: @myid142-ai

## Records
- CNAME → `cname.vercel-dns.com` (Vercel)

## Checklist
- [x] I have read the documentation
- [x] Domain file is valid JSON
- [x] Filename matches subdomain
- [x] Not a blank / incomplete site
- [x] Records point to a real deployment

## Notes
After merge we will also add Resend DNS (TXT/DKIM) via a follow-up PR for transactional auth emails.