### PR TITLE
Enable Cloudflare proxy on cascade.is-a.dev (IPv4)

### DIFF
--- a/domains/cascade.json
+++ b/domains/cascade.json
@@ -9,5 +9,5 @@
       "2a12:bec4:1651:104::f8e"
     ]
   },
-  "proxied": false
+  "proxied": true
 }


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://cascade.is-a.dev

# Website Purpose

Enable Cloudflare proxy (`proxied: true`) on the existing `cascade.is-a.dev` registration.

The origin VPS is IPv6-only (AAAA). Without the proxy, IPv4-only networks get `DNS_PROBE_FINISHED_NXDOMAIN`. Orange-cloud proxy lets Cloudflare serve A/AAAA anycast to clients while connecting to the IPv6 origin.
