### PR TITLE
Register ujjwalpratap.is-a.dev

### DIFF
--- a/domains/ujjwalpratap.json
+++ b/domains/ujjwalpratap.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ujjwal9034",
+    "email": "ujjwalchauhan671@gmail.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
### Domain Registration

**Subdomain:** ujjwalpratap.is-a.dev
**Record Type:** CNAME
**Target:** cname.vercel-dns.com

**Description:** Personal developer portfolio website built with React, Vite, and Framer Motion. Hosted on Vercel.

**Repository:** https://github.com/ujjwal9034/ujjwal-portfolio
**Live Preview:** https://ujjwal-portfolio-teal.vercel.app