### PR TITLE
add acorn.is-a.dev

### DIFF
--- a/domains/acorn.json
+++ b/domains/acorn.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "TECHYAko",
+    "email": "aklennwankwo@gmail.com"
+  },
+  "records": {
+    "CNAME": "techyako.github.io"
+  }
+}


### PR DESCRIPTION
Registering `acorn.is-a.dev` for Eaglercraft 1.16.5, a browser port of Minecraft 1.16.5 compiled to WebAssembly.

Points to my GitHub Pages site: https://techyako.github.io/Eaglercraft-1.16.5/

```json
{
  "owner": {
    "username": "TECHYAko",
    "email": "aklennwankwo@gmail.com"
  },
  "records": {
    "CNAME": "techyako.github.io"
  }
}
```