### PR TITLE
Register digitaltirth.is-a.dev

### DIFF
--- a/domains/digitaltirth.json
+++ b/domains/digitaltirth.json
@@ -1,0 +1,10 @@
+{
+  "description": "Digital Tirth - an open devotional web experience: light a diya, ring the bell, offer daan. Built as a static web app.",
+  "owner": {
+    "username": "aryandigital",
+    "email": "89099181+aryandigital@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "gray-mud-083838800.7.azurestaticapps.net"
+  }
+}


### PR DESCRIPTION
Registering digitaltirth.is-a.dev -> Azure Static Web App (CNAME: gray-mud-083838800.7.azurestaticapps.net). Digital Tirth is a devotional web experience (diya lighting, temple bell ambience, sankalp wall). Site is live at the CNAME target. I have read the terms of service.