### PR TITLE
Add longyu and futu.longyu subdomains

### DIFF
--- a/domains/futu.longyu.json
+++ b/domains/futu.longyu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "LongYu-LY"
+  },
+  "repo": "https://github.com/LongYu-LY/LongYu-LY.github.io",
+  "records": {
+    "A": ["47.251.126.47"]
+  }
+}

--- a/domains/longyu.json
+++ b/domains/longyu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "LongYu-LY"
+  },
+  "repo": "https://github.com/LongYu-LY/LongYu-LY.github.io",
+  "records": {
+    "A": ["47.251.126.47"]
+  }
+}


### PR DESCRIPTION
Requesting two A records pointing to my server (47.251.126.47):
- longyu.is-a.dev (personal website)
- futu.longyu.is-a.dev (dashboard)