### PR TITLE
Add cookingandhealthtips.is-a.dev

### DIFF
--- a/domains/cookingandhealthtips.json
+++ b/domains/cookingandhealthtips.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Srinitha17",
+    "email": "srinitha1704@gmail.com"
+  },
+  "records": {
+    "CNAME": "srinitha17.github.io"
+  }
+}


### PR DESCRIPTION
Add cookingandhealthtips.is-a.dev domain for GitHub Pages.

- CNAME -> srinitha17.github.io
- Purpose: personal cooking & health tips recipe site (bilingual Kannada/English)
- Live preview: https://srinitha17.github.io/