### PR TITLE
feat: add brac.is-a.dev for the BRAC Bangla information website

### DIFF
--- a/domains/brac.json
+++ b/domains/brac.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "international-cell"
+  },
+  "records": {
+    "CNAME": "brac-bangla-info.pages.dev"
+  }
+}


### PR DESCRIPTION
I would like to register rac.is-a.dev to point to the BRAC Bangla information website hosted on Cloudflare Pages.

- [x] My website is not a blogging site / no explicit porn / no monetized content
- [x] I am not abusing the free service
- [x] I have read the terms of service and agree
- [x] The domain is for the BRAC Bangla information project on Cloudflare Pages (CNAME: brac-bangla-info.pages.dev)