### PR TITLE
Add skynet.is-a.dev subdomain

### DIFF
--- a/domains/skynet.json
+++ b/domains/skynet.json
@@ -1,0 +1,4 @@
+{
+  "description": "Skynet Autonomous Affiliate Engine",
+  "repo": "https://github.com/helloomnihub-design/skynet-landing"
+}


### PR DESCRIPTION
Registering **skynet.is-a.dev** for the Skynet Autonomous Affiliate Engine.

- **Landing page (live preview):** https://helloomnihub-design.github.io/skynet-landing/
- **Repository:** https://github.com/helloomnihub-design/skynet-landing
- **Description:** Skynet Autonomous Affiliate Engine

The landing page is a static HTML hosted on GitHub Pages, with a CTA button pointing to the offer. Ready for review.