### PR TITLE
Add domains/dsiacademy.json for dsiacademy.is-a.devAdd domains/dsiacademy.json for dsiacademy.is-a.dev

### DIFF
--- a/domains/dsiacademy.json
+++ b/domains/dsiacademy.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "azo9digitalservice-dotcom"
+  },
+  "records": {
+    "CNAME": "interface-c7g.pages.dev"
+  }
+}


### PR DESCRIPTION
Adds dsiacademy.is-a.dev pointing to interface-c7g.pages.dev.

Adds the file domains/dsiacademy.json with owner.username = "azo9digitalservice-dotcom".
Adds a single CNAME record: interface-c7g.pages.dev.
No other files are modified.