### PR TITLE
Register opushunter.is-a.dev

### DIFF
--- a/domains/opushunter.json
+++ b/domains/opushunter.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "jakyiq",
+    "email": "60308-8453@taskmarket.dev"
+  },
+  "records": {
+    "A": ["32.197.197.147"]
+  },
+  "proxied": false
+}

--- a/domains/pramuditha.json
+++ b/domains/pramuditha.json
@@ -4,6 +4,6 @@
     "email": "pramudithanadun@gmail.com"
   },
   "records": {
-    "CNAME": "cname.vercel-dns.com"
+    "CNAME": "pramuditha-is-a-dev.onrender.com"
   }
 }


### PR DESCRIPTION
## Subdomain Application

- **Subdomain:** opushunter.is-a.dev
- **Record type:** A
- **Record value:** 32.197.197.147
- **Description:** x402 API storefront for autonomous AI agents
- **Screenshot/Preview:** http://32.197.197.147:4021/
- **Do you have a website?** Yes, running at the IP above
- **Proxied:** No