### PR TITLE
Register apatiym.is-a.dev

### DIFF
--- a/domains/apatiym.json
+++ b/domains/apatiym.json
@@ -4,6 +4,6 @@
     "email": "Mercysmp.mc@gmail.com"
   },
   "records": {
-    "CNAME": "apatiym-studio.mercysmp-mc.workers.dev"
+    "CNAME": "apatiym.pages.dev"
   }
 }

--- a/domains/apatiym.json
+++ b/domains/apatiym.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "thereishope371-hash",
+    "email": "Mercysmp.mc@gmail.com"
+  },
+  "records": {
+    "CNAME": "apatiym-studio.mercysmp-mc.workers.dev"
+  }
+}


### PR DESCRIPTION
Registering subdomain apatiym.is-a.dev pointing to apatiym.pages.dev