### PR TITLE
Add telegram-lite.json with owner and records

### DIFF
--- a/domains/telegram-lite.json
+++ b/domains/telegram-lite.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "hashemian1382",
+        "email": "aho.hashemian@gmail.com"
+    },
+    "records": {
+        "A": ["216.24.57.1"]
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://telegram-web-lite.onrender.com

Source code: https://github.com/hashemian1382/telegram-web-lite

# Website Purpose

Telegram Web Lite is a free and open-source, self-hostable Telegram web client I
built to learn and demonstrate a modern Python web stack: FastAPI, Telethon,
SQLAlchemy 2.0 and server-rendered Jinja2 templates, backed by PostgreSQL.

The landing page at the root URL documents the project publicly — the
architecture, the design decisions, the HTTP API surface, and instructions for
running your own instance from source. It is open to everyone with no login
required.

Some implementation details the project demonstrates:

- Telegram sessions are persisted as Telethon `StringSession` values in the
  database rather than `.session` files, so the app is completely stateless and
  survives restarts on an ephemeral filesystem.
- Passwords are hashed with Argon2id via `pwdlib`, with automatic re-hash on
  login, and sessions use signed HttpOnly cookies.
- The frontend has no build step and no runtime network dependencies — a single
  hand-written stylesheet, one vanilla JS file and an inline SVG sprite, so it
  works offline and behind a strict CSP.
- Telethon clients are pooled per user in-process with an idle-connection reaper.

This is a personal, non-commercial project. There is no advertising, no payment
of any kind, and no revenue model. It is not affiliated with or endorsed by
Telegram; users authenticate with their own Telegram API credentials obtained
from my.telegram.org/apps.