### PR TITLE
Register masive-als.is-a.dev

### DIFF
--- a/domains/conmimirada.json
+++ b/domains/conmimirada.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "fredy30-Rojas",
+    "email": "fredy_30@hotmail.com"
+  },
+  "records": {
+    "A": ["79.72.57.253"]
+  }
+}

--- a/domains/masive-als.json
+++ b/domains/masive-als.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "fredy30-Rojas",
+    "email": "fredy_30@hotmail.com"
+  },
+  "record": {
+    "A": ["79.72.57.253"]
+  },
+  "description": "MASIVE-ALS: Scientific computing project using AlphaFold, AutoDock-GPU and GROMACS on MareNostrum 5 supercomputer for ALS drug discovery. Open source software tools for molecular docking at exascale."
+}


### PR DESCRIPTION
## masive-als.is-a.dev

**Project:** MASIVE-ALS - Molecular Docking at Exascale for ALS Proteinopathy

**Description:** Scientific computing project using AlphaFold-Multimer, AutoDock-GPU, and GROMACS on the MareNostrum 5 supercomputer (BSC-CNS, Barcelona) for ALS drug discovery. The project performs massive virtual screening of 10 million compounds against TDP-43, SOD1, and FUS proteins.

**Software used:** AlphaFold-Multimer (Nobel Prize 2024), AutoDock-GPU, GROMACS, OpenBabel, Python

**Open source:** github.com/fredy30-Rojas/masive-als (CC-BY 4.0)

This domain will host the project landing page with scientific documentation, results, and tools.