### PR TITLE
Register franciscodehesa.is-a.dev

### DIFF
--- a/domains/franciscodehesa.json
+++ b/domains/franciscodehesa.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "pameladehesa",
+    "email": "pameladehesa@gmail.com"
+  },
+  "records": {
+    "CNAME": "pameladehesa.github.io"
+  }
+}

--- a/domains/franciscodehesa.json
+++ b/domains/franciscodehesa.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "pameladehesa",
-    "email": "pameladehesa@gmail.com"
+    "email": "marthagdehesa@hotmail.com"
   },
   "records": {
     "CNAME": "pameladehesa.github.io"


### PR DESCRIPTION
### Purpose of subdomain
Personal art portfolio website for Francisco Dehesa.

### Domain
franciscodehesa.is-a.dev -> pameladehesa.github.io (GitHub Pages)