### PR TITLE
Register neobrowser.is-a.dev

### DIFF
--- a/domains/neobrowser.json
+++ b/domains/neobrowser.json
@@ -1,0 +1,11 @@
+{
+  "description": "NeoBrowser — an MCP server that drives real Chrome with real logged-in sessions",
+  "repo": "https://github.com/pitiflautico/neobrowser",
+  "owner": {
+    "username": "pitiflautico",
+    "email": "pitiflautico3@gmail.com"
+  },
+  "records": {
+    "CNAME": "pitiflautico.github.io"
+  }
+}


### PR DESCRIPTION
Registering neobrowser.is-a.dev for the NeoBrowser open-source project. CNAME points to the project's GitHub Pages site.