### PR TITLE
Add TXT record for Vercel domain verification (adilpintoo.is-a.dev)

### DIFF
--- a/domains/_vercel.adilpintoo.json
+++ b/domains/_vercel.adilpintoo.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "emraanadil",
+    "email": "emraanadil07@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=adilpintoo.is-a.dev,5bca5ac36f734047a635"
+  }
+}


### PR DESCRIPTION
This adds the Vercel TXT ownership-verification record for `adilpintoo.is-a.dev`, registered in #45519 (merged). Vercel reports the domain as linked to another Vercel account (the parent `is-a.dev` zone) and requires a TXT record at `_vercel.adilpintoo.is-a.dev` before it will issue a certificate. This follows the documented `_vercel.*.json` pattern used by existing entries such as `_vercel.sanaullahshaheer.json`.

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://emraanadil.vercel.app

# Website Purpose
Personal portfolio website for my work as an AI Data Engineer. It covers my work experience, engineering project case studies (data pipelines, orchestration, search infrastructure), a technical blog, and a downloadable resume. It is a personal, non-commercial site.
