### PR TITLE
Add maranatha.is-a.dev

### DIFF
--- a/domains/maranatha.json
+++ b/domains/maranatha.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"ypmulima-11"},"records":{"CNAME":"ypmulima-11.github.io"},"proxied":true}


### PR DESCRIPTION
### Requested Domain
maranatha.is-a.dev

### Description
Maranatha Choir official website, hosted on GitHub Pages at ypmulima-11.github.io/Maranatha.

### Records
CNAME -> ypmulima-11.github.io (proxied)