### PR TITLE
Add subdomains and TXT record to ramon.json

### DIFF
--- a/domains/ramon.json
+++ b/domains/ramon.json
@@ -5,5 +5,12 @@
     },
     "records": {
         "CNAME": "noisy-aqua-thhfvmsj.edgeone.dev"
+    },
+    "subdomains": {
+        "edgeonereclaim": {
+            "records": {
+                "TXT": "reclaim-xh4rufjlrp0f0n5w67epw0ep19dxsacm"
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds an edgeonereclaim subdomain record to verify ownership of ramon.is-a.dev with EdgeOne Pages hosting, required for custom domain SSL/HTTPS setup.

<!--
YOU MUST FILL OUT THIS ENTIRE TEMPLATE FOR YOUR PR TO BE APPROVED!

DO NOT MODIFY OR REMOVE THIS TEMPLATE (INCLUDING REMOVING COMMENTS) OR YOUR PR WILL FAIL VALIDATION!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->
<!-- Do not modify anything in this section other than the checkboxes, or your PR will fail validation. -->

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview
<!-- WEBSITE_PREVIEW_START -->
https://noisy-aqua-thhfvmsj.edgeone.dev/
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose
<!-- WEBSITE_PURPOSE_START -->
This is my personal portfolio site as a CS student at UIC. It showcases software projects I've built (including a credit-scoring model for gig workers built at a Capital One hackathon, an OCR-based pantry tracker, and a field check-in system from a software engineering internship), my work experience, and links to my GitHub and resume.
<!-- WEBSITE_PURPOSE_END -->