### PR TITLE
feat: add chat.yangzhuoqun.is-a.dev

### DIFF
--- a/domains/chat.yangzhuoqun.json
+++ b/domains/chat.yangzhuoqun.json
@@ -1,0 +1,12 @@
+{
+  "description": "Matrix chat server for yangzhuoqun",
+  "owner": {
+    "username": "yangzhuoqun-666",
+    "email": "yangzhuoqun_youxi@outlook.com"
+  },
+  "records": {
+    "A": [
+      "154.9.227.36"
+    ]
+  }
+}


### PR DESCRIPTION
### Your required domain
chat.yangzhuoqun.is-a.dev

### Record
A | 154.9.227.36

### Proof of ownership
I own yangzhuoqun.is-a.dev and its subdomains, this is for my Matrix homeserver.

- [x] I have read and understood the [Terms of Service](https://is-a.dev/terms)
- [x] I understand my policy will be [disclosed](https://is-a.dev/.well-known/security.txt)
- [x] I understand that my record(s) will be public

### WEBSITE_PREVIEW_START
No website preview available (Matrix server).
### WEBSITE_PREVIEW_END

### WEBSITE_PURPOSE_START
Self-hosted Matrix chat server.
### WEBSITE_PURPOSE_END
