### PR TITLE
Add _vercel TXT verification record for nilshogberg.is-a.dev

### DIFF
--- a/domains/_vercel.nilshogberg.json
+++ b/domains/_vercel.nilshogberg.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "Nimaho71",
+        "email": "nils.oi.hogberg@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=nilshogberg.is-a.dev,eb3a29a7bf4389851e75"
+    }
+}


### PR DESCRIPTION
This adds the Vercel TXT ownership-verification record for `nilshogberg.is-a.dev`, registered in #45266 (merged). Vercel reports the domain as linked to another Vercel account (the parent `is-a.dev` zone) and requires a TXT record at `_vercel.nilshogberg.is-a.dev` before it will issue a certificate. This follows the documented `_vercel.*.json` pattern used by existing entries such as `_vercel.adilpintoo.json`.

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://nilshogberg.vercel.app

# Website Purpose
Personal portfolio website showcasing my software engineering and cybersecurity projects (a chess engine, an SPH fluid simulation, an AI-driven web scraper, CTF work). Non-commercial.