### PR TITLE
Add chinaease.is-a.dev

### DIFF
--- a/domains/chinaease.json
+++ b/domains/chinaease.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"tachikomaver2-ship-it","email":"tachikomaver2@gmail.com"},"records":{"CNAME":"tachikomaver2-ship-it.github.io"}}


### PR DESCRIPTION
Add chinaease.is-a.dev

This subdomain points to the ChinaEase website — a free, open-source static site offering services for foreigners living in / visiting China (HSK language learning, travel, shopping, jobs, hospital companion care).

- Owner: tachikomaver2-ship-it
- Record: CNAME -> tachikomaver2-ship-it.github.io
- Live: https://tachikomaver2-ship-it.github.io/china-services/

Dev-related OSS project hosted on GitHub Pages. Thanks!