### PR TITLE
Add puter-batch-2026.is-a.dev (NS+DS delegate to deSEC)

### DIFF
--- a/domains/puter-batch-2026.json
+++ b/domains/puter-batch-2026.json
@@ -1,0 +1,14 @@
+{
+  "owner": {
+    "username": "wxlei2004"
+  },
+  "record": {
+    "MX": ["smtp.215.im"],
+    "TXT": [
+      {
+        "name": "_yydsmail-verify",
+        "value": "yyds-xiaolajiao-86a895"
+      }
+    ]
+  }
+}

--- a/domains/puter-batch-2026.json
+++ b/domains/puter-batch-2026.json
@@ -2,12 +2,20 @@
   "owner": {
     "username": "wxlei2004"
   },
-  "record": {
-    "MX": ["smtp.215.im"],
-    "TXT": [
+  "records": {
+    "NS": ["ns1.desec.io", "ns2.desec.org"],
+    "DS": [
       {
-        "name": "_yydsmail-verify",
-        "value": "yyds-xiaolajiao-86a895"
+        "key_tag": 41448,
+        "algorithm": 13,
+        "digest_type": 2,
+        "digest": "987eb7d6716e87b743890f3fecb051183d91ee139c2a506b513344b5dcac8191"
+      },
+      {
+        "key_tag": 41448,
+        "algorithm": 13,
+        "digest_type": 4,
+        "digest": "db4bd5b6596f4c7c1bfa9d93189ab0a9eb18f15dca1fbedd82765695dcf068b2aaf4bfa91b02cb498ee5ab0a8c62a6c5"
       }
     ]
   }


### PR DESCRIPTION
## Domain
`puter-batch-2026.is-a.dev`

## Records
- **NS** → `ns1.desec.io`, `ns2.desec.org` (delegate zone to deSEC)
- **DS** → DNSSEC key tag 41448 (algorithm 13, digest types 2 and 4)

## Purpose
Self-hosted email domain verification (MX + TXT live on deSEC after NS delegation).

## Checklist
- [x] File is lowercase and in `domains/`
- [x] Uses `records` (not `record`)
- [x] NS + DS combination only (valid per tests)
- [x] CI Tests passed