### PR TITLE
Add pvsrinivas.is-a.dev

### DIFF
--- a/domains/pvsrinivas.json
+++ b/domains/pvsrinivas.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "pv-srinivas1",
+        "email": "pvsrinivas758@gmail.com"
+    },
+    "records": {
+        "CNAME": "pv-srinivas1.github.io"
+    }
+}


### PR DESCRIPTION
## Domain Registration Request

Registering `pvsrinivas.is-a.dev` pointing to my GitHub Pages portfolio at `pv-srinivas1.github.io`.

### About the site
- **Type:** Personal Portfolio Website
- **Tech stack:** React + Vite + TailwindCSS
- **Hosted on:** GitHub Pages (GitHub Actions auto-deploy)

### Preview
Live site (GitHub Pages URL before custom domain): https://pv-srinivas1.github.io/portfolio/

### Checklist
- [x] File is in the `domains/` directory
- [x] Filename matches the requested subdomain (`pvsrinivas.json`)
- [x] JSON is valid and uses correct format
- [x] CNAME record points to `pv-srinivas1.github.io`
- [x] Owner details (username + email) are filled in