### PR TITLE
Add Vercel verification for sani.is-a.dev

### DIFF
--- a/domains/_vercel.sani.json
+++ b/domains/_vercel.sani.json
@@ -1,0 +1,13 @@
+{
+  "name": "_vercel.sani",
+  "description": "Vercel TXT ownership verification",
+  "owner": {
+    "username": "umersanii",
+    "email": "iamumersani@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=sani.is-a.dev,45c505d7b88defcefefc"
+    ]
+  }
+}

--- a/domains/_vercel.sani.json
+++ b/domains/_vercel.sani.json
@@ -1,6 +1,4 @@
 {
-  "name": "_vercel.sani",
-  "description": "Vercel TXT ownership verification",
   "owner": {
     "username": "umersanii",
     "email": "iamumersani@gmail.com"

--- a/domains/_vercel.www.sani.json
+++ b/domains/_vercel.www.sani.json
@@ -1,0 +1,13 @@
+{
+  "name": "_vercel.www.sani",
+  "description": "Vercel TXT ownership verification",
+  "owner": {
+    "username": "umersanii",
+    "email": "iamumersani@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "vc-domain-verify=www.sani.is-a.dev,f47279c09de88964db5c"
+    ]
+  }
+}

--- a/domains/_vercel.www.sani.json
+++ b/domains/_vercel.www.sani.json
@@ -1,6 +1,4 @@
 {
-  "name": "_vercel.www.sani",
-  "description": "Vercel TXT ownership verification",
   "owner": {
     "username": "umersanii",
     "email": "iamumersani@gmail.com"

--- a/domains/www.sani.json
+++ b/domains/www.sani.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "umersanii",
+    "email": "iamumersani@gmail.com"
+  },
+  "records": {
+    "CNAME": "fb90ef103753e6c1.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://www.umersanii.tech
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
Follow-up to my already-approved sani.is-a.dev (#48545). Adding the `_vercel.sani` and `_vercel.www.sani` TXT records Vercel requires for domain ownership verification, plus a `www.sani` CNAME so www.sani.is-a.dev resolves alongside the root domain.
<!-- WEBSITE_PURPOSE_END -->
