### PR TITLE
Add jouspace.is-a.dev

### DIFF
--- a/domains/jouspace.json
+++ b/domains/jouspace.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "datascyther",
+    "email": "contact.jouspace@gmail.com"
+  },
+  "records": {
+    "CNAME": "jouspace.pages.dev"
+  }
+}


### PR DESCRIPTION
Requesting `jouspace.is-a.dev` with a CNAME record pointing to `jouspace.pages.dev` (Cloudflare Pages).

```json
{
  "owner": {
    "username": "datascyther",
    "email": "contact.jouspace@gmail.com"
  },
  "records": {
    "CNAME": "jouspace.pages.dev"
  }
}
```