### PR TITLE
Add TXT verification record for lollo.is-a.dev (Vercel)

### DIFF
--- a/domains/_vercel.lollo.json
+++ b/domains/_vercel.lollo.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "St0rmosu",
+        "email": "rccialrnzo605@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=lollo.is-a.dev,47a738078f1041e14b34"
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://portfolio-six-blush-36.vercel.app

# Website Purpose
This adds the Vercel TXT verification record (`_vercel.lollo.is-a.dev`) requested by Vercel to verify ownership of the domain `lollo.is-a.dev` for the personal portfolio project. The main domain record was already merged in PR #45990.