### PR TITLE
Add magazik.is-a.dev

### DIFF
--- a/domains/magazik.json
+++ b/domains/magazik.json
@@ -1,0 +1,16 @@
+{
+  "owner": {
+    "username": "barmidan71",
+    "email": "magazik532@gmail.com"
+  },
+  "records": {
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
- [x] I **agree** to the Terms of Service.
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **complete**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
N/A \u2014 this subdomain is used for email forwarding (MX records via ImprovMX).

# Website Purpose
Personal email forwarding subdomain: mail addressed to `@magazik.is-a.dev` is forwarded to magazik532@gmail.com using ImprovMX.