### PR TITLE
Add jouspace.is-a.dev

### DIFF
--- a/domains/jouspace.json
+++ b/domains/jouspace.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "datascyther",
+    "email": "contact.jouspace@gmail.com"
+  },
+  "records": {
+    "CNAME": "jouspace.pages.dev"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://jouspace.pages.dev
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
Jouspace is a local-first, account-free AI journaling web app (React + TypeScript + Vite, wrapped for Android). It is a personal software project / portfolio piece, not a commercial product. The site lets users write journal entries and get private, on-device-style AI reflections. This subdomain request is to get a clean, shareable URL for the project (e.g. on LinkedIn).
<!-- WEBSITE_PURPOSE_END -->

Domain record:
```json
{
  "owner": {
    "username": "datascyther",
    "email": "contact.jouspace@gmail.com"
  },
  "records": {
    "CNAME": "jouspace.pages.dev"
  }
}
```