### PR TITLE
Register pmangialavori.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-eatsjobs.pmangialavori.json
+++ b/domains/_github-pages-challenge-eatsjobs.pmangialavori.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "eatsjobs",
+    "email": "eatsjobs.41srie@bumpmail.io"
+  },
+  "records": {
+    "TXT": "cf09fc97e0e81ab21d48bca91465f7"
+  }
+}

--- a/domains/pmangialavori.json
+++ b/domains/pmangialavori.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "eatsjobs",
+    "email": "eatsjobs.41srie@bumpmail.io"
+  },
+  "records": {
+    "CNAME": "eatsjobs.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://eatsjobs.github.io/

# Website Purpose

Personal portfolio site for Pasquale Mangialavori, a Senior Frontend Engineer at Scandit. Includes about/bio, work experience timeline, open-source projects, and contact links.