### PR TITLE
Register conmimirada.is-a.dev and masive-als.is-a.dev (software development projects)

### DIFF
--- a/domains/conmimirada.json
+++ b/domains/conmimirada.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "fredy30-Rojas",
+    "email": "fredy_30@hotmail.com"
+  },
+  "records": {
+    "A": ["79.72.57.253"]
+  }
+}

--- a/domains/masive-als.json
+++ b/domains/masive-als.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "fredy30-Rojas",
+    "email": "fredy_30@hotmail.com"
+  },
+  "record": {
+    "A": ["79.72.57.253"]
+  },
+  "description": "MASIVE-ALS: Scientific computing project using AlphaFold, AutoDock-GPU and GROMACS on MareNostrum 5 supercomputer for ALS drug discovery. Open source software tools for molecular docking at exascale."
+}


### PR DESCRIPTION
## Two domain registrations - both software development projects

---

### 1. conmimirada.is-a.dev

**Type:** SOFTWARE DEVELOPMENT / ASSISTIVE TECHNOLOGY TOOLS

This is a software tools and documentation website. It provides:

- **Software Installation Guides** for OptiKey (C#/.NET eye-tracking keyboard), Freebuff (Node.js/TypeScript AI coding assistant), Python, and Node.js
- **Technical Documentation** with API references and configuration parameters
- **Download Links** to GitHub releases and official installers
- **Developer Community** link (Telegram group for troubleshooting)

**Software ecosystems:** Python (pygaze, MediaPipe), Node.js (npm), .NET/C#, Git/GitHub

> Previous submission #45602 was auto-closed by a bot. The page literally helps users install and configure multiple software development tools.

---

### 2. masive-als.is-a.dev

**Type:** SCIENTIFIC COMPUTING / BIOINFORMATICS SOFTWARE

This is the project page for MASIVE-ALS, a computational drug discovery pipeline using:

- **AlphaFold-Multimer** (Nobel Prize 2024) for protein structure prediction
- **AutoDock-GPU** for massive virtual screening
- **GROMACS** for molecular dynamics simulations
- **Python** scripts for data processing and analysis
- Running on **MareNostrum 5** supercomputer (BSC-CNS, Barcelona)

**Open source:** github.com/fredy30-Rojas/masive-als (CC-BY 4.0)

---

Both domains point to the same Oracle Cloud server (79.72.57.253) hosting nginx with software documentation and project pages.

Please review manually - both projects are genuine software development efforts. Thank you.