### PR TITLE
Add yuka.json for personal email domain configuration

### DIFF
--- a/register/yuka.json
+++ b/register/yuka.json
@@ -1,0 +1,7 @@
+{
+  "subdomain": "yuka",
+  "domain": "is-a.dev",
+  "description": "Personal email domain for hobby programming",
+  "repos": ["https://github.com/onikatasyoko"],
+  "email": "meko@tuta.io"
+}


### PR DESCRIPTION
- [x] I agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domains/domain-structure.html).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `email` field.
- [x] I have provided a link to my website below.

# Website Preview
https://github.com/onikatasyoko

# Website Purpose
Personal email domain for hobby programming; receive-only via Zoho Mail.