### PR TITLE
Add dr-ahmed.is-a.dev with Cloudflare NS delegation

### DIFF
--- a/domains/dr-ahmed.json
+++ b/domains/dr-ahmed.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "ana-joker",
+    "email": "ana.joker@users.noreply.github.com"
+  },
+  "records": {
+    "NS": ["aryanna.ns.cloudflare.com", "brad.ns.cloudflare.com"]
+  }
+}


### PR DESCRIPTION
Registering dr-ahmed.is-a.dev with NS records pointing to Cloudflare for Email Routing usage. Owner: ana-joker.