### PR TITLE
Register abdulloh.is-a.dev

### DIFF
--- a/domains/_railway-verify.abdulloh.json
+++ b/domains/_railway-verify.abdulloh.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "aabdukarimov997-ui",
+    "email": "aabdukarimov997@gmail.com"
+  },
+  "records": {
+    "TXT": "railway-verify=68c0239ff2ea3e9cd5c277f9b204eb93a2c413620e8cd6845b49051fa59f4bd7"
+  }
+}

--- a/domains/abdulloh.json
+++ b/domains/abdulloh.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "aabdukarimov997-ui",
+    "email": "aabdukarimov997@gmail.com"
+  },
+  "records": {
+    "CNAME": "e708cnig.up.railway.app"
+  }
+}


### PR DESCRIPTION
## Domain Registration

Registering **abdulloh.is-a.dev** for the AAA — Premium Crypto Trading Academy website, hosted on Railway.

### Files
- `domains/abdulloh.json` — CNAME → `e708cnig.up.railway.app` (Railway custom domain target)
- `domains/_railway-verify.abdulloh.json` — TXT record required by Railway for domain ownership verification

### Website preview
https://aaa-abdulloh-8ecf.up.railway.app

The site is a live production website (crypto trading education and market analysis). I've already added the custom domain in the Railway dashboard and it's waiting for the DNS records from this PR to verify.