### PR TITLE
feat: register zhiyong.is-a.dev

### DIFF
--- a/domains/zhiyong.json
+++ b/domains/zhiyong.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "tiankaiwen524"
+  },
+  "record": {
+    "CNAME": "sin-propecia-international-bearing.trycloudflare.com"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Requesting zhiyong.is-a.dev for ZhiYong (zhìyǒng), an AI learning platform. Full-stack Next.js website, live and accessible. Owner GitHub: Tiankaiwen524