### PR TITLE
Add azevedo.is-a.dev subdomain

### DIFF
--- a/domains/azevedo.json
+++ b/domains/azevedo.json
@@ -1,0 +1,10 @@
+{
+  "description": "My awesome portfolio",
+  "repo": "https://github.com/oazvedo/oazvedo.github.io",
+  "owner": {
+    "username": "oazvedo"
+  },
+  "records": {
+    "CNAME": "oazvedo.github.io"
+  }
+}


### PR DESCRIPTION
## Description

Registering `azevedo.is-a.dev` to point to my GitHub Pages site.

## Type of registration

- [x] New domain registration
- [ ] Domain registration edit
- [ ] Domain removal
- [ ] Other

## Records

- CNAME -> oazvedo.github.io (source: https://github.com/oazvedo/oazvedo.github.io)