### PR TITLE
Add windu.is-a.dev

### DIFF
--- a/domains/_vercel.windu.json
+++ b/domains/_vercel.windu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ayethor",
+    "email": "hayrullaevmaga@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=windu.is-a.dev,2770eec9a4970b227efc"
+  }
+}

--- a/domains/windu.json
+++ b/domains/windu.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ayethor",
+    "email": "hayrullaevmaga@gmail.com"
+  },
+  "records": {
+    "CNAME": "c92f5b2d625bb23b.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
Requesting `windu.is-a.dev` for Windu Voice — a desktop voice assistant.

Two files, as done for other Vercel-hosted subdomains in this registry:

- `domains/windu.json` — CNAME to the Vercel deployment
- `domains/_vercel.windu.json` — TXT record Vercel requires to verify domain ownership

The domain is already added to the Vercel project, so it will resolve as soon as the records go live.
