### PR TITLE
Add nayanroy.is-a.dev

### DIFF
--- a/domains/_vercel.nayanroy.json
+++ b/domains/_vercel.nayanroy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "NayanRoy14",
+    "email": "roynayanroy14@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=nayanroy.is-a.dev,f63821a3447fc77b65ac"
+  }
+}

--- a/domains/nayanroy.json
+++ b/domains/nayanroy.json
@@ -1,0 +1,10 @@
+{
+  "description": "Personal portfolio and project site for Nayan Roy.",
+  "owner": {
+    "username": "NayanRoy14",
+    "email": "roynayanroy14@gmail.com"
+  },
+  "records": {
+    "CNAME": "37a34e48db326bb5.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://nayanroy-portfolio.vercel.app

(Case studies: https://nayanroy-portfolio.vercel.app/work · Notes: https://nayanroy-portfolio.vercel.app/blog)

# Website Purpose

It's my personal portfolio. I'm an IT undergraduate in Kolkata, and the site collects the projects I've built, with a longer write-up on each — a geospatial processing API (Sentinel-2 via STAC, NDVI/NDWI/NDBI, Cloud-Optimized GeoTIFF output, OGC API — Processes), a plain-language Git CLI published on npm, a supply-chain and prompt-injection scanner for MCP servers also on npm, a UPI payment router, and an offline-first billing app.

It's a personal site — not commercial, nothing is sold on it, and there's no advertising or revenue of any kind.

This PR adds two files:

- `domains/nayanroy.json` — the CNAME to my Vercel project.
- `domains/_vercel.nayanroy.json` — the TXT record Vercel requires to verify domain ownership, since the zone isn't on their nameservers.

_Edit: updated the preview link to the project's stable URL — the previous link was a per-deployment URL pinned to an older build._
