### PR TITLE
[Register]: etudiantsdroitmaroc.is-a.dev

### DIFF
--- a/domains/etudiantsdroitmaroc.json
+++ b/domains/etudiantsdroitmaroc.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Amiri41",
+    "email": "194530031+Amiri41@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "amiri41.github.io"
+  }
+}

--- a/etudiantsdroitmaroc.json
+++ b/etudiantsdroitmaroc.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Amiri41",
+    "email": "194530031+Amiri41@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "amiri41.github.io"
+  }
+}


### PR DESCRIPTION
### Domain
etudiantsdroitmaroc.is-a.dev

### Purpose
صفحة هبوط ترويجية لتطبيق تعليمي لطلبة كليات الحقوق بالمغرب (Étudiants en Droit Maroc)، مستضافة عبر GitHub Pages.

### Records
CNAME -> amiri41.github.io