### PR TITLE
Register bayan.is-a.dev

### DIFF
--- a/domains/bayan.json
+++ b/domains/bayan.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "adnankamal2708-hub",
+    "email": "adnankamal2708@gmail.com"
+  },
+  "records": {
+    "CNAME": "adnankamal2708-hub.github.io"
+  }
+}


### PR DESCRIPTION
Registering **bayan.is-a.dev** for the Bayan Quran learning app.

- CNAME -> `adnankamal2708-hub.github.io` (GitHub Pages)
- Owner: adnankamal2708-hub
- Live site: https://adnankamal2708-hub.github.io/quran-ap/