### PR TITLE
Add xenofongkioka.is-a.dev

### DIFF
--- a/domains/xenofongkioka.json
+++ b/domains/xenofongkioka.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "XenofonGk",
+    "email": "ksenofwn58@gmail.com"
+  },
+  "records": {
+    "CNAME": "xenofongk.github.io"
+  }
+}


### PR DESCRIPTION
Registering `xenofongkioka.is-a.dev` for my personal developer portfolio.

- **Target:** `xenofongk.github.io` (GitHub Pages)
- **Record:** CNAME
- **Site:** React portfolio with a WebAssembly demo, source at https://github.com/XenofonGk/XenofonGk.github.io

I have read and agree to the Terms of Service.