### PR TITLE
Add mythik.is-a.dev

### DIFF
--- a/domains/mythik.json
+++ b/domains/mythik.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Grisalvo1"
+  },
+  "records": {
+    "A": ["51.94.91.37"]
+  }
+}


### PR DESCRIPTION
## Website preview

https://51.94.91.37

MythiK is a non-commercial World of Warcraft guild management and raid progress project.

The website is currently hosted on an AWS EC2 instance and the requested A record points to:

51.94.91.37

<img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/c987ef9a-cdae-40a8-b779-ca85f6f0161c" />

<img width="1913" height="918" alt="image" src="https://github.com/user-attachments/assets/1a8f6420-473a-4ca8-a114-c69ca7f1ad51" />

The site is deployed on AWS EC2 and the A record points to 51.94.91.37; HTTPS/final domain setup is pending.