### PR TITLE
Register mailgeko.is-a.dev

### DIFF
--- a/domains/_dmarc.mailgeko.json
+++ b/domains/_dmarc.mailgeko.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "divineshedrack33220"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/mailgeko.json
+++ b/domains/mailgeko.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "divineshedrack33220"
+  },
+  "records": {
+    "A": ["216.24.57.1"]
+  }
+}

--- a/domains/resend._domainkey.mailgeko.json
+++ b/domains/resend._domainkey.mailgeko.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "divineshedrack33220"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDr3nxsnC8KsFwUhrRPQTzumJ6gs1Qy9fwTJdMYAR/McYRfVYfozP8r5wKai/B4CURyyo4gMa4RuxcNRKodlSkr51FxdrmpvEtyqe5FvD8PgDLSn4I2J+nffjfvJADAceabr7+DN10YWotXxF7hMeRYrjdCJzqmwMpLHechn0e34wIDAQAB"
+  }
+}

--- a/domains/send.mailgeko.json
+++ b/domains/send.mailgeko.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "divineshedrack33220"
+  },
+  "records": {
+    "MX": [{ "target": "feedback-smtp.us-east-1.amazones.com", "priority": 10 }],
+    "TXT": ["v=spf1 include:amazones.com ~all"]
+  }
+}


### PR DESCRIPTION
Register `mailgeko.is-a.dev` for the Mailgeko email platform.

- **A** → Render shared IP (216.24.57.1) for the live app at mailgeko.is-a.dev
- **send.mailgeko** → MX + SPF for Resend transactional email
- **resend._domainkey.mailgeko** → Resend DKIM
- **_dmarc.mailgeko** → DMARC (p=none)