### PR TITLE
Add TXT record for Google site verification

### DIFF
--- a/domains/luciddev.json
+++ b/domains/luciddev.json
@@ -1,11 +1,10 @@
 {
-    "owner": {
-        "username": "lawrencenjeri4-lgtm",
-        "email": "lucidtechsolutions41@gmail.com"
-    },
-    "records": {
-        "A": [
-            "216.198.79.1"
-        ]
-    }
+  "owner": {
+    "username": "lawrencenjeri4-lgtm",
+    "email": "lucidtechsolutions41@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"],
+    "TXT": "google-site-verification=Vf7FB7EcmlsF_lNzfvrwPR058zVe6VsBJbTmOfUZhjk"
+  }
 }


### PR DESCRIPTION
Add the Google Search Console verification TXT record for luciddev.is-a.dev to verify domain ownership and enable Google Search Console indexing and search performance tracking.