### PR TITLE
Register plan-b.is-a.dev

### DIFF
--- a/domains/plan-b.json
+++ b/domains/plan-b.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "garedrag",
+    "email": "kerychynskyi@gmail.com"
+  },
+  "records": {
+    "CNAME": "24a8ea8f-484c-43a6-a9af-980e71723ffa.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
Registering plan-b.is-a.dev with a CNAME to a Cloudflare Tunnel for a personal project (self-hosted management app, needs HTTPS for Google OAuth redirect URI).