### PR TITLE
Domain: il-gobbo-di-loreto.is-a.dev

### DIFF
--- a/domains/il-gobbo-di-loreto.json
+++ b/domains/il-gobbo-di-loreto.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "coriz68",
+    "email": "rizzo.corrado@gmail.com"
+  },
+  "record": {
+    "CNAME": "coriz68.github.io"
+  },
+  "description": "Il Gobbo di Loreto - sito satirico a pubblicazione periodica (Hugo su GitHub Pages)"
+}

--- a/domains/il-gobbo-di-loreto.json
+++ b/domains/il-gobbo-di-loreto.json
@@ -3,7 +3,7 @@
     "username": "coriz68",
     "email": "rizzo.corrado@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "coriz68.github.io"
   },
   "description": "Il Gobbo di Loreto - sito satirico a pubblicazione periodica (Hugo su GitHub Pages)"


### PR DESCRIPTION
**Title:** il-gobbo-di-loreto.is-a.dev
**Description:** Il Gobbo di Loreto — sito satirico a pubblicazione periodica, Hugo su GitHub Pages (repo: Coriz68/Il-Gobbo-di-Loreto).
**Domain:** il-gobbo-di-loreto.is-a.dev
**Record type:** CNAME → coriz68.github.io