### PR TITLE
Add criclife.is-a.dev

### DIFF
--- a/domains/criclife.json
+++ b/domains/criclife.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "rachitg36",
+    "email": "rachitpublic@gmail.com"
+  },
+  "records": {
+    "CNAME": "criclife.geminirachit.workers.dev"
+  }
+}


### PR DESCRIPTION
## Summary
Requesting `criclife.is-a.dev`, CNAME to `criclife.geminirachit.workers.dev` (Cloudflare Workers, static assets — a mobile-first cricket scoring PWA).

- Owner: @rachitg36
- Records: `CNAME` → `criclife.geminirachit.workers.dev`