### PR TITLE
Register vynnra.is-a.dev

### DIFF
--- a/domains/vynnra.json
+++ b/domains/vynnra.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "vodcarebeccca",
+    "email": "amelia71832@gmail.com"
+  },
+  "records": {
+    "CNAME": "new-api-production-f497.up.railway.app"
+  }
+}


### PR DESCRIPTION
## New Domain Registration

**Domain:** `vynnra.is-a.dev`
**Record Type:** CNAME
**Target:** `new-api-production-f497.up.railway.app`

### Checklist
- [x] Domain is available (404 on /domains/vynnra.json)
- [x] Valid JSON schema (owner + records)
- [x] CNAME points to a live Railway service with HTTPS support
- [x] Read and agreed to the [Terms of Service](https://terms.is-a.dev)

### Purpose
Custom domain for Vynnra AI API gateway hosted on Railway.

---
[![Add to Cloudflare](https://api.workers.is-a.dev/add-to-cloudflare.svg)](https://workers.tools/is-a-dev)
