### PR TITLE
Add Vercel verification TXT for tarekelda.is-a.dev

### DIFF
--- a/domains/_vercel.tarekelda.json
+++ b/domains/_vercel.tarekelda.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "pulsarCS",
+        "email": "talterx1@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=tarekelda.is-a.dev,31d2ed544be56011379f"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://tarekelda.vercel.app

# Website Purpose

This adds the Vercel domain verification TXT record for tarekelda.is-a.dev, which was registered in #47187, following the steps in your Vercel guide (docs.is-a.dev/guides/vercel). Vercel requires this record at _vercel.tarekelda.is-a.dev before it will serve the domain. The website itself is my personal software development portfolio, already live at the preview link above.
