### PR TITLE
Register ns.is-a.dev

### DIFF
--- a/domains/ns.json
+++ b/domains/ns.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "itsmeadarsh2008"
+  },
+  "records": {
+    "CNAME": "itsmeadarsh2008.github.io"
+  }
+}


### PR DESCRIPTION
Registering **ns.is-a.dev** for the NetSpeed project — a free, open-source browser-based internet speed test (React + Vite) hosted on GitHub Pages at https://itsmeadarsh2008.github.io/netspeed.

Source: https://github.com/itsmeadarsh2008/netspeed