### PR TITLE
Register sipir.is-a.dev

### DIFF
--- a/domains/sipir.json
+++ b/domains/sipir.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "sipircip",
+        "email": "Sipir17@gmail.com"
+    },
+    "records": {
+        "NS": [
+            "khalid.ns.cloudflare.com",
+            "melody.ns.cloudflare.com"
+        ]
+    }
+}


### PR DESCRIPTION
Registering sipir.is-a.dev with NS records pointing to Cloudflare for DNS management and DDoS protection.

Reason for NS records: Using Cloudflare's free plan for SSL, caching, and DDoS protection on my personal API server.

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the owner key.
- [x] I have provided a link to my website below.

Website Preview: https://jefferson-alberta-jamie-gst.trycloudflare.com

Website Purpose: Personal API server for optical character recognition (OCR) and automated text extraction from images.