### PR TITLE
add mentigen.is-a.dev

### DIFF
--- a/domains/mentigen.json
+++ b/domains/mentigen.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Mentigen",
+    "email": "mentigen14@gmail.com"
+  },
+  "records": {
+    "CNAME": "m-srv.tail8e654d.ts.net"
+  }
+}


### PR DESCRIPTION
## What is the domain used for?

Personal homepage and self-hosted services (Paperless document management). The site is live at https://m-srv.tail8e654d.ts.net/ and redirects to a landing page with a link to Paperless.

## Why a .ts.net CNAME?

The previous PR was denied because the reviewer thought this pointed to a private Tailscale network. I want to clarify how this works.

m-srv.tail8e654d.ts.net is a Tailscale Funnel address. Funnel is a feature that exposes a local server to the public internet - not just to devices on the Tailscale network. Anyone without Tailscale installed can open https://m-srv.tail8e654d.ts.net/ in a browser and reach the site. It works exactly like a regular public URL.

Tailscale Funnel docs: https://tailscale.com/kb/1223/funnel

The CNAME chain: mentigen.is-a.dev -> m-srv.tail8e654d.ts.net -> Tailscale Funnel -> my server. Since is-a.dev uses Cloudflare as a proxy, SSL is handled by Cloudflare on the way in, same as any other subdomain here.

## Is it publicly accessible?

Yes. curl -I https://m-srv.tail8e654d.ts.net/ returns HTTP 200 from any network.

Website preview: https://m-srv.tail8e654d.ts.net/

## Checklist

- [x] I have read the contributing guidelines
- [x] I have a valid reason for the domain
- [x] My PR title is add mentigen.is-a.dev
- [x] The JSON file is valid
- [x] The domain points to a publicly accessible site