### PR TITLE
Add peligosongs.is-a.dev

### DIFF
--- a/domains/peligosongs.json
+++ b/domains/peligosongs.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "sinatra182",
+    "email": "sunsekdong@gmail.com"
+  },
+  "record": {
+    "CNAME": "398e886d-590c-4f1f-ad3f-3bc5e21760bf.cfargotunnel.com"
+  }
+}


### PR DESCRIPTION
Requesting peligosongs.is-a.dev — CNAME to Cloudflare tunnel for self-hosted services.