### PR TITLE
Add terrylifeos subdomain

### DIFF
--- a/domains/llm.terrylifeos.json
+++ b/domains/llm.terrylifeos.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "cschng",
+    "email": "cschng@gmail.com"
+  },
+  "record": {
+    "CNAME": "cb3fbd67-da35-4e75-829c-8f2ce97c2646.cfargotunnel.com"
+  },
+  "domain": "terrylifeos.is-a.dev",
+  "subdomain": "llm.terrylifeos"
+}

--- a/domains/terrylifeos.json
+++ b/domains/terrylifeos.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "cschng",
+    "email": "cschng@gmail.com"
+  },
+  "record": {
+    "CNAME": "cb3fbd67-da35-4e75-829c-8f2ce97c2646.cfargotunnel.com"
+  },
+  "domain": "terrylifeos.is-a.dev",
+  "subdomain": "terrylifeos"
+}


### PR DESCRIPTION
Personal lifeos dashboard (life management webapp) routed via my
Cloudflare Named Tunnel.

Subdomains:
  - terrylifeos.is-a.dev     -> main webapp UI
  - llm.terrylifeos.is-a.dev -> local LLM endpoint

Both CNAME to my Cloudflare Tunnel (cb3fbd67-da35-4e75-829c-8f2ce97c2646).
Project is for personal daily-driver use, not a public site.