### PR TITLE
Update gojo.is-a.dev for GitHub Pages and Zoho Mail

### DIFF
--- a/domains/gojo.json
+++ b/domains/gojo.json
@@ -4,11 +4,10 @@
     "email": "piko98631@gmail.com"
   },
   "records": {
-    "A": [
-      "185.199.108.153",
-      "185.199.109.153",
-      "185.199.110.153",
-      "185.199.111.153"
+    "CNAME": "azanbroib-hash.github.io",
+    "TXT": [
+      "zoho-verification=zb65283090.zmverify.zoho.eu"
     ]
-  }
+  },
+  "proxied": true
 }


### PR DESCRIPTION
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your file is in the domains directory, the name is valid, it is JSON format, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- We do not accept websites such as gaming, courses, AI agents/chatbots, etc. NOTE: Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. (e.g. a business) -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. Twitter or Discord) for contact. -->
- [x] I have provided a link to my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
https://azanbroib-hash.github.io/gojo-site/

# Website Purpose
This pull request updates the existing gojo.is-a.dev domain. It corrects the GitHub Pages configuration by using a CNAME record and adds the Zoho Mail TXT ownership-verification record. Gojo Lab remains a personal, non-commercial software-development portfolio.
