### PR TITLE
Update TXT record for domain verification

### DIFF
--- a/domains/_vercel.amitdange.json
+++ b/domains/_vercel.amitdange.json
@@ -4,6 +4,6 @@
     "email": "amit.dange2003@gmail.com"
   },
   "records": {
-    "TXT": "vc-domain-verify=amitdange.is-a.dev,48e7ce3a21b0560eb894"
+    "TXT": "vc-domain-verify=amitdange.is-a.dev,b1d9e3a24c49a8b1df89"
   }
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://amitdange.vercel.app

# Website Purpose
Personal portfolio of my work as a Software & AI Engineer — projects,
experience, skills and contact, presented as an interactive 3D city walk
I built with React and Three.js. Non-commercial.

**Note:** this is not a new registration. `amitdange.is-a.dev` was merged
earlier and the A record is working correctly. This PR only updates the
verification token in `_vercel.amitdange.json`: Vercel regenerated it when
I removed a stray `www` entry from my project, so the previously merged
TXT value is now stale and Vercel can't verify ownership. One file, one
line changed — the A record in `amitdange.json` is untouched.