### PR TITLE
Add MX and TXT records to zxyandreay.json

### DIFF
--- a/domains/zxyandreay.json
+++ b/domains/zxyandreay.json
@@ -1,9 +1,16 @@
 {
-    "owner": {
-        "username": "zxyandreay",
-        "email": "zxyandreay@gmail.com"
-    },
-    "records": {
-        "A": ["216.198.79.1"]
-    }
+  "owner": {
+    "username": "zxyandreay",
+    "email": "zxyandreay@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"],
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  }
 }


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements

* [x] I **agree** to the [[Terms of Service](https://is-a.dev/terms)](https://is-a.dev/terms).
* [x] My file is following the [[domain structure](https://docs.is-a.dev/domain-structure/)](https://docs.is-a.dev/domain-structure/).
* [x] My website is **reachable** and **completed**.
* [x] My website is **software development** related.
* [x] My website is **not for commercial use**.
* [x] I have provided sufficient contact information in the `owner` key.
* [x] I have provided a link to my website below.

# Website Preview

https://zxyandreay.is-a.dev/

# Website Purpose

This is an update to my existing `zxyandreay.is-a.dev` developer portfolio domain.

The website is already deployed and operational at https://zxyandreay.is-a.dev/ and is used as my personal developer portfolio to showcase my software development projects, technical work, experience, and skills.

This pull request does not change the website hosting or its existing purpose. It only adds MX and SPF DNS records for ImprovMX so I can use professional branded email addresses under my existing developer identity, such as `hello@zxyandreay.is-a.dev` and `jobs@zxyandreay.is-a.dev`.

The existing website A record is being preserved.