### PR TITLE
Add Vercel TXT verification for bandishachowdhury.is-a.dev

### DIFF
--- a/domains/_vercel.bandishachowdhury.json
+++ b/domains/_vercel.bandishachowdhury.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "binayshaw7777",
+    "email": "bandishachowdhury07@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=bandishachowdhury.is-a.dev,ef66b00cac80600c50c8"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://bandisha-portfolio.vercel.app

# Website Purpose
This PR adds the TXT verification record `_vercel.bandishachowdhury.json` required by Vercel for custom domain ownership verification of `bandishachowdhury.is-a.dev` (personal software development portfolio).