### PR TITLE
Add dsl.is-a.dev

### DIFF
--- a/domains/dsl.json
+++ b/domains/dsl.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "prayasabhinav",
+        "email": "me@prayasabhinav.net"
+    },
+    "records": {
+        "CNAME": "dsl-status.aiclub.anu.edu.in"
+    }
+}


### PR DESCRIPTION
**Subdomain:** `dsl.is-a.dev`
**Record:** CNAME → `dsl-status.aiclub.anu.edu.in`

A course tool for sixty-three interaction-design students at Anant National University. Each writes one line a day against the day's question and reads what the others wrote. Self-hosted on our own server behind our own reverse proxy — not Vercel or Netlify, so no TXT verification is needed.

The short name is so students can type it from memory.