### PR TITLE
Add brainadvisor.is-a.dev

### DIFF
--- a/domains/brainadvisor.json
+++ b/domains/brainadvisor.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "1034jcd"
+  },
+  "records": {
+    "CNAME": "brainadvisor.cloudflare-family.workers.dev"
+  }
+}

--- a/domains/brainadvisor.json
+++ b/domains/brainadvisor.json
@@ -3,6 +3,6 @@
     "username": "1034jcd"
   },
   "records": {
-    "CNAME": "brainadvisor.cloudflare-family.workers.dev"
+    "CNAME": "1034jcd.github.io"
   }
 }


### PR DESCRIPTION
Registering a free subdomain for the BrainAdvisor AI app.

- Domain: brainadvisor.is-a.dev
- CNAME: brainadvisor.cloudflare-family.workers.dev
- Owner: 1034jcd