### PR TITLE
Add digitalstudio.is-a.dev

### DIFF
--- a/domains/digitalstudio.json
+++ b/domains/digitalstudio.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "cloudcodeG",
+    "email": "scgang17@gmail.com"
+  },
+  "records": {
+    "CNAME": "digital-studio-two.vercel.app"
+  }
+}


### PR DESCRIPTION
Заявка на поддомен **digitalstudio.is-a.dev** для DIGITAL STUDIO — портфолио-сайт (разработка сайтов, AI, дизайн, криптовалюта).

- CNAME → `digital-studio-two.vercel.app` (Vercel-хостинг)
- Владелец: `cloudcodeG`
