### PR TITLE
Register basis.is-a.dev

### DIFF
--- a/domains/_vercel.basis.json
+++ b/domains/_vercel.basis.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "aitoflo",
+    "email": "gurleen@aitoflo.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=basis.is-a.dev,a42c745ee477061bb21d"
+  }
+}

--- a/domains/basis.json
+++ b/domains/basis.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "aitoflo",
+    "email": "gurleen@aitoflo.com"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering **basis.is-a.dev** for Basis, a cross-venue market research system (currently at https://basis-site.vercel.app).

The subdomain points at Vercel via CNAME (cname.vercel-dns.com, proxied: false). Site is live and content-complete.