### PR TITLE
Register a1one.is-a.dev

### DIFF
--- a/domains/a1one.json
+++ b/domains/a1one.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "xA10N3x",
+        "email": "knvsq6dxx9@privaterelay.appleid.com"
+    },
+    "record": {
+        "CNAME": "dash.a1one.net"
+    }
+}


### PR DESCRIPTION
Registers the subdomain **a1one.is-a.dev** for the CallRail transcription system dashboard.

- CNAME → dash.a1one.net (Cloudflare-hosted management dashboard)
- Owner: @xA10N3x