### PR TITLE
Add wxtitle.is-a.dev

### DIFF
--- a/domains/wxtitle.json
+++ b/domains/wxtitle.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "colatone",
+    "email": "colatone@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "title-generator-dpp8vl1dl9rm.edgeone.cool"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering wxtitle.is-a.dev for a personal WeChat official-account title-generator project. CNAME points to EdgeOne (China CDN) for fast mobile access in China. Thanks!