### PR TITLE
fix: update arem.is-a.dev A record to 76.76.21.21

### DIFF
--- a/domains/arem.json
+++ b/domains/arem.json
@@ -4,6 +4,6 @@
     "email": "toromadeadesina@gmail.com"
   },
   "records": {
-    "A": ["216.198.79.1"]
+    "A": ["76.76.21.21"]
   }
 }


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://arem-khaki.vercel.app

# Website Purpose

Update the A record for arem.is-a.dev from 216.198.79.1 to Vercel's anycast address 76.76.21.21 (the previous IP stopped resolving/connecting). Personal portfolio for a Web3 technical writer and builder. Non-commercial, personal use. Hosted on Vercel.