### PR TITLE
Add jaykayy.is-a.dev for jaykayy portfolio

### DIFF
--- a/domains/jaykayy.json
+++ b/domains/jaykayy.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "jaykayhq",
+    "email": "joeukpai55@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "subdomain": "jaykayy"
+}


### PR DESCRIPTION
Portfolio for **jaykayy** — Web & Mobile (Flutter) + AI & Automation + Computer Eng.

- **Subdomain:** jaykayy (replaces apexascent per owner request https://github.com/is-a-dev/register/pull/49031)
- **Owner:** jaykayhq (joeukpai55@gmail.com)
- **Hosting:** Vercel (Next.js 15.5.9, studio repo jaykayhq/studio commit 2447c79)
- **Record:** CNAME cname.vercel-dns.com
- **Case study:** /case-studies/emerge (Flutter Emerge app v1.0.9+14, published as jaykayy on Play Store)
- **Brand:** jaykayy, Port-Harcourt, NG

This replaces apexascent branding — site now shows jaykayy everywhere (jaykayy.is-a.dev). Previous PR #49031 for apexascent can be closed or kept as alias.