### PR TITLE
Register app-condominio.is-a.dev

### DIFF
--- a/domains/_dmarc.app-condominio.json
+++ b/domains/_dmarc.app-condominio.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "igormach00",
+    "email": "igormach00@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "v=DMARC1; p=none;"
+    ]
+  }
+}

--- a/domains/app-condominio.json
+++ b/domains/app-condominio.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "igormach00",
+    "email": "igormach00@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "v=spf1 -all"
+    ]
+  }
+}

--- a/domains/resend._domainkey.app-condominio.json
+++ b/domains/resend._domainkey.app-condominio.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "igormach00",
+    "email": "igormach00@gmail.com"
+  },
+  "records": {
+    "TXT": [
+      "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDKsQneLYG1kxP974K0A8tTko6icumieFVGVQQsdGtYc1yWmCY2n5c9rnppE/rVnPQOPYlUjy8cTarHdRjV30UJ4iluifD2Kbjn4FpG8qh9BxC3ezRlYyqbMjh8196r3UPR1TH28hYX7WnjOT3/2150MAHR3XLdEsTNHcOKWwYG0QIDAQAB"
+    ]
+  }
+}

--- a/domains/send.app-condominio.json
+++ b/domains/send.app-condominio.json
@@ -1,0 +1,17 @@
+{
+  "owner": {
+    "username": "igormach00",
+    "email": "igormach00@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "feedback-smtp.sa-east-1.amazonses.com",
+        "priority": 10
+      }
+    ],
+    "TXT": [
+      "v=spf1 include:amazonses.com ~all"
+    ]
+  }
+}


### PR DESCRIPTION
### Purpose
Free subdomain for a personal, non-commercial pilot project (a condo residents' marketplace app), used only for outbound transactional e-mail via Resend — no website hosted on it.

### Records
- `app-condominio.is-a.dev` — hardening SPF (`v=spf1 -all`, apex sends no mail).
- `resend._domainkey.app-condominio.is-a.dev` — DKIM TXT for Resend.
- `send.app-condominio.is-a.dev` — MX + SPF for Resend's sending subdomain.
- `_dmarc.app-condominio.is-a.dev` — DMARC policy.

Checked the repo for naming conflicts before opening this.