### PR TITLE
Add apexascent.is-a.dev for jaykayy (Apex Ascent portfolio)

### DIFF
--- a/domains/apexascent.json
+++ b/domains/apexascent.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "jaykayhq",
+    "email": "joeukpai55@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "subdomain": "apexascent"
+}


### PR DESCRIPTION
Portfolio for **jaykayy** — Web & Mobile (Flutter) + AI & Automation + Computer Eng. 

- **Subdomain:** apexascent
- **Owner:** jaykayhq (joeukpai55@gmail.com)
- **Hosting:** Vercel (Next.js 15.5.9, studio repo jaykayhq/studio)
- **Record:** CNAME cname.vercel-dns.com
- **Case study:** /case-studies/emerge (Flutter Emerge app v1.0.9+14, published as jaykayy on Play Store)
- **Brand:** Apex Ascent, Port-Harcourt, NG

Verified available via API 404 before creation. Studio build passes (11 routes). Emerge user landing separate at web-landing (polished, links to apexascent.is-a.dev/case-studies/emerge).

Closes is-a-dev requirement: owner email matches GitHub, CNAME valid.