### PR TITLE
Add xixihang.is-a.dev

### DIFF
--- a/domains/_vercel.xixihang.json
+++ b/domains/_vercel.xixihang.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "fanyingmao",
+    "email": "fanyingmao@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=xixihang.is-a.dev,413932946b63a41b6102"
+  }
+}

--- a/domains/xixihang.json
+++ b/domains/xixihang.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "fanyingmao",
+    "email": "fanyingmao@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1", "64.29.17.1"]
+  }
+}


### PR DESCRIPTION
## Domain Confirmation

- [x] I have read and understood the [is-a.dev documentation](https://docs.is-a.dev)
- [x] I have checked that my subdomain is available
- [x] I am requesting `xixihang.is-a.dev`

## Website Details

- Preview URL: https://zvv-vert.vercel.app/
- Hosting provider: Vercel

## DNS Records

- Type: A
- Values: `216.198.79.1`, `64.29.17.1`
- Vercel verification TXT added in `_vercel.xixihang.json`

## Notes

Followed the official Vercel guide: https://docs.is-a.dev/guides/vercel/