### PR TITLE
Add Vercel verification records for srishti.is-a.dev

### DIFF
--- a/domains/_vercel.www.srishti.json
+++ b/domains/_vercel.www.srishti.json
@@ -4,7 +4,6 @@
         "email": "srishti@growthz.ai"
     },
     "records": {
-        "A": ["216.198.79.1"],
-        "TXT": ["vc-domain-verify=srishti.is-a.dev,3369b335199d874e34a8"]
+        "TXT": ["vc-domain-verify=www.srishti.is-a.dev,b833e6f0811b28f851af"]
     }
 }

--- a/domains/www.srishti.json
+++ b/domains/www.srishti.json
@@ -4,7 +4,6 @@
         "email": "srishti@growthz.ai"
     },
     "records": {
-        "A": ["216.198.79.1"],
-        "TXT": ["vc-domain-verify=srishti.is-a.dev,3369b335199d874e34a8"]
+        "CNAME": "9568931d03fdc8c.vercel-dns-017.com"
     }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://srishti-dev.vercel.app/

# Website Purpose

Follow-up to #47211 (merged). Adding the Vercel-required A/TXT verification records for the root domain, plus the `www` subdomain (CNAME) with its own TXT verification, so `srishti.is-a.dev` and `www.srishti.is-a.dev` pass Vercel's domain verification and resolve correctly.
