### PR TITLE
Claim pixelworks.is-a.dev for portfolio website

### DIFF
--- a/domains/pixelworks.json
+++ b/domains/pixelworks.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "teamsamvaad"
+  },
+  "records": {
+    "CNAME": "teamsamvaad.github.io"
+  },
+  "description": "PixelWorks \u2014 free web portfolio & client demo sites"
+}


### PR DESCRIPTION
Claiming **pixelworks.is-a.dev** for my web development portfolio.

- **Domain:** pixelworks.is-a.dev
- **Record:** CNAME → teamsamvaad.github.io
- **Purpose:** live portfolio of 15 client-ready business websites (GitHub Pages)