### PR TITLE
Register ddara.is-a.dev

### DIFF
--- a/domains/ddara.json
+++ b/domains/ddara.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "leeeunlove02"
+  },
+  "records": {
+    "CNAME": "leeeunlove02.github.io"
+  }
+}


### PR DESCRIPTION
Registering `ddara.is-a.dev` (CNAME -> leeeunlove02.github.io) for a children's drawing/coloring web app (GitHub Pages). Records: CNAME only. Thanks!