### PR TITLE
feat: add GitHub Pages challenge TXT record for phoenix.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-mj-praba.phoenix.json
+++ b/domains/_github-pages-challenge-mj-praba.phoenix.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "mj-praba",
+        "email": "manojprabaharj@gmail.com"
+    },
+    "records": {
+        "TXT": "5452a491b95bcdd3a1c52cf415670c"
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://mj-praba.github.io/manoj-portfolio/

# Website Purpose

Personal portfolio for Manoj Prabahar J, Backend Engineer. `phoenix.is-a.dev` was already registered in #46148 with a CNAME to `mj-praba.github.io`. This PR only adds the `_github-pages-challenge-mj-praba` TXT record that GitHub requires to verify `phoenix.is-a.dev` as a custom domain for that same GitHub Pages site.