### PR TITLE
Register adrianerlikhman.is-a.dev

### DIFF
--- a/domains/adrianerlikhman.json
+++ b/domains/adrianerlikhman.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "adrian-erlikhman",
+    "email": "erlikhman.adrian@gmail.com"
+  },
+  "records": {
+    "CNAME": "adrian-erlikhman.github.io"
+  }
+}


### PR DESCRIPTION
Registering **adrianerlikhman.is-a.dev** for my personal portfolio.

- CNAME → `adrian-erlikhman.github.io` (GitHub Pages)
- Site is live and mine.

Thanks for maintaining is-a.dev!