### PR TITLE
Update brusnica.json: switch A record to CNAME

### DIFF
--- a/domains/brusnica.json
+++ b/domains/brusnica.json
@@ -4,6 +4,6 @@
     "email": "gooldes@gmail.com"
   },
   "records": {
-    "A": ["134.17.37.128"]
+    "CNAME": "alikenetik-kn-1011.netcraze.pro"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

http://alikenetik-kn-1011.netcraze.pro/

# Website Purpose

Bilingual (RU/EN) website of a small software development team: our projects and case studies, plus live demo landings deployed on the same host (/demo/*). Built with Next.js 15, TypeScript and Tailwind CSS, self-hosted on our VPS.

# Reason for this change

Thanks for merging #46952! Right after it went live I found the A record no longer works: my host assigns the VPS a NAT'd public address and it changed the same day (134.17.37.128 → 134.17.172.0), so `brusnica.is-a.dev` now points at a dead IP and the Let's Encrypt HTTP-01 challenge times out.

This switches the record to a CNAME pointing at the host's stable hostname `alikenetik-kn-1011.netcraze.pro`, which tracks the machine regardless of the address it gets. No other records are set, so the CNAME stands alone.