### PR TITLE
Add study-tools.is-a.dev

### DIFF
--- a/domains/_vercel.study-tools.json
+++ b/domains/_vercel.study-tools.json
@@ -1,8 +1,0 @@
-{
-    "owner": {
-        "username": "uuadwdad-cmyk"
-    },
-    "records": {
-        "TXT": "vercel-domain-verification=odin-proxy-study-tools"
-    }
-}

--- a/domains/_vercel.study-tools.json
+++ b/domains/_vercel.study-tools.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "uuadwdad-cmyk"
+    },
+    "records": {
+        "TXT": "vercel-domain-verification=odin-proxy-study-tools"
+    }
+}

--- a/domains/study-tools.json
+++ b/domains/study-tools.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "uuadwdad-cmyk"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
## Domain Registration

- Subdomain: study-tools.is-a.dev
- Owner: @uuadwdad-cmyk
- Hosting: Vercel
- Purpose: Developer tools / study app

### Files added:
- \domains/study-tools.json\ — CNAME record pointing to Vercel
- \domains/_vercel.study-tools.json\ — TXT verification record

### Preview
Site is deployed on Vercel and ready for the custom domain connection.