### PR TITLE
Register winar9router.is-a.dev

### DIFF
--- a/daily.log
+++ b/daily.log
@@ -1,1 +1,1 @@
-fix: resolve race condition on async - 2026-08-10
+refactor: clean up redundant logic in handler - 2026-08-11

--- a/daily.log
+++ b/daily.log
@@ -1,1 +1,1 @@
-refactor: clean up redundant logic in handler - 2026-08-11
+refactor: simplify nested conditional - 2026-08-11

--- a/daily.log
+++ b/daily.log
@@ -1,0 +1,1 @@
+fix: resolve race condition on async - 2026-08-10

--- a/domains/winar9router.json
+++ b/domains/winar9router.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "robet31"
+  },
+  "records": {
+    "CNAME": "robet-9od0oo2te.tail625da0.ts.net"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Registering winar9router.is-a.dev to route to my personal AI gateway (9Router) exposed via Tailscale Funnel.

Demo website: http://localhost:20128/dashboard (dashboard) � public endpoint: https://robet-9od0oo2te.tail625da0.ts.net

It proxies to my Tailscale funnel hostname.
