### PR TITLE
Add Vercel TXT verification for yashwinreddy.is-a.dev

### DIFF
--- a/domains/_vercel.yashwinreddy.json
+++ b/domains/_vercel.yashwinreddy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "YashwinReddy29",
+    "email": "yashwinlakkireddy@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=yashwinreddy.is-a.dev,4589616d5ece1e092491"
+  }
+}


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://yashwin-reddy-portfolio-orpin.vercel.app

# Website Purpose
This is a supplementary PR adding the `_vercel` TXT verification record needed to connect my already-registered domain `yashwinreddy.is-a.dev` (approved in #46721) to my Vercel project. The site itself is my personal software engineering portfolio, showcasing projects, work experience, and technical writing.