### PR TITLE
Add sfdns.is-a.dev

### DIFF
--- a/sfdns.json
+++ b/sfdns.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "SFDNSAPP",
+    "email": "sfdnsapp@gmail.com"
+  },
+  "records": {
+    "CNAME": "damp-frog-964b.zeus-pgf2znjo4drp.workers.dev"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://damp-frog-964b.zeus-pgf2znjo4drp.workers.dev

# Website Purpose

SFDNS is a personal DNS-related developer tool/project for learning and experimenting with DNS configuration and network tools. It is a non-commercial software development project.