### PR TITLE
Register cascade.is-a.dev (personal projects, proxied)

### DIFF
--- a/domains/cascade.json
+++ b/domains/cascade.json
@@ -1,0 +1,13 @@
+{
+    "owner": {
+        "username": "MariusSurGithub",
+        "email": "trolle.marius@gmail.com"
+    },
+    "description": "Personal self-hosted software projects (portfolio / homelab). Public page is non-commercial; panel login is on /login only.",
+    "records": {
+        "AAAA": [
+            "2a12:bec4:1651:104::f8e"
+        ]
+    },
+    "proxied": true
+}


### PR DESCRIPTION
## cascade.is-a.dev

Restoring my subdomain after it was removed.

### What is hosted
- **Root (`/`)**: personal, non-commercial page about self-hosted software projects (homelab / portfolio).
- **`/login`**: private management UI only (not a login wall on the root).
- Nested apps under path prefixes (e.g. `/sacfolio`).

### DNS
- `AAAA` → VPS IPv6 `2a12:bec4:1651:104::f8e`
- `proxied: true` so IPv4 clients can reach it via Cloudflare (origin is IPv6-only)

### Compliance
- Individual GitHub account owner
- Software-development related personal projects
- No commercial / for-profit landing on the root
- Root is **not** behind a login page
