### PR TITLE
Register physicsink.is-a.dev

### DIFF
--- a/domains/physicsink.json
+++ b/domains/physicsink.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Emran-Y"
+  },
+  "records": {
+    "A": ["169.58.6.53"]
+  }
+}


### PR DESCRIPTION
Registering the free subdomain **physicsink.is-a.dev** for a private physics tutoring site.

- owner: Emran-Y
- record: A -> 169.58.6.53

Follows the domain-structure docs (A record, no proxy).