### PR TITLE
Register mc.cascade.is-a.dev (Minecraft Java)

### DIFF
--- a/domains/mc.cascade.json
+++ b/domains/mc.cascade.json
@@ -1,0 +1,11 @@
+{
+  "description": "Minecraft Java join hostname for Cascade (playit tunnel, single server on 25565)",
+  "owner": {
+    "username": "MariusSurGithub",
+    "email": "trolle.marius@gmail.com"
+  },
+  "records": {
+    "CNAME": "jacobs-tissue.tun.ply.gg"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your file is in the domains directory, the name is valid, it is JSON format, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [x] My website is **software development** related. <!-- We do not accept websites such as gaming, courses, AI agents/chatbots, etc. NOTE: Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. (e.g. a business) -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. Twitter or Discord) for contact. -->
- [x] I have provided a link to my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link of your website below. We do NOT accept screenshots, with the exception we ask you for one. -->
<!-- This should be a link to the existing domain your website is on, NOT the is-a.dev domain you're applying for. (e.g. abc.vercel.app, abc.github.io) -->
<!-- SCREENSHOTS ARE NOT PERMITTED AS PREVIEWS. -->

https://cascade.is-a.dev

# Website Purpose
<!-- Please tell us the purpose or motive behind your website. For example, it is a portfolio website, etc. -->

Nested subdomain `mc.cascade.is-a.dev` for joining a self-hosted Minecraft Java server managed by the Cascade Vision control panel (`cascade.is-a.dev`, already registered under the same owner). Root stays the panel (AAAA only); this nested host is a CNAME to the playit.gg tunnel (`jacobs-tissue.tun.ply.gg`, port 25565). Parent `domains/cascade.json` is already on main.
