### PR TITLE
Register francopedia.is-a.dev

### DIFF
--- a/domains/francopedia.json
+++ b/domains/francopedia.json
@@ -1,0 +1,11 @@
+{
+  "description": "FrancoPedia — the Vascular Intern Guide landing page",
+  "repo": "https://github.com/momomojo/francopedia",
+  "owner": {
+    "username": "momomojo",
+    "email": "mohibhafeez@gmail.com"
+  },
+  "records": {
+    "CNAME": "momomojo.github.io"
+  }
+}


### PR DESCRIPTION
Registers `francopedia.is-a.dev` for the FrancoPedia Vascular Intern Guide landing page, hosted on GitHub Pages at `momomojo.github.io`.