### PR TITLE
Register slimu.is-a.dev for GitHub Pages

### DIFF
--- a/domains/slimu.json
+++ b/domains/slimu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "slimulv1",
+    "email": "slimulv1@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "slimulv1.github.io"
+  }
+}


### PR DESCRIPTION
Registering the subdomain `slimu.is-a.dev` pointing to my GitHub Pages site (`slimulv1.github.io`).