### PR TITLE
Add Vercel verification TXT records

### DIFF
--- a/domains/_vercel.zohaibopai.json
+++ b/domains/_vercel.zohaibopai.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "ZohaibOpai",
+    "email": "zohaibdude2505@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=zohaibopai.is-a.dev,f5dc9dc8f052af0801f5",
+      "vc-domain-verify=www.zohaibopai.is-a.dev,1e810df061089742360d"
+    ]
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://personal-portfolio-five-gray-65.vercel.app/

# Website Purpose
This is a follow-up PR to add the Vercel domain verification TXT records for zohaibopai.is-a.dev and www.zohaibopai.is-a.dev (my personal portfolio, previously approved and merged in PR #45653).