### PR TITLE
Register ncu-dxyyt.is-a.dev

### DIFF
--- a/domains/ncu-dxyyt.json
+++ b/domains/ncu-dxyyt.json
@@ -1,0 +1,9 @@
+{
+    "records":  {
+                    "CNAME":  "3338323533.github.io"
+                },
+    "owner":  {
+                  "email":  "3338323533@users.noreply.github.com",
+                  "username":  "3338323533"
+              }
+}


### PR DESCRIPTION
## Register 
cu-dxyyt.is-a.dev`n
### Details
- **Subdomain**: ncu-dxyyt
- **Purpose**: 南昌大学前湖校区电信营业厅开学办事指南 (NCU Qianhu Campus Telecom Service Guide)
- **Repository**: https://github.com/3338323533/ncu-telecom-guide
- **Records**: CNAME to 3338323533.github.io

### About
This is a campus telecom service guide page for Nanchang University Qianhu Campus, providing new student package info, FAQs, and service details.