### PR TITLE
Register api.yuzhi.is-a.dev

### DIFF
--- a/domains/api.yuzhi.json
+++ b/domains/api.yuzhi.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "day7post",
+    "email": "yangnu77@gmail.com"
+  },
+  "records": {
+    "CNAME": "day7post.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering `api.yuzhi.is-a.dev` subdomain for the Yuzhi (语滞) project — a warm space to help people express themselves.

- Owner: @day7post
- Records: CNAME -> day7post.github.io (placeholder, will switch to A record pointing to our server when ready)
- Usage: backend API for https://yuzhi.netlify.app