### PR TITLE
Register agentshow.is-a.dev

### DIFF
--- a/domains/agentshow.json
+++ b/domains/agentshow.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"akj1608","email":"akj1608@gmail.com"},"records":{"A":["216.24.57.1"]}}


### PR DESCRIPTION
## Summary
Register `agentshow.is-a.dev` for the Agentshow platform — live streaming of AI agent coding sessions.

## Checklist
- [x] I have read and understood the [Terms of Service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md)
- [x] My project is related to software development
- [x] I am the owner of the GitHub account listed

## DNS
Points to Render via A record `216.24.57.1` (Agentshow production).

Made with [Cursor](https://cursor.com)