### PR TITLE
Add Resend email DNS records for minurjoy.is-a.dev

### DIFF
--- a/domains/resend._domainkey.minurjoy.json
+++ b/domains/resend._domainkey.minurjoy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "MJ0121",
+    "email": "minurrahmanjoy1@gmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCi14rZ2pHZcXaqPwsi6V1jVveF9S2m7PS4fKSwIdPDgi7cQnpfLNazT+2rGxHXdovuZLu+hOfJkWQ8vbY3eAW5ocDjfNWR2avYbbo/pfhbVf0UzsN8tq9EpHFEKAgsA5GQI5/XohaQpF5y5Sl94NHyYC/SMkDp2mEfTt9wstYYDQIDAQAB"
+  }
+}

--- a/domains/send.minurjoy.json
+++ b/domains/send.minurjoy.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "MJ0121",
+    "email": "minurrahmanjoy1@gmail.com"
+  },
+  "records": {
+    "MX": [
+      { "target": "feedback-smtp.us-east-1.amazonses.com", "priority": 10 }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://portfolio-ljv8ssy7p-minurrahmanjoy1-5890s-projects.vercel.app

# Website Purpose

This PR adds the DNS records required to verify the `minurjoy.is-a.dev` email domain with Resend (DKIM TXT under `resend._domainkey.minurjoy.is-a.dev`, plus SPF TXT and MX under `send.minurjoy.is-a.dev`). The root domain already exists and hosts my software developer portfolio. With these records, the portfolio's contact form will be able to send emails from a branded sender (`hello@minurjoy.is-a.dev`) instead of the Resend onboarding fallback address.
