### PR TITLE
Add zxcvbecho.is-a.dev

### DIFF
--- a/domains/zxcvbecho.json
+++ b/domains/zxcvbecho.json
@@ -2,7 +2,7 @@
   "owner": {
     "username": "gemausername"
   },
-  "record": {
+  "records": {
     "CNAME": "aa3eaa33-b9f0-4d43-95e7-96bd07e02c68.cfargotunnel.com"
   }
 }

--- a/domains/zxcvbecho.json
+++ b/domains/zxcvbecho.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "gemausername"
+  },
+  "record": {
+    "CNAME": "aa3eaa33-b9f0-4d43-95e7-96bd07e02c68.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
Closing: is-a.dev blocks CNAME records ending in .cfargotunnel.com (disallowed-cnames.json). Switching to DuckDNS instead.