### PR TITLE
Add Vercel TXT verification for eduardoyuki.is-a.dev

### DIFF
--- a/domains/_vercel.eduardoyuki.json
+++ b/domains/_vercel.eduardoyuki.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "eduardoyuki",
+    "email": "yukieduardopro@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=eduardoyuki.is-a.dev,4cc2fb722e3582596dd8"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the owner key.
- [x] I have provided a link to my website below.

# Website Preview
https://portfolio-eduardo-yuki.vercel.app

# Website Purpose
This adds the required _vercel TXT verification record so Vercel can confirm ownership of eduardoyuki.is-a.dev (registered in PR #47875, already merged). This is a follow-up record required by Vercel's domain verification, not a new domain.