### PR TITLE
Register medigitalhub.is-a.dev subdomain

### DIFF
--- a/domains/medigitalhub.json
+++ b/domains/medigitalhub.json
@@ -1,7 +1,7 @@
 {
     "owner": {
         "username": "magogwa",
-        "email": "magogwa@users.noreply.github.com"
+        "email": "magogwakambayeko@gmail.com"
     },
     "records": {
         "CNAME": "me-digital-hub.pages.dev"

--- a/domains/medigitalhub.json
+++ b/domains/medigitalhub.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "magogwa",
+        "email": "magogwa@users.noreply.github.com"
+    },
+    "records": {
+        "CNAME": "me-digital-hub.pages.dev"
+    },
+    "proxied": true
+}


### PR DESCRIPTION
## Description

Registering the subdomain `medigitalhub.is-a.dev` for my M&E Data Collection & Analytics Platform, hosted on Cloudflare Pages.

## Records

```json
{
  "owner": {
    "username": "magogwa",
    "email": "magogwakambayeko@gmail.com"
  },
  "records": {
    "CNAME": "me-digital-hub.pages.dev"
  },
  "proxied": true
}
```

## Preview

The site is currently live at https://me-digital-hub.pages.dev (the `medigitalhub.is-a.dev` subdomain will point to it).