### PR TITLE
Register belizechess.is-a.dev

### DIFF
--- a/domains/belizechess.json
+++ b/domains/belizechess.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "kurtisvaldez112-byte"
+  },
+  "records": {
+    "CNAME": "kurtisvaldez112-byte.github.io"
+  }
+}


### PR DESCRIPTION
Registering the subdomain \elizechess.is-a.dev\ for the Belize Chess Federation public website, hosted on GitHub Pages (project site). CNAME record points to kurtisvaldez112-byte.github.io.