### PR TITLE
feat(domain): add www.linoshuke.is-a.dev

### DIFF
--- a/domains/_vercel.linoshuke.json
+++ b/domains/_vercel.linoshuke.json
@@ -3,6 +3,9 @@
     "username": "linoshuke"
   },
   "records": {
-    "TXT": "vc-domain-verify=linoshuke.is-a.dev,0cb08d6cff77f71769ce"
+    "TXT": [
+      "vc-domain-verify=linoshuke.is-a.dev,0cb08d6cff77f71769ce",
+      "vc-domain-verify=www.linoshuke.is-a.dev,64183709a1d35524a8ce"
+    ]
   }
 }

--- a/domains/www.linoshuke.json
+++ b/domains/www.linoshuke.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "linoshuke"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

https://www.linoshuke.is-a.dev

This adds the `www` subdomain for the existing `linoshuke.is-a.dev` domain, which serves the same portfolio site: https://linoshuke.is-a.dev

# Website Purpose

Personal developer portfolio for linoshuke.
