### PR TITLE
Register soulmateos.is-a.dev

### DIFF
--- a/domains/soulmateos.json
+++ b/domains/soulmateos.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "singularitycurse26-svg",
+    "email": "hawpetossjustin25@gmail.com"
+  },
+  "records": {
+    "A": [
+      "75.2.60.5"
+    ]
+  }
+}

--- a/domains/www.soulmateos.json
+++ b/domains/www.soulmateos.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "singularitycurse26-svg",
+    "email": "hawpetossjustin25@gmail.com"
+  },
+  "records": {
+    "CNAME": "soulmate-hermes-agent.netlify.app"
+  }
+}


### PR DESCRIPTION
## Description
Registering `soulmateos.is-a.dev` for the Soulmate OS project.

## Domain Purpose
Soulmate OS is an open-source AI operating system with a self-improving LLM, recursive linking, and a unified digital life platform. The domain will point to our Netlify-hosted landing page.

- **soulmateos.is-a.dev** → A record to Netlify load balancer (75.2.60.5)
- **www.soulmateos.is-a.dev** → CNAME to soulmate-hermes-agent.netlify.app

## Preview
- Landing page: https://soulmate-hermes-agent.netlify.app
- GitHub: https://github.com/singularitycurse26-svg

## Checklist
- [x] The domain is not already registered
- [x] The website is complete and functional
- [x] The JSON file format is correct
- [x] The filename is in lowercase