### PR TITLE
Fix: split root TXT verification for srishti.is-a.dev

### DIFF
--- a/domains/_vercel.srishti.json
+++ b/domains/_vercel.srishti.json
@@ -4,6 +4,6 @@
         "email": "srishti@growthz.ai"
     },
     "records": {
-        "A": ["216.198.79.1"]
+        "TXT": ["vc-domain-verify=srishti.is-a.dev,3369b335199d874e34a8"]
     }
 }


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://srishti-dev.vercel.app/

# Website Purpose

Follow-up to #47537. The root domain's `_vercel` TXT verification record combined in `srishti.json` alongside the `A` record wasn't resolving via public DNS (confirmed via nslookup against 8.8.8.8 and 1.1.1.1), while the `www` subdomain's separately-filed TXT record resolved fine. Splitting the root TXT into its own `_vercel.srishti.json` file, matching the working pattern used elsewhere in the registry (e.g. `_vercel.gianpaolo.json`), to fix Vercel domain verification for `srishti.is-a.dev`.
