### PR TITLE
Add Vercel TXT verification for bandishachowdhury.is-a.dev

### DIFF
--- a/domains/_vercel.bandishachowdhury.json
+++ b/domains/_vercel.bandishachowdhury.json
@@ -4,6 +4,6 @@
     "email": "bandishachowdhury07@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=bandishachowdhury.is-a.dev,ef66b00cac80600c50c8"
+    "TXT": "vc-domain-verify=bandishachowdhury.is-a.dev,192156269262106afc2f"
   }
 }


### PR DESCRIPTION
### Subdomain
`_vercel.bandishachowdhury.is-a.dev`

### Description
Add Vercel domain verification TXT record for `bandishachowdhury.is-a.dev`.

### Record
`TXT` -> `vc-domain-verify=bandishachowdhury.is-a.dev,192156269262106afc2f`