### PR TITLE
Register locale.is-a.dev for email routing (Resend)

### DIFF
--- a/domains/_dmarc.locale.json
+++ b/domains/_dmarc.locale.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "hanxsoloxx",
+    "email": "localeapp.ng@gmail.com"
+  },
+  "records": {
+    "TXT": "v=DMARC1; p=none;"
+  }
+}

--- a/domains/locale.json
+++ b/domains/locale.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "hanxsoloxx",
+    "email": "localeapp.ng@gmail.com"
+  },
+  "records": {
+    "TXT": "Locale - hyperlocal grocery delivery app (in development)"
+  }
+}

--- a/domains/resend._domainkey.locale.json
+++ b/domains/resend._domainkey.locale.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "hanxsoloxx",
+    "email": "localeapp.ng@gmail.com"
+  },
+  "records": {
+    "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDD4ztnq2EcSFbxWJ+kg7EfJoMrILQPgugXF4ISu0WCr7KkxyVtUA29ZD3xS8HoJi0ONkEHWmL7o4shbwABS7b9SskCIAvmXig90Y97Z2pvJY37obRr538CpTCdpEYb3CMq5wFIR63dwiCNeW21nH51PnNRDUB/MmPS73NT6ZCyVwIDAQAB"
+  }
+}

--- a/domains/send.locale.json
+++ b/domains/send.locale.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "hanxsoloxx",
+    "email": "localeapp.ng@gmail.com"
+  },
+  "records": {
+    "MX": [
+      { "target": "feedback-smtp.eu-west-1.amazonses.com", "priority": 10 }
+    ],
+    "TXT": "v=spf1 include:amazonses.com ~all"
+  }
+}


### PR DESCRIPTION
This domain (locale.is-a.dev) is used purely for email routing via Resend DKIM, SPF/MX, and DMARC records only. There's no website to preview, since this domain doesn't host any content.


