### PR TITLE
Register gpt-bridge.is-a.dev

### DIFF
--- a/domains/gpt-bridge.json
+++ b/domains/gpt-bridge.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "marona190",
+    "email": "mzahra89@gmail.com"
+  },
+  "records": {
+    "CNAME": "eda217b0-16f9-475c-a251-89f118826692.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
CNAME record pointing to a personal Cloudflare Tunnel used for a private local dev bridge. No public content is served.