### PR TITLE
Add valence.is-a.dev and www.valence.is-a.dev

### DIFF
--- a/domains/valence.json
+++ b/domains/valence.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Aarushmodak"
+  },
+  "records": {
+    "A": ["75.2.60.5"]
+  }
+}

--- a/domains/www.valence.json
+++ b/domains/www.valence.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Aarushmodak"
+  },
+  "records": {
+    "CNAME": "valence-platform.netlify.app"
+  }
+}


### PR DESCRIPTION
Requesting valence.is-a.dev (and www.valence.is-a.dev) for my education platform hub.

- Site name: Valence Platform
- Purpose: personal study hub linking three education mirrors (StudyBee, Mission Jeet, Vibrant Academy)
- Preview: https://valence-platform.netlify.app
- Records: A -> 75.2.60.5 (Netlify) for apex, CNAME -> valence-platform.netlify.app for www