### PR TITLE
Register homecalc-tools.is-a.dev

### DIFF
--- a/domains/homecalc-tools.json
+++ b/domains/homecalc-tools.json
@@ -1,0 +1,9 @@
+{
+    "record":  {
+                   "CNAME":  "3-mama-3.github.io"
+               },
+    "owner":  {
+                  "email":  "nesquike.e1@gmail.com",
+                  "username":  "3-MAMA-3"
+              }
+}


### PR DESCRIPTION
Registering the free subdomain homecalc-tools.is-a.dev for the calculator site. CNAME to 3-mama-3.github.io.