### PR TITLE
Add sarahgordonportfolio.is-a.dev and techmorahsolution.is-a.dev

### DIFF
--- a/domains/sarahgordonportfolio.json
+++ b/domains/sarahgordonportfolio.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "SarahGordon895",
+    "email": "gordonsarah2404@gmail.com"
+  },
+  "records": {
+    "CNAME": "sarahgordon895.github.io"
+  }
+}

--- a/domains/techmorahsolution.json
+++ b/domains/techmorahsolution.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "SarahGordon895",
+    "email": "gordonsarah2404@gmail.com"
+  },
+  "records": {
+    "CNAME": "sarahgordon895.github.io"
+  }
+}


### PR DESCRIPTION
## Description
Register two GitHub Pages custom domains for my developer portfolio and project showcase:

- `sarahgordonportfolio.is-a.dev` → https://sarahgordon895.github.io/sarahgordon.github.io/
- `techmorahsolution.is-a.dev` → https://sarahgordon895.github.io/TechMorah/

Both CNAME records point to `sarahgordon895.github.io`.

## Checklist
- [x] I agree to the Terms of Service (https://is-a.dev/terms)
- [x] My file follows the domain structure docs
- [x] My websites are reachable and complete
- [x] My websites are software development related
- [x] I have provided contact information in the owner key
- [x] I have provided a preview of my websites above

## Notes
Personal developer portfolio (Sarah Gordon) and open project showcase (TechMorah static site on GitHub Pages).