### PR TITLE
Add vortex.is-a.dev

### DIFF
--- a/_domains/vortex.json
+++ b/_domains/vortex.json
@@ -1,0 +1,4 @@
+{
+  "owner": { "username": "Leroy202023", "email": "Leroy202023@users.noreply.github.com" },
+  "records": { "CNAME": "c8b53439-7b36-407e-b934-9be18b2d79b5.cfargotunnel.com" }
+}


### PR DESCRIPTION
Free subdomain for a Cloudflare-tunneled VORTEX gateway (notrack.ai uncensored chat + image/video gen).