### PR TITLE
Register vimrella.is-a.dev

### DIFF
--- a/domains/vimrella.json
+++ b/domains/vimrella.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "MarkMillon",
+    "email": "markusmilliones@gmail.com"
+  },
+  "records": {
+    "CNAME": "markmillon.github.io"
+  }
+}


### PR DESCRIPTION
Registering `vimrella.is-a.dev` for the Vimrella Health storefront, served from GitHub Pages at `markmillon.github.io`.

- Domain: **vimrella.is-a.dev**
- Record: `CNAME markmillon.github.io`
- Repository: https://github.com/MarkMillon/vimrella (Pages already enabled)

The site is a pre-launch supplement storefront used for supplier outreach. Thanks!