### PR TITLE
Add Google Search Console TXT verification for kartik.is-a.dev

### DIFF
--- a/domains/kartik.json
+++ b/domains/kartik.json
@@ -4,7 +4,6 @@
         "email": "k.a.r.t.i.k.2007.17@gmail.com"
     },
     "records": {
-        "CNAME": "cname.vercel-dns.com",
-        "TXT": "google-site-verification=aDW1JA9mjoEYwVJkdKcjdsVbUWDeVKDxRsWcO_pEjUY"
+        "CNAME": "cname.vercel-dns.com"
     }
 }

--- a/domains/kartik.json
+++ b/domains/kartik.json
@@ -4,6 +4,7 @@
         "email": "k.a.r.t.i.k.2007.17@gmail.com"
     },
     "records": {
-        "CNAME": "cname.vercel-dns.com"
+        "CNAME": "cname.vercel-dns.com",
+        "TXT": "google-site-verification=aDW1JA9mjoEYwVJkdKcjdsVbUWDeVKDxRsWcO_pEjUY"
     }
 }


### PR DESCRIPTION
## Description

Added the Google Search Console TXT verification record for kartik.is-a.dev.

- Added Google Search Console TXT verification
- Preserved the existing Vercel DNS configuration
- No existing records were removed