### PR TITLE
Register financial-independence.is-a.dev

### DIFF
--- a/domains/financial-independence.json
+++ b/domains/financial-independence.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "lucassing",
+    "email": "singlucasmartin@gmail.com"
+  },
+  "records": {
+    "CNAME": "fire.lucas-martin-sing.com.ar"
+  }
+}

--- a/domains/financial-independence.json
+++ b/domains/financial-independence.json
@@ -4,6 +4,6 @@
     "email": "singlucasmartin@gmail.com"
   },
   "records": {
-    "CNAME": "fire.lucas-martin-sing.com.ar"
+    "A": ["192.162.86.237"]
   }
 }


### PR DESCRIPTION
Registering **financial-independence.is-a.dev** — the public domain for my FIRE (Financial Independence, Retire Early) calculator.

- **Type**: A record pointing directly to `192.162.86.237` (my VPS, no proxy)
- **What it serves**: a fully static React/Vite app. No auth, no backend, public for anyone.
- **Verify once merged**: `curl https://financial-independence.is-a.dev/` returns the calculator homepage.