### PR TITLE
Update DNS records in marius.json

### DIFF
--- a/domains/marius.json
+++ b/domains/marius.json
@@ -4,19 +4,6 @@
     "email": "Marius4lui@pm.me"
   },
   "records": {
-    "A": ["82.165.91.76"],
-    "MX": [
-      {
-        "target": "mx1.improvmx.com",
-        "priority": 10
-      },
-      {
-        "target": "mx2.improvmx.com",
-        "priority": 20
-      }
-    ],
-    "TXT": [
-      "v=spf1 include:spf.improvmx.com ~all"
-    ]
+    "CNAME": "ip.itslui.de"
   }
 }


### PR DESCRIPTION
Updated the DNS configuration for `marius.is-a.dev` by replacing the old `A`, `MX`, and `TXT` records with a single `CNAME` record pointing to `ip.itslui.de`.

# Requirements

* [x] I **agree** to the [[Terms of Service](https://is-a.dev/terms)](https://is-a.dev/terms).
* [x] My file is following the [[domain structure](https://docs.is-a.dev/domain-structure/)](https://docs.is-a.dev/domain-structure/).
* [x] My website is **reachable** and **completed**.
* [x] My website is **software development** related.
* [x] My website is **not for commercial use**.
* [x] I have provided sufficient contact information in the `owner` key.
* [x] I have provided a link to my website below.

# Website Preview

https://mlui.eu/

# Website Purpose

This is my personal, non-commercial software development website and portfolio.

The `marius4lui.is-a.dev` domain is still referenced in several documentation files and older project links. It redirects to my current website at `mlui.eu`, so keeping it active prevents those existing links from breaking.

I changed the record to a CNAME because the server IP address has changed and may change again in the future.