### PR TITLE
feat: register smallstudio.is-a.dev

### DIFF
--- a/domains/smallstudio.json
+++ b/domains/smallstudio.json
@@ -1,0 +1,11 @@
+{
+  "description": "Small Studio Projects — official studio website",
+  "owner": {
+    "username": "Umeshfarrow",
+    "email": "umeshfarrow@gmail.com"
+  },
+  "records": {
+    "CNAME": "small-studio-projects.github.io"
+  },
+  "repo": "https://github.com/small-studio-projects/small-studio-projects.github.io"
+}


### PR DESCRIPTION
Registering **smallstudio.is-a.dev** for Small Studio (github.com/small-studio-projects).

- CNAME: small-studio-projects.github.io
- Owner: Umeshfarrow
- Site: official studio website (projects, docs)

Please review — happy to adjust anything.