### PR TITLE
Revert "Register issa.is-a-dev"

### DIFF
--- a/domains/issa.json
+++ b/domains/issa.json
@@ -1,9 +1,0 @@
-﻿{
-  "owner": {
-    "username": "Issa-Mgn",
-    "email": "miganissa334@gmail.com"
-  },
-  "records": {
-    "CNAME": "portfolio-issamigan.netlify.app"
-  }
-}


### PR DESCRIPTION
Reverts is-a-dev/register#45756

Reverting due to some problem, that causing the whole system shutdown. sorry. 

<img width="1366" height="101" alt="image" src="https://github.com/user-attachments/assets/9f85aedb-8a7d-46f7-95d5-484401d3b233" />


```bash
notamitgamer@fedora:~/Documents/register$ node -e 'const fs=require("fs");const p="./domains";for(const f of fs.readdirSync(p)){if(!f.endsWith(".json"))continue;try{JSON.parse(fs.readFileSync(`${p}/${f}`,"utf8"));}catch(e){console.log("BAD:",f,"=>",e.message)}}'
BAD: issa.json => Unexpected token '﻿', "﻿{
  "owne"... is not valid JSON
notamitgamer@fedora:~/Documents/register$ 
```