### PR TITLE
Register powerland-mirror.is-a.dev

### DIFF
--- a/domains/powerland-mirror.json
+++ b/domains/powerland-mirror.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Camil96",
+    "email": "camil96@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "camil96.github.io"
+  }
+}


### PR DESCRIPTION
### Domain Request
- **Subdomain requested:** `powerland-mirror.is-a.dev`
- **Type:** CNAME → `camil96.github.io` (GitHub Pages)
- **Purpose:** Personal static mirror/demo project of a Belgian energy company website (Powerland), hosted on my own GitHub Pages. Used as a web-development demo/portfolio piece.
- **No trademark use as identity**: the site is an existing public website mirrored for demo purposes; happy to adjust the name if maintainers prefer.