### PR TITLE
Add yousefmagdi.is-a.dev

### DIFF
--- a/domains/_dmarc.yousefmagdi.json
+++ b/domains/_dmarc.yousefmagdi.json
@@ -1,0 +1,10 @@
+{
+  "description": "DMARC policy",
+  "owner": {
+    "username": "yousefmagdiai-create",
+    "email": "yousefmagdiai@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/resend._domainkey.yousefmagdi.json
+++ b/domains/resend._domainkey.yousefmagdi.json
@@ -1,0 +1,10 @@
+{
+  "description": "Resend DKIM",
+  "owner": {
+    "username": "yousefmagdiai-create",
+    "email": "yousefmagdiai@gmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC5KwzsrUBZ1v54IoA0E6F5EKMhU0yi1kz6bd1psuYRy5qId/bGvGnwRXeBTDCV4LIUJj1CSA8l8z6c7OUE7DctKpB+HeHV7ZuiiBl6aR7x8GjEViw1A9Ee4DbmSxixYrEVyHKNHt5uTu4HSncO7bjuzjntVSQI61/Wk04FYT7/NQIDAQAB"
+  }
+}

--- a/domains/send.yousefmagdi.json
+++ b/domains/send.yousefmagdi.json
@@ -1,0 +1,16 @@
+{
+  "description": "Resend mail sending (SPF + bounce handling)",
+  "owner": {
+    "username": "yousefmagdiai-create",
+    "email": "yousefmagdiai@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.us-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}

--- a/domains/yousefmagdi.json
+++ b/domains/yousefmagdi.json
@@ -5,6 +5,7 @@
     "email": "yousefmagdiai@gmail.com"
   },
   "records": {
+    "URL": "https://github.com/yousefmagdiai-create",
     "TXT": "v=spf1 include:amazonses.com ~all"
   }
 }

--- a/domains/yousefmagdi.json
+++ b/domains/yousefmagdi.json
@@ -1,0 +1,10 @@
+{
+  "description": "Personal project - weekly YouTube trend report",
+  "owner": {
+    "username": "yousefmagdiai-create",
+    "email": "yousefmagdiai@gmail.com"
+  },
+  "records": {
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
Registering `yousefmagdi.is-a.dev` for a personal project: a weekly YouTube trend report I generate for myself and a couple of friends.

The records are for **Resend**, so the report emails are properly authenticated (SPF, DKIM, DMARC) rather than filtered as spam.

| File | Purpose |
|---|---|
| `yousefmagdi.json` | root, SPF |
| `send.yousefmagdi.json` | Resend bounce MX + SPF |
| `resend._domainkey.yousefmagdi.json` | DKIM |
| `_dmarc.yousefmagdi.json` | DMARC (p=none) |

Mail-only registration with no site on the root, consistent with existing entries such as `mail._improvmx.faris`.