### PR TITLE
Add blog.nourin.is-a.dev

### DIFF
--- a/domains/blog.nourin.json
+++ b/domains/blog.nourin.json
@@ -1,0 +1,11 @@
+{
+  "description": "blog",
+  "repo": "https://github.com/nourinawadd/nourin-drive",
+  "owner": {
+    "username": "nourinawadd",
+    "email": "nourinawad@gmail.com"
+  },
+  "records": {
+    "A": ["89.168.117.165"]
+  }
+}


### PR DESCRIPTION
## Requirements
- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the owner key.
- [x] I have provided a link to my website below.

## Website Preview
https://nourinawadd.github.io/

## Website Purpose
My personal blog, and part of my portfolio project at nourin.is-a.dev. The posts are markdown files built into static HTML by a small site generator I wrote myself. Source is at https://github.com/nourinawadd/nourin-drive under `blog/`. The desktop site it
belongs to is already on nourin.is-a.dev, and I'd like the blog on the blog subdomain.

## Note on the previous PR (#47573)
That one was denied as inaccessible, and I've fixed the cause. The preview link I gave was `http://`, but modern browsers auto-upgrade to HTTPS, and my server's certificate only covers `nourin.is-a.dev` , so the reviewer would have hit a
`NET::ERR_CERT_COMMON_NAME_INVALID` interstitial rather than the site.

The preview above is the identical build served over GitHub Pages with a valid certificate, so it opens cleanly. The record in this PR still points at my own server; I'll issue a certificate for blog.nourin.is-a.dev there as soon as the DNS record exists.