### PR TITLE
Register serviceos.is-a.dev for serviceOS

### DIFF
--- a/domains/serviceos.json
+++ b/domains/serviceos.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "hasangonen91",
+    "email": "hasangonen91@gmail.com"
+  },
+  "records": {
+    "CNAME": "hasangonen91.github.io"
+  }
+}


### PR DESCRIPTION
Registering `serviceos.is-a.dev` for the serviceOS online appointment system landing page.

- **CNAME**: hasangonen91.github.io
- GitHub Pages hosts the static landing page.