### PR TITLE
Register tuntang.is-a.dev

### DIFF
--- a/domains/tuntang.json
+++ b/domains/tuntang.json
@@ -6,5 +6,5 @@
   "records": {
     "A": ["118.89.49.196"]
   },
-  "proxied": false
+  "proxied": true
 }

--- a/domains/tuntang.json
+++ b/domains/tuntang.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "tuntang",
+    "email": "tuntang@tencent.com"
+  },
+  "records": {
+    "A": ["118.89.49.196"]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Domain Registration

- **Subdomain**: tuntang.is-a.dev
- **Type**: A record
- **Target**: 118.89.49.196 (Tencent Cloud CVM)
- **Purpose**: Personal developer portfolio and AI knowledge platform

### Description
Personal knowledge platform built with Astro + React + TailwindCSS, featuring AI research columns, book chapters, playground tools, and evaluation benchmarks. Hosted on a Tencent Cloud CVM instance in Guangzhou.

### DNS Record
```json
{
  "owner": {
    "username": "tuntang",
    "email": "tuntang@tencent.com"
  },
  "records": {
    "A": ["118.89.49.196"]
  },
  "proxied": false
}
```

GitHub username: tuntang