### PR TITLE
feat: register openrouter-rankings.is-a.dev subdomain

### DIFF
--- a/domains/openrouter-rankings.json
+++ b/domains/openrouter-rankings.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "Chonkiboiwa"
+    "username": "Chonkiboiwa",
+    "email": "tbagger2002@gmail.com"
   },
   "records": {
     "CNAME": "chonkiboiwa.github.io"

--- a/domains/openrouter-rankings.json
+++ b/domains/openrouter-rankings.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Chonkiboiwa"
+  },
+  "records": {
+    "CNAME": "chonkiboiwa.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements
 
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.
 
# Website Preview
 
https://chonkiboiwa.github.io/openrouter-providers/
 
# Website Purpose
 
OpenRouter Rankings — a fully static website that displays every OpenRouter model with all providers, pricing, uptime, and composite rankings (value, AI benchmarks, arena scores). It helps developers compare model providers and find the best pricing. Open source, no ads, no commercial use.