### PR TITLE
Restore cascade.is-a.dev (IPv6 origin + Cloudflare proxy for IPv4)

### DIFF
--- a/domains/cascade.json
+++ b/domains/cascade.json
@@ -1,0 +1,13 @@
+{
+  "description": "Personal open-source Cascade Vision server panel (self-hosted Node/React control panel for Discord bots, sites, and game servers)",
+  "owner": {
+    "username": "MariusSurGithub",
+    "email": "trolle.marius@gmail.com"
+  },
+  "records": {
+    "AAAA": [
+      "2a12:bec4:1651:104::f8e"
+    ]
+  },
+  "proxied": true
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://cascade.tail652f33.ts.net/

(Live Tailscale Funnel mirror of the same self-hosted Cascade Vision panel. The is-a.dev hostname is currently unregistered after `domains/cascade.json` was deleted.)

# Website Purpose

**Restore** `cascade.is-a.dev` after `domains/cascade.json` was removed in https://github.com/is-a-dev/register/commit/54c5abdf8d319446fb665581a84f8964e4fccc1d (follow-up to closed PR https://github.com/is-a-dev/register/pull/47400).

Cascade Vision is my personal open-source self-hosted Node/React control panel (Discord bots, static sites, game servers).

DNS setup:
- `AAAA` → `2a12:bec4:1651:104::f8e` (IPv6-only VPS origin)
- `proxied: true` so Cloudflare publishes A/AAAA anycast for **IPv4 clients**

Without the orange-cloud proxy, IPv4-only networks fail with `DNS_PROBE_FINISHED_NXDOMAIN` because there is no A record — only AAAA. Proxying is documented as supported: https://docs.is-a.dev/domain-structure/

Happy to adjust if maintainers prefer a different allowed pattern; goal is simply to restore the name and keep the site reachable on IPv4 and IPv6.