### PR TITLE
Register priyal.is-a.dev

### DIFF
--- a/domains/priyal.json
+++ b/domains/priyal.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "edrischhawniwala",
+    "email": "echhawniwala@gmail.com"
+  },
+  "records": {
+    "CNAME": "priyal.pages.dev"
+  }
+}


### PR DESCRIPTION
Registering `priyal.is-a.dev` for a personal birthday microsite — a static page with a countdown, photos and a message for a friend's birthday.

**Record:** CNAME → `priyal.pages.dev` (Cloudflare Pages, live and serving)

Personal and non-commercial. No ads, no tracking, no analytics.

_(Reopened: my earlier PR #48426 pointed at a `.workers.dev` target, which is disallowed. Now on Cloudflare Pages.)_