### PR TITLE
Register cocobisla.is-a.dev

### DIFF
--- a/domains/cocobisla.json
+++ b/domains/cocobisla.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Tiggreee",
+    "email": "tiggreee@vmdev.lat"
+  },
+  "records": {
+    "CNAME": "cocob-web---codigobien.whitetree-e39b7f21.eastus2.azurecontainerapps.io"
+  }
+}


### PR DESCRIPTION
Requesting `cocobisla.is-a.dev` as a short, presentable QA/demo URL for our team's hackathon project, pointing to our existing Azure Container Apps deployment via CNAME.

- [x] I have read and agree with the [Terms of Service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md)
- [x] My domain does not violate any of the rules in the Terms of Service
- [x] My domain is not for phishing or spamming purposes
- [x] I own/control the target of the record(s) I am adding