### PR TITLE
Register nexusdigital.is-a.dev

### DIFF
--- a/domains/nexusdigital.json
+++ b/domains/nexusdigital.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "brayanmercadogg-hash",
+        "email": "NexusDigitalOff@gmail.com"
+    },
+    "description": "NexusDigital - Agencia Digital",
+    "records": {
+        "CNAME": "brayanmercadogg-hash.github.io"
+    }
+}


### PR DESCRIPTION
Register nexusdigital.is-a.dev for NexusDigital - Agencia Digital

- [x] I have read and understood the [terms of service](https://is-a.dev/terms-of-service).
- [x] I am not using a company name (e.g. Google, Apple, Microsoft, etc.) or a name that is already taken by another domain.
- [x] The domain I am registering is not for commercial use.
- [x] The domain I am registering is not for redirecting to another domain.

Domain: nexusdigital.is-a.dev
CNAME: brayanmercadogg-hash.github.io