### PR TITLE
feat: register gaganjain.is-a.dev and www.gaganjain.is-a.dev for Vercel

### DIFF
--- a/domains/gaganjain.json
+++ b/domains/gaganjain.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "gaganjainse"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}

--- a/domains/www.gaganjain.json
+++ b/domains/www.gaganjain.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "gaganjainse"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not** for commercial use.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website.

# Website Preview
https://gaganjain.vercel.app

# Website Purpose
Personal portfolio website for an AI / LLM Engineer. Showcases projects in GenAI, Agentic AI, RAG, LLM fine-tuning, and Production AI systems.

# DNS Setup (Vercel)
Both domains point to cname.vercel-dns.com (Vercel's universal custom-domain target):
- gaganjain.is-a.dev -> CNAME cname.vercel-dns.com
- www.gaganjain.is-a.dev -> CNAME cname.vercel-dns.com