### PR TITLE
Register www.austin.is-a.dev

### DIFF
--- a/domains/www.austin.json
+++ b/domains/www.austin.json
@@ -1,0 +1,11 @@
+{
+  "description": "Austin Munene - Developer Portfolio (www alias)",
+  "repo": "https://github.com/AustinMunene/Austin.is-a.dev",
+  "owner": {
+    "username": "AustinMunene",
+    "email": "austinmunesh@gmail.com"
+  },
+  "records": {
+    "CNAME": "austinmunene.netlify.app"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://austinmunene.netlify.app

# Website Purpose
My personal developer portfolio, showcasing my projects and skills as a software developer.

This PR adds the `www` alias for my existing root subdomain `austin.is-a.dev`, which was registered in #46128 and is already live. Netlify lists `www.austin.is-a.dev` as a domain alias that redirects to the primary domain, but it stays on "Pending DNS verification" because no DNS record exists for it. This nested record points to the same Netlify project as the parent, so `www.austin.is-a.dev` will 301 to `austin.is-a.dev`.

Both files are owned by the same user (`AustinMunene`), and the parent has no NS records.
