### PR TITLE
Add Vercel TXT verification for mhklogs.is-a.dev

### DIFF
--- a/domains/_vercel.mhklogs.json
+++ b/domains/_vercel.mhklogs.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "hklogs",
+    "email": "kayanihassaan5@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=mhklogs.is-a.dev,4d0e0c1c76b49c5299be"
+  }
+}


### PR DESCRIPTION
Adds the TXT record required by Vercel to verify ownership of `mhklogs.is-a.dev` (linked to another Vercel account).

- TXT record: `vc-domain-verify=mhklogs.is-a.dev,4d0e0c1c76b49c5299be`
- Domain already exists: `domains/mhklogs.json` (CNAME `cname.vercel-dns.com`)