### PR TITLE
Register soulmateos.is-a.dev

### DIFF
--- a/domains/soulmateos.json
+++ b/domains/soulmateos.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "singularitycurse26-svg",
+    "email": "hawpetossjustin25@gmail.com"
+  },
+  "records": {
+    "A": [
+      "75.2.60.5"
+    ]
+  }
+}

--- a/domains/www.soulmateos.json
+++ b/domains/www.soulmateos.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "singularitycurse26-svg",
+    "email": "hawpetossjustin25@gmail.com"
+  },
+  "records": {
+    "CNAME": "soulmate-hermes-agent.netlify.app"
+  }
+}


### PR DESCRIPTION
## Domain Registration

Registering `soulmateos.is-a.dev` for the Soulmate OS project.

**Website:** https://soulmate-hermes-agent.netlify.app
**GitHub:** https://github.com/singularitycurse26-svg/soulmate
**Description:** Soulmate OS — A local-first AI reasoning agent with persistent memory, crypto wallet, and full web UI

### Files added:
- `domains/soulmateos.json` — A record pointing to Netlify load balancer (75.2.60.5)
- `domains/www.soulmateos.json` — CNAME record pointing to soulmate-hermes-agent.netlify.app

### Preview
The site is already live and deployed on Netlify. This domain was previously registered but expired. Re-registering to restore the custom domain.