### PR TITLE
Register priyal.is-a.dev

### DIFF
--- a/domains/priyal.json
+++ b/domains/priyal.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "edrischhawniwala",
+    "email": "echhawniwala@gmail.com"
+  },
+  "records": {
+    "CNAME": "happy-birthday-priyal.echhawniwala.workers.dev"
+  }
+}


### PR DESCRIPTION
Registering `priyal.is-a.dev` for a personal birthday gift microsite — a static page with a countdown, photos and a message for a friend's birthday.

**Record:** CNAME → `happy-birthday-priyal.echhawniwala.workers.dev` (Cloudflare Workers, already live and serving)

Personal, non-commercial, no ads and no tracking.