### PR TITLE
Add peewee.is-a.dev

### DIFF
--- a/domains/peewee.json
+++ b/domains/peewee.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "gabelossless",
+    "email": "gabelossless@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "proxied": false,
+  "repo": "https://github.com/gabelossless/peewee-coin"
+}


### PR DESCRIPTION
Adding `peewee.is-a.dev` — official website domain for the PEEWEE ($PEEWEE) Solana memecoin community site, currently hosted on Vercel.

Repo: https://github.com/gabelossless/peewee-coin