### PR TITLE
Register claris.is-a.dev

### DIFF
--- a/domains/claris.json
+++ b/domains/claris.json
@@ -1,0 +1,11 @@
+{
+  "description": "CLARIS clinical investigation research prototype",
+  "repo": "https://github.com/ayushcodes13/claris",
+  "owner": {
+    "username": "ayushcodes13",
+    "email": "150503820+ayushcodes13@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
## Domain
claris.is-a.dev

## Target
Vercel deployment for the CLARIS clinical investigation research prototype.

## Repository
https://github.com/ayushcodes13/claris

## DNS
CNAME to cname.vercel-dns.com