### PR TITLE
Register aurahub.is-a.dev

### DIFF
--- a/domains/aurahub.json
+++ b/domains/aurahub.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "Gokulanand-art",
+        "email": "gokulanand744@gmail.com"
+    },
+    "description": "AURA Hub — an AI-native software engineering environment (IDE-style desktop app). Public project site.",
+    "repo": "https://github.com/Aura-hub-ai-native-workspace/aura-hub-website",
+    "records": {
+        "CNAME": "aura-hub-website-v2.pages.dev"
+    },
+    "proxied": true
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://aura-hub-website-v2.pages.dev

# Website Purpose
AURA Hub is an open desktop software-engineering environment (an IDE-style workspace, not a chatbot product) — no pricing, no paid tier, no commercial transactions on the site. This subdomain hosts the project's public information page.
