### PR TITLE
Add wqqr.is-a.dev (WeChat group QR landing)

### DIFF
--- a/domains/wqqr.json
+++ b/domains/wqqr.json
@@ -1,0 +1,1 @@
+{  "owner": {    "username": "aoligei1020-rgb",    "email": "311124360+aoligei1020-rgb@users.noreply.github.com"  },  "records": {    "CNAME": "wechat-qr-code.pages.dev"  }}


### PR DESCRIPTION
Adding wqqr.is-a.dev subdomain pointing CNAME to wechat-qr-code.pages.dev (Cloudflare Pages). This serves a WeChat group invitation landing page.