### PR TITLE
add boris.is-a.dev

### DIFF
--- a/domains/boris.json
+++ b/domains/boris.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "borismilner",
+    "email": "boris.milner@gmail.com"
+  },
+  "records": {
+    "CNAME": "borismilner.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://borismilner.github.io/
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
It is my personal site, and it indexes the open-source developer tools I write and
maintain, among them grabbit, AgentBox and snapper, with a short description of what
each one is for.

A portfolio rather than a product: nothing on it is for sale, there is no signup and
no payment path anywhere on the site. I would like a memorable address for it that is
easier to say out loud than the github.io one.
<!-- WEBSITE_PURPOSE_END -->
