### PR TITLE
Register mobilemasters.is-a.dev

### DIFF
--- a/mobilemasters.json
+++ b/mobilemasters.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "qwenout-commits",
+    "email": "qwenout@gmail.com"
+  },
+  "record": {
+    "A": ["216.198.79.1"],
+    "TXT": ["vc-domain-verify=mobilemasters.is-a.dev,e56d554d44fc95139148"]
+  }
+}


### PR DESCRIPTION
Registering mobilemasters.is-a.dev for MobileMasters 868, a phone repair business in San Fernando, Trinidad & Tobago.

## Subdomain
mobilemasters.is-a.dev

## About
MobileMasters 868 is a phone and computer repair shop in San Fernando, Trinidad & Tobago. The website is a Next.js production site deployed on Vercel, with a live product catalog, search, and admin dashboard.

## Live preview
The site is live at: https://mobilemasters868-five.vercel.app

## Records
- A record: 216.198.79.1 (Vercel's recommended IP)
- TXT record: vc-domain-verify=mobilemasters.is-a.dev,e56d554d44fc95139148 (Vercel verification)

## Checklist
- [x] The file is in the `domains/` directory
- [x] The filename is `mobilemasters.json`
- [x] The JSON is valid
- [x] I've included a publicly available preview URL