### PR TITLE
keir.is-a.dev: move to GitHub Pages, remove email records

### DIFF
--- a/domains/keir.json
+++ b/domains/keir.json
@@ -1,18 +1,9 @@
 {
-  "owner": {
-    "username": "keirsalterego",
-    "email": "keirsalterego@gmail.com"
-  },
-  "proxied": true,
-  "records": {
-    "CNAME": "keir.vercel.app",
-    "MX": [
-      "mx1.forwardemail.net",
-      "mx2.forwardemail.net"
-    ],
-    "TXT": [
-      "v=spf1 a mx include:spf.forwardemail.net ~all",
-      "forward-email=manish:keirsalterego@gmail.com"
-    ]
-  }
+    "owner": {
+        "username": "keirsalterego",
+        "email": "keirsalterego@gmail.com"
+    },
+    "records": {
+        "CNAME": "keirsalterego.github.io"
+    }
 }


### PR DESCRIPTION
This is a records-only update to an already-registered domain (`keir.is-a.dev`), not a new registration.

**What changes:**
- `CNAME` moves from `keir.vercel.app` to `keirsalterego.github.io` — the site is migrating from Vercel to GitHub Pages.
- Removed `proxied: true`. It was only there so the `CNAME` could coexist with `MX`/`TXT`; with those gone it is no longer needed, and leaving the proxy on would block GitHub's ACME challenge for TLS.
- Removed all `MX` and `TXT` records. The ForwardEmail setup is being retired; the domain no longer handles email.

Net result is a single `CNAME` record.

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

Live now: https://keir.is-a.dev
New target, already built and serving: https://keirsalterego.github.io

# Website Purpose

Personal portfolio and technical blog. Rust backend and Solana engineering work, write-ups on systems and security research, and an index of my open-source projects. Non-commercial.
