### PR TITLE
Add ale-offline.is-a.dev

### DIFF
--- a/domains/ale-offline.json
+++ b/domains/ale-offline.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "A4L5E",
+    "email": "web.desing.4l5@gmail.com"
+  },
+  "records": {
+    "CNAME": "a4l5e.github.io"
+  },
+  "proxied": true
+}


### PR DESCRIPTION
Solicito el subdominio ale-offline.is-a.dev para mi proyecto personal ale-offline.

Owner: A4L5E (web.desing.4l5@gmail.com)
Records: CNAME -> a4l5e.github.io (GitHub Pages, proyecto Astro ale-offline)
Proxied: true

Proyecto ya desplegado en https://a4l5e.github.io/ale-offline/ y se conectara como dominio custom una vez aprobado.

Gracias!