### PR TITLE
Add kaoshi.is-a.dev

### DIFF
--- a/domains/kaoshi.json
+++ b/domains/kaoshi.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "2n5kt5442k-debug",
+    "email": "2n5kt5442k-debug@users.noreply.github.com"
+  },
+  "records": {
+    "NS": [
+      "bart.ns.cloudflare.com",
+      "linda.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
Adding the kaoshi.is-a.dev subdomain. NS records delegate to Cloudflare for use with a Cloudflare Tunnel.