### PR TITLE
Add Mailjet SPF and DKIM authentication for zxyandreay.is-a.dev

### DIFF
--- a/domains/mailjet._domainkey.zxyandreay.json
+++ b/domains/mailjet._domainkey.zxyandreay.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "zxyandreay",
+    "email": "zxyandreay@gmail.com"
+  },
+  "records": {
+    "TXT": "k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujNJF8b/c7NDnfknAVuFrCgyt+K5MqYzBiEUa6C8mD4pMJwAKLd2INkiCDeaztXdV0aHN4EiOoJrljgGvr9TUhS/pYMvxc7aS71Wpyb5bjDJhFgC+eVx6t8yJE0uUV8ol/jQZO+Jaa6ZJ6o4llj2ZsgJnRM8TXlagc1jkv7mvBH8nXd5w92xa5KkUeWAyhhrLEifuoDmgHChKNJjyrugKoXYN7yagVKmzBhciQh/fNWLLhiZAViteNT3rXP+VL5b628HmE5SHWDww2pnOiRroab5K9NCD6AGRAoUfa1/tPjpwO+N0uiD4CA9qiKb9pCK1+dgSxpBHMWi3eec3c6z6QIDAQAB"
+  }
+}

--- a/domains/zxyandreay.json
+++ b/domains/zxyandreay.json
@@ -10,7 +10,7 @@
       "mx2.improvmx.com"
     ],
     "TXT": [
-      "v=spf1 include:spf.improvmx.com ~all"
+      "v=spf1 include:spf.mailjet.com include:spf.improvmx.com ~all"
     ]
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://zxyandreay.is-a.dev

# Website Purpose

This is an update to my existing `zxyandreay.is-a.dev` developer portfolio domain.

The website is already deployed and operational at https://zxyandreay.is-a.dev and is used as my personal developer portfolio to showcase my software development projects, technical work, experience, and skills.

This pull request does not change the website hosting or its existing purpose. It updates the email authentication configuration for my existing professional contact addresses under the domain.

The changes:

- Update the existing SPF record to authorize both ImprovMX and Mailjet.
- Add the Mailjet DKIM record for authenticated outgoing email.
- Preserve the existing website and ImprovMX email forwarding configuration.

ImprovMX remains responsible for incoming email forwarding, while Mailjet is being configured as the SMTP provider for outgoing email from addresses such as `contact@zxyandreay.is-a.dev` and `support@zxyandreay.is-a.dev`.