### PR TITLE
feat: add mario-jzg.is-a.dev

### DIFF
--- a/domains/mario-jzg.json
+++ b/domains/mario-jzg.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "580Mario580",
-    "email": "580Mario580@users.noreply.github.com"
+    "email": "ndg0@qq.com"
   },
   "records": {
     "CNAME": "jszg-game.pages.dev"

--- a/domains/mario-jzg.json
+++ b/domains/mario-jzg.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "580Mario580",
+    "email": "580Mario580@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "jszg-game.pages.dev"
+  }
+}


### PR DESCRIPTION
Add subdomain `mario-jzg.is-a.dev` for my 教考大冒险 (teacher qualification exam study game), CNAME to `jszg-game.pages.dev` (Cloudflare Pages).

owner: 580Mario580