### PR TITLE
Request for gama.is-a.dev

### DIFF
--- a/domains/gama.json
+++ b/domains/gama.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "lennebraha38"
+    },
+    "records": {
+        "CNAME": "lennebraha38.github.io"
+    }
+}


### PR DESCRIPTION
Requesting the `gama` subdomain to host my GitHub Pages site (Turkish technology community portal). The domain points to lennebraha38.github.io via CNAME.