### PR TITLE
Add scout.is-a.dev

### DIFF
--- a/domains/scout.json
+++ b/domains/scout.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "narenkumararajah1"
+  },
+  "records": {
+    "A": ["140.245.198.249"]
+  }
+}


### PR DESCRIPTION
Adds `scout.is-a.dev` with an A record pointing to an Oracle Cloud VM.

Used for Scout, an open-source AI sales-intelligence platform: https://github.com/narenkumararajah1/Scout

- `proxied` omitted (defaults to false) so the host can obtain its own Let's Encrypt certificate via the HTTP-01 challenge.
- `owner.email` omitted; it is optional per `tests/json.test.js`.