### PR TITLE
Redirect divyakush.is-a.dev to www.divyakush.com (URL record, 301)

### DIFF
--- a/domains/divyakush.json
+++ b/domains/divyakush.json
@@ -4,6 +4,6 @@
     "email": "divyakushpunjabi@gmail.com"
   },
   "records": {
-    "CNAME": "divyakush2006.github.io"
+    "CNAME": "cname.vercel-dns.com"
   }
 }

--- a/domains/divyakush.json
+++ b/domains/divyakush.json
@@ -4,6 +4,6 @@
     "email": "divyakushpunjabi@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "URL": "https://www.divyakush.com"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://www.divyakush.com

# Website Purpose

This is my personal software-developer portfolio. I originally hosted it at `divyakush.is-a.dev` and have since moved it to my own domain, `www.divyakush.com`.

This PR updates my **existing** `divyakush.is-a.dev` entry to a `URL` record so the old subdomain permanently redirects to my portfolio at `www.divyakush.com`. It is a non-commercial personal portfolio showcasing my full-stack and applied-AI projects. Ownership (`Divyakush2006`) is unchanged — only the record type/target changed.
