### PR TITLE
Update luisanchez.is-a.dev to point to Cloudflare Pages

### DIFF
--- a/domains/luisanchez.json
+++ b/domains/luisanchez.json
@@ -3,6 +3,6 @@
     "username": "LuiSanchezPy"
   },
   "records": {
-    "A": ["198.187.29.220"]
+    "CNAME": "luisanchez.pages.dev"
   }
 }


### PR DESCRIPTION
Updating my existing domain `luisanchez.is-a.dev` to point to Cloudflare Pages
instead of the previous A record, so the site gets automatic HTTPS.

**Live site:** https://luisanchez.pages.dev

It is my personal portfolio as a web developer from Asunción, Paraguay: five
sample sites, one per industry, each with its own design. No commercial
transactions, no ads, no tracking, no affiliate links.

The Cloudflare Pages custom domain is already configured on my side and is
waiting for this DNS record.

**Change:** `"A": ["198.187.29.220"]` → `"CNAME": "luisanchez.pages.dev"`
