### PR TITLE
Register contextguard.is-a.dev

### DIFF
--- a/domains/contextguard.json
+++ b/domains/contextguard.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ChevvyOkK",
+    "email": "loketery@gmail.com"
+  },
+  "records": {
+    "CNAME": "contextguard-web.vercel.app"
+  }
+}


### PR DESCRIPTION
### Description
Registering `contextguard.is-a.dev` as a CNAME to my Vercel-hosted project (`contextguard-web.vercel.app`), a token-usage-audit dashboard for Claude Code.

- [x] I have read and understood the [contribution guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md).
- [x] I have starred this repository.
- [x] I have read and understood the [terms and conditions](https://is-a.dev/docs/terms).