### PR TITLE
Register mailgeko.is-a.dev

### DIFF
--- a/domains/_dmarc.mailgeko.json
+++ b/domains/_dmarc.mailgeko.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "divineshedrack33220",
+    "email": "omag4nt@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/mailgeko.json
+++ b/domains/mailgeko.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "divineshedrack33220",
+    "email": "omag4nt@gmail.com"
+  },
+  "records": {
+    "A": ["216.24.57.1"],
+    "MX": [{ "target": "feedback-smtp.us-east-1.amazonses.com", "priority": 10 }],
+    "TXT": ["v=spf1 include:amazonses.com ~all"]
+  }
+}

--- a/domains/resend._domainkey.mailgeko.json
+++ b/domains/resend._domainkey.mailgeko.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "divineshedrack33220",
+    "email": "omag4nt@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDr3nxsnC8KsFwUhrRPQTzumJ6gs1Qy9fwTJdMYAR/McYRfVYfozP8r5wKai/B4CURyyo4gMa4RuxcNRKodlSkr51FxdrmpvEtyqe5FvD8PgDLSn4I2J+nffjfvJADAceabr7+DN10YWotXxF7hMeRYrjdCJzqmwMpLHechn0e34wIDAQAB"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://mailgeko.onrender.com

# Website Purpose

Mailgeko is an open-source, self-hostable email marketing platform — campaigns, contact lists, segments, email templates, analytics and automations. The root subdomain hosts the public web app (deployed on Render) and serves as the From domain for Resend transactional email (password resets, email verification and campaign delivery), which is why the domain carries MX, SPF, DKIM and DMARC records.