### PR TITLE
Register api.bdhm.is-a.dev

### DIFF
--- a/domains/api.bdhm.json
+++ b/domains/api.bdhm.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "000bdhm",
+    "email": "bdhm32@gmail.com"
+  },
+  "records": {
+    "URL": "https://api.bdhm32.workers.dev"
+  },
+  "redirect_config": {
+    "redirect_paths": true
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the \owner\ key.

## Domain

Registers nested subdomain \api.bdhm.is-a.dev\ (i already hold \bdhm.is-a.dev\).

Points to a self-hosted status/uptime/other API running on Cloudflare Workers. Uses a \URL\ redirect with \
edirect_paths: true\ so API paths are preserved, e.g. \api.bdhm.is-a.dev/api/v1/status\ -> \https://api.bdhm32.workers.dev/api/v1/status\.