### PR TITLE
feat(domain): add taimwe.is-a.dev

### DIFF
--- a/domains/taimwe.json
+++ b/domains/taimwe.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "taimweromita505-source",
+    "email": "taimweromita505@gmail.com"
+  },
+  "records": {
+    "CNAME": "taimweromita505-source.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Requesting a subdomain for my personal portfolio site, hosted on GitHub Pages.

- **Subdomain:** `taimwe.is-a.dev`
- **Target:** `taimweromita505-source.github.io` (CNAME)
- **Purpose:** personal developer portfolio
- **GitHub:** taimweromita505-source

Thank you!
