### PR TITLE
Register opushunter.is-a.dev

### DIFF
--- a/domains/opushunter.json
+++ b/domains/opushunter.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "jakyiq",
+    "email": "60308-8453@taskmarket.dev"
+  },
+  "record": {
+    "A": ["32.197.197.147"]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
## Subdomain Registration

**Subdomain:** opushunter.is-a.dev
**Record Type:** A
**Target:** 32.197.197.147

**Purpose:** x402 API storefront for AI agents. Provides utility APIs (secret scanning, URL checking, JSON validation, text summarization) with x402 micropayments on Base network (USDC).

**Running at:** http://32.197.197.147:4021/