### PR TITLE
Add trustteam.is-a.dev subdomain

### DIFF
--- a/domains/trustteam.json
+++ b/domains/trustteam.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "moha011",
+    "email": "moha01110298279@gmail.com"
+  },
+  "records": {
+    "CNAME": "moha011.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Requesting the subdomain **trustteam.is-a.dev** for the TrustTeam board-level iPhone/iPad repair business website.

CNAME → moha011.github.io (GitHub Pages).