### PR TITLE
feat: add blog.yangzhuoqun.is-a.dev and oj.yangzhuoqun.is-a.dev

### DIFF
--- a/domains/blog.yangzhuoqun.json
+++ b/domains/blog.yangzhuoqun.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "yangzhuoqun-666",
+    "email": "yangzhuoqun_youxi@outlook.com"
+  },
+  "records": {
+    "A": [
+      "154.9.227.36"
+    ]
+  }
+}

--- a/domains/oj.yangzhuoqun.json
+++ b/domains/oj.yangzhuoqun.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "yangzhuoqun-666",
+    "email": "yangzhuoqun_youxi@outlook.com"
+  },
+  "records": {
+    "A": [
+      "154.9.227.36"
+    ]
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS ENTIRE TEMPLATE FOR YOUR PR TO BE APPROVED!

DO NOT MODIFY OR REMOVE THIS TEMPLATE (INCLUDING REMOVING COMMENTS) OR YOUR PR WILL FAIL VALIDATION!
-->

# Requirements

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
http://blog.154.9.227.36.sslip.io/
http://154.9.227.36:8888/
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
blog.yangzhuoqun.is-a.dev: 个人技术博客（Hugo 静态站点）。
oj.yangzhuoqun.is-a.dev: 个人在线判题系统（HydroOJ），用于算法竞赛练习，均属于软件开发相关个人项目，无商业用途。
<!-- WEBSITE_PURPOSE_END -->