### PR TITLE
Add Vercel verification for bryanjames.is-a.dev

### DIFF
--- a/domains/_vercel.bryanjames.json
+++ b/domains/_vercel.bryanjames.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "bryanjamesdionisio",
+    "email": "dionisiobryanjames@yahoo.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=bryanjames.is-a.dev,d22613d321f7078a03af"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://bjgd-portfolio.vercel.app
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
This file adds the Vercel TXT verification record required to attach the registered bryanjames.is-a.dev subdomain to my Vercel portfolio project (bjgd-portfolio).
<!-- WEBSITE_PURPOSE_END -->
