### PR TITLE
Update DNS records in khag.json

### DIFF
--- a/domains/khag.json
+++ b/domains/khag.json
@@ -4,8 +4,12 @@
     "email": "nguyendaikhang2000@gmail.com"
   },
   "records": {
-    "A": [
-      "160.191.244.75"
+    "NS": [
+      "ns1.byet.org",
+      "ns2.byet.org",
+      "ns3.byet.org",
+      "ns4.byet.org",
+      "ns5.byet.org"
     ]
   }
 }


### PR DESCRIPTION
Removed A record and added NS records for DNS configuration.

<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [X] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [X] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your file is in the domains directory, the name is valid, it is JSON format, etc. -->
- [X] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [X] My website is **software development** related. <!-- We do not accept websites such as gaming, courses, AI agents/chatbots, etc. NOTE: Only your root subdomain needs to meet this requirement. -->
- [X] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. (e.g. a business) -->
- [X] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. Twitter or Discord) for contact. -->
- [X] I have provided a link to my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
https://profile-blue-three-97.vercel.app

# Website Purpose
This website is my personal software development portfolio. It showcases my web development projects, programming work, technical skills, and related development activities. The website is non-commercial and is intended for personal and developer portfolio purposes.

## Reason for NS Records
I am requesting NS records because my website is hosted on ByetHost, which provides its DNS configuration through the following nameservers:

- ns1.byet.org

- ns2.byet.org

- ns3.byet.org

- ns4.byet.org

- ns5.byet.org

Using NS delegation allows the `is-a.bot` subdomain to use the DNS configuration provided by my hosting provider. This is required for the hosting setup I am using and allows ByetHost to manage the DNS records for the domain.
I am not requesting NS records for commercial purposes. The domain will be used for my personal Discord bot/dashboard project.
