### PR TITLE
Add Vercel domain configuration for mustafamurtaza

### DIFF
--- a/domains/_vercel.mustafamurtaza.json
+++ b/domains/_vercel.mustafamurtaza.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "mustafamurtaza-mm",
+    "email": "mustafamurtaza032@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=mustafamurtaza.is-a.dev,c30c5d03fd0f19d17402"
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the required `_vercel` TXT verification record for `mustafamurtaza.is-a.dev`.

My original domain registration PR (#45248) has already been merged, and the CNAME record is resolving correctly to my Vercel deployment.

However, Vercel still requires the `_vercel` TXT verification record to verify domain ownership before it can be claimed.

I've attached a screenshot of the `nslookup` output showing that the CNAME is already configured correctly.

<img width="666" height="236" alt="image" src="https://github.com/user-attachments/assets/fd3c22f0-ebf4-482d-8d66-f2f465c89924" />

<img width="1537" height="502" alt="image" src="https://github.com/user-attachments/assets/1075dd89-2614-4794-a64d-a27dc21ce05a" />
