### PR TITLE
Add operio.is-a.dev

### DIFF
--- a/domains/_railway-verify.operio.json
+++ b/domains/_railway-verify.operio.json
@@ -1,0 +1,10 @@
+{
+  "description": "Railway domain verification for operio.is-a.dev",
+  "owner": {
+    "username": "axeelhrz",
+    "email": "axeelhrz@gmail.com"
+  },
+  "records": {
+    "TXT": "railway-verify=f2c2168a6fd989a03c34502a6da98cb712a1a7b077299beb6bbd8c0a15371a67"
+  }
+}

--- a/domains/operio.json
+++ b/domains/operio.json
@@ -1,0 +1,11 @@
+{
+  "description": "Operio — SaaS platform for service businesses",
+  "repo": "https://github.com/axeelhrz/register",
+  "owner": {
+    "username": "axeelhrz",
+    "email": "axeelhrz@gmail.com"
+  },
+  "records": {
+    "CNAME": "operio.up.railway.app"
+  }
+}

--- a/domains/operio.json
+++ b/domains/operio.json
@@ -6,6 +6,6 @@
     "email": "axeelhrz@gmail.com"
   },
   "records": {
-    "CNAME": "operio.up.railway.app"
+    "CNAME": "pq3cu6zg.up.railway.app"
   }
 }


### PR DESCRIPTION
## Subdomain
`operio.is-a.dev`

## Purpose
SaaS platform (Operio) for service businesses — Next.js app hosted on Railway.

## DNS
CNAME → `operio.up.railway.app`

Made with [Cursor](https://cursor.com)