### PR TITLE
feat: add shiftcal.is-a.dev

### DIFF
--- a/domains/shiftcal.json
+++ b/domains/shiftcal.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "bju10147-bb"
+  },
+  "records": {
+    "CNAME": "bju10147-bb.github.io",
+    "TXT": "google-site-verification=V3OIC4WsPxQZf5T98ENo2DE9XvwIaZfHR9JFzVxrYCc"
+  }
+}


### PR DESCRIPTION
Registering `shiftcal.is-a.dev` for an Android shift-schedule calendar app.

- `CNAME` → GitHub Pages site hosting the app homepage and privacy policy
- `TXT` → Google Search Console domain verification (required for Google OAuth brand verification)