### PR TITLE
Register kang-dev

### DIFF
--- a/domains/kang-dev.json
+++ b/domains/kang-dev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Kang0234",
+        "email": "18980762558@163.com"
+    },
+    "records": {
+        "CNAME": ["kang0234.github.io"]
+    }
+}


### PR DESCRIPTION
Registering kang-dev.is-a.dev for my personal website hosted at kang0234.github.io. Thank you!