### PR TITLE
Update aaa.is-a.dev: CNAME → A 89.108.70.71

### DIFF
--- a/domains/aaa.json
+++ b/domains/aaa.json
@@ -1,9 +1,11 @@
 {
-  "owner": {
-    "username": "profpomeha-create",
-    "email": "aandreichenko@mail.ru"
-  },
-  "records": {
-    "CNAME": "profpomeha-create.github.io"
-  }
+    "owner": {
+        "username": "profpomeha-create",
+        "email": "aandreichenko@mail.ru"
+    },
+    "records": {
+        "A": [
+            "89.108.70.71"
+        ]
+    }
 }


### PR DESCRIPTION
Moving https://aaa.is-a.dev from GitHub Pages to a VPS.

- Owner: profpomeha-create
- Record: A 89.108.70.71
- Site is already served by nginx on that host for Host: aaa.is-a.dev
