### PR TITLE
Add sucre-radio-95-9.is-a.dev

### DIFF
--- a/domains/sucre-radio-95-9.json
+++ b/domains/sucre-radio-95-9.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "RickMagic",
+    "email": "richard.suarezrsj06@gmail.com"
+  },
+  "records": {
+    "CNAME": "RickMagic.github.io"
+  }
+}

--- a/domains/sucre-radio-95-9.json
+++ b/domains/sucre-radio-95-9.json
@@ -4,6 +4,6 @@
     "email": "richard.suarezrsj06@gmail.com"
   },
   "records": {
-    "CNAME": "RickMagic.github.io"
+    "CNAME": "rickmagic.github.io"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://rickmagic.github.io/

# Website Purpose
Página web oficial de la emisora comunitaria Sucre Radio 95.9 FM (Cumaná, Venezuela). Permite escuchar la radio en línea, consultar la programación semanal y las noticias, y da acceso al panel interno de avances informativos.