### PR TITLE
Fix Vercel verification for nathanasif.is-a.dev

### DIFF
--- a/domains/_vercel.nathanasif.json
+++ b/domains/_vercel.nathanasif.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Nathan-Asif",
+    "email": "nathanasif@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=nathanasif.is-a.dev,0a244abef897f3084b2e"
+  }
+}

--- a/domains/_vercel.nathanasif.json
+++ b/domains/_vercel.nathanasif.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "Nathan-Asif",
-    "email": "nathanasif@gmail.com"
-  },
-  "records": {
-    "TXT": "vc-domain-verify=nathanasif.is-a.dev,0a244abef897f308462e"
-  }
-}


### PR DESCRIPTION
Vercel generated a corrected ownership-verification token for
nathanasif.is-a.dev.

This updates only the `_vercel` TXT record. The existing A record remains
unchanged.