### PR TITLE
feat: register smartdoc.is-a.dev

### DIFF
--- a/domains/smartdoc.json
+++ b/domains/smartdoc.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "PhuocThanh22",
+    "email": "PhuocThanh22@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "witty-sand-083ee8e00.7.azurestaticapps.net"
+  }
+}


### PR DESCRIPTION
Register subdomain for my Azure Smart Document Platform (Static Web App).

Domain: smartdoc.is-a.dev
CNAME -> witty-sand-083ee8e00.7.azurestaticapps.net