### PR TITLE
Register tarekelda.is-a.dev

### DIFF
--- a/domains/tarekelda.json
+++ b/domains/tarekelda.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "pulsarCS",
+        "email": "talterx1@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
Personal portfolio of Tarek Abdeldayem (Tarek Elda), deployed on Vercel. CNAME points at cname.vercel-dns.com and the domain is attached to the Vercel project.