### PR TITLE
Add longyu and futu.longyu subdomains

### DIFF
--- a/domains/futu.longyu.json
+++ b/domains/futu.longyu.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "LongYu-LY",
+    "email": "846410745@qq.com"
+  },
+  "repo": "https://github.com/LongYu-LY/LongYu-LY.github.io",
+  "records": {
+    "A": ["47.251.126.47"]
+  }
+}

--- a/domains/longyu.json
+++ b/domains/longyu.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "LongYu-LY",
+    "email": "846410745@qq.com"
+  },
+  "repo": "https://github.com/LongYu-LY/LongYu-LY.github.io",
+  "records": {
+    "A": ["47.251.126.47"]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://levy-jar-vessels-yellow.trycloudflare.com

# Website Purpose
`longyu.is-a.dev` is my personal research site: it aggregates daily AI/ML paper recommendations and stores my reading notes, built as a self-hosted web app (search, KaTeX math rendering, GitHub trending feed). Purely for personal study use.

`futu.longyu.is-a.dev` is the dashboard for my personal stock-monitoring scripts, also self-hosted and for personal use only.
