### PR TITLE
Fix Vercel verification for www.sani.is-a.dev

### DIFF
--- a/domains/_vercel.sani.json
+++ b/domains/_vercel.sani.json
@@ -5,7 +5,8 @@
   },
   "records": {
     "TXT": [
-      "vc-domain-verify=sani.is-a.dev,45c505d7b88defcefefc"
+      "vc-domain-verify=sani.is-a.dev,45c505d7b88defcefefc",
+      "vc-domain-verify=www.sani.is-a.dev,f47279c09de88964db5c"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `www.sani.is-a.dev` has been stuck in "Verification Required" on Vercel for several days despite `_vercel.www.sani.is-a.dev` already carrying the correct TXT token (added in #48548).
- Vercel treats `sani.is-a.dev` as the registrable-domain boundary (since `is-a.dev` is on the Public Suffix List), so it checks `_vercel.sani.is-a.dev` for verifying any subdomain under it, not the nested `_vercel.www.sani.is-a.dev`.
- This adds the missing `vc-domain-verify=www.sani.is-a.dev,...` token as a second TXT value on the existing `domains/_vercel.sani.json` record.

## Test plan
- [x] Verified both TXT records resolve correctly via Cloudflare and Google DoH after merge/propagation
- [ ] Confirm Vercel dashboard clears "Verification Required" for www.sani.is-a.dev after DNS propagates