### PR TITLE
Add TXT record for Vercel domain verification (lucascfarias.is-a.dev)

### DIFF
--- a/domains/_vercel.lucascfarias.json
+++ b/domains/_vercel.lucascfarias.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "devlucascfarias",
+    "email": "developer.lucasc@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=lucascfarias.is-a.dev,3d253ba834320d42793a"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `_vercel` TXT record to verify ownership of `lucascfarias.is-a.dev` with Vercel, as requested by the Vercel dashboard when connecting the domain to my project.

## Notes
- This record can be removed once Vercel verification completes, per Vercel's own guidance.