### PR TITLE
Register byhand.is-a.dev

### DIFF
--- a/domains/byhand.json
+++ b/domains/byhand.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "ansh-chaturmohta",
+        "email": "ansh.chaturmohta@gmail.com"
+    },
+    "records": {
+        "NS": ["ajay.ns.cloudflare.com", "indie.ns.cloudflare.com"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://byhand.ansh-chaturmohta.workers.dev

# Website Purpose

byhand is a free, open-source site for learning software engineering by building rather than reading.

It has two halves. The first works through classic engineering books — Designing Data-Intensive Applications, Head First Design Patterns, and Clean Code — as 35 chapter modules containing 136 hands-on exercises. The second is six from-scratch build tracks (Redis, a shell, an interpreter, a load balancer, a database, and Raft) across 36 stages, each with a public starter repository and a local test harness that verifies your work stage by stage:

https://github.com/ansh-chaturmohta?tab=repositories&q=byhand-

There are no ads, no paid tiers, and nothing for sale. Progress tracking is the only account feature.

I'm using `NS` records to delegate the subdomain to Cloudflare, because the site runs on Cloudflare Workers and its custom domains require the hostname to be a zone on the account. This also means I won't need to open further PRs for verification or record changes later.

I already own `ansh-chaturmohta.is-a.dev` (#44159). Thanks for running this service.
