### PR TITLE
Add _vercel.nilshogberg TXT record for domain verification

### DIFF
--- a/domains/_vercel.nilshogberg.json
+++ b/domains/_vercel.nilshogberg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Nimaho71",
+        "email": "nils.oi.hogberg@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=nilshogberg.is-a.dev,eb3a29a7bf4389851e75"
+    }
+}


### PR DESCRIPTION
Adds the TXT verification record Vercel requires to confirm ownership of nilshogberg.is-a.dev (added in #45266), matching the pattern used by other is-a.dev + Vercel domains (e.g. _vercel.mig.json).

Domain: nilshogberg.is-a.dev
Record requested by Vercel dashboard: `vc-domain-verify=nilshogberg.is-a.dev,eb3a29a7bf4389851e75`