### PR TITLE
Register xiaoyugeoai.is-a.dev

### DIFF
--- a/domains/xiaoyugeoai.json
+++ b/domains/xiaoyugeoai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "wei123-w",
+    "email": "2563119813@QQ.COM"
+  },
+  "records": {
+    "CNAME": "xiao-yu-geo-ai-web.vercel.app"
+  }
+}


### PR DESCRIPTION
## Domain Name

xiaoyugeoai.is-a.dev

## Website

https://xiao-yu-geo-ai-web.vercel.app/

## Description

Official website for XiaoYu GeoAI, an AI-powered remote sensing image interpretation and GIS processing platform.

## Requirements

* [x] I have checked that the domain is available.
* [x] I own the website linked above.
* [x] The JSON file has been added to the `domains` folder.
* [x] I understand that this request is for a subdomain of is-a.dev.