### PR TITLE
Register pitchminds.is-a.dev

### DIFF
--- a/domains/pitchminds.json
+++ b/domains/pitchminds.json
@@ -1,0 +1,11 @@
+{
+    "owner": {
+        "username": "zach333miller",
+        "email": "zach333miller@gmail.com"
+    },
+    "records": {
+        "A": [
+            "104.131.180.29"
+        ]
+    }
+}


### PR DESCRIPTION
Registering `pitchminds.is-a.dev` for Pitch Minds — a free football-manager web game where every player is an AI agent with personality and memory. A record points at the game server.

- Site (current temporary URL): https://pitchminds.cadastral.online
- Open source of the register entry only; game repo is private.