### PR TITLE
add adeshdeshmukh.is-a.dev domain

### DIFF
--- a/domains/_vercel.adeshdeshmukh.json
+++ b/domains/_vercel.adeshdeshmukh.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "AdeshDeshmukh"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=adeshdeshmukh.is-a.dev,f447290d18443c0316a8"
+  }
+}

--- a/domains/adeshdeshmukh.json
+++ b/domains/adeshdeshmukh.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "AdeshDeshmukh"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
This PR adds the domain `adeshdeshmukh.is-a.dev` to the is-a.dev directory.

- **Target domain:** `adeshdeshmukh.is-a.dev`
- **Records:** A record pointing to Vercel + TXT verification for Vercel
- **Owner:** @AdeshDeshmukh

Requirements:
- [x] I have read the [documentation](https://docs.is-a.dev) and my file follows the required format.
- [x] The domain is unique and not already in use.
- [x] I understand this subdomain is free of charge and subject to the [Terms of Service](https://is-a.dev/terms).
