### PR TITLE
Register serviceos.is-a.dev

### DIFF
--- a/domains/serviceos.json
+++ b/domains/serviceos.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "mkizil916",
+    "email": "hasangonen91@gmail.com"
+  },
+  "record": {
+    "CNAME": "customer-web.mkizil916.workers.dev"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Registering serviceos.is-a.dev for serviceOS — a free online appointment system for barbershops and beauty salons in Turkey.

CNAME: customer-web.mkizil916.workers.dev