### PR TITLE
Update Vercel verification TXT for nayanroy.is-a.dev

### DIFF
--- a/domains/_vercel.nayanroy.json
+++ b/domains/_vercel.nayanroy.json
@@ -4,6 +4,6 @@
     "email": "roynayanroy14@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=nayanroy.is-a.dev,f63821a3447fc77b65ac"
+    "TXT": "vc-domain-verify=nayanroy.is-a.dev,45bfcd0ac6c63a061657"
   }
 }


### PR DESCRIPTION
## Summary

Updates the `_vercel.nayanroy` TXT record to the current Vercel domain-verify value.

`nayanroy.is-a.dev` was registered in #46110 and the DNS is working — the CNAME still resolves to Vercel's edge. The site behind it has been rebuilt on a new Vercel project, and Vercel issues a **per-project** verification value, so the existing TXT carries the previous project's token and ownership verification cannot complete.

This is a one-line change to an existing record I already own. No new subdomain, no CNAME change.

```diff
-    "TXT": "vc-domain-verify=nayanroy.is-a.dev,f63821a3447fc77b65ac"
+    "TXT": "vc-domain-verify=nayanroy.is-a.dev,45bfcd0ac6c63a061657"
```

## Site

The site is live and publicly reachable here: https://portfolio-xi-nine-ndgnt33cei.vercel.app

Once this record propagates, Vercel verifies ownership and it serves at `nayanroy.is-a.dev`.

## Checklist

- [x] I own this subdomain (registered in #46110, same GitHub account)
- [x] Only an existing record is modified
- [x] The site is live and reachable