### PR TITLE
Add troynin.is-a.dev

### DIFF
--- a/domains/troynin.json
+++ b/domains/troynin.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "kernel-picnic",
+        "twitter": "anton_troynin"
+    },
+    "records": {
+        "CNAME": "kernel-picnic.github.io"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://kernel-picnic.github.io/troynin.dev/

# Website Purpose

It's my personal portfolio as a frontend developer: a short intro and a list of the projects I've worked on. Source: https://github.com/kernel-picnic/troynin.dev

It used to live on troynin.dev, but I decided not to renew that domain, so I moved the site to GitHub Pages and would like to point `troynin.is-a.dev` at it.
