### PR TITLE
Register carloscabello.is-a.dev

### DIFF
--- a/domains/carloscabello.json
+++ b/domains/carloscabello.json
@@ -1,0 +1,11 @@
+{
+  "description": "Carlos Cabello's personal portfolio",
+  "owner": {
+    "username": "CarlosCabelloTroncoso",
+    "email": "ignaciocarlos016@gmail.com",
+    "repo": "https://github.com/CarlosCabelloTroncoso/portfolio-2026"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering carloscabello.is-a.dev to point to my personal portfolio, deployed on Vercel (source: https://github.com/CarlosCabelloTroncoso/portfolio-2026).