### PR TITLE
domains: add jifeng (CNAME to Cloudflare Pages)

### DIFF
--- a/domains/jifeng.json
+++ b/domains/jifeng.json
@@ -1,12 +1,9 @@
 {
-  "repo": "https://github.com/Yangchengen-hub/sanfengyun-review",
   "owner": {
     "username": "Yangchengen-hub",
     "email": "3565583431@qq.com"
   },
   "records": {
-    "A": [
-      "43.226.44.4"
-    ]
+    "CNAME": "jifeng-cn.pages.dev"
   }
 }


### PR DESCRIPTION
# Requirements
- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview
<!-- WEBSITE_PREVIEW_START -->
https://jifeng-cn.pages.dev
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose
<!-- WEBSITE_PURPOSE_START -->
This is the non-commercial website of Jifeng Studio, a personal software development and mobile tinkering workshop. It hosts the studio introduction page plus a self-built security/operations monitoring dashboard for the project. The domain will CNAME to the existing completed site deployed on Cloudflare Pages.
<!-- WEBSITE_PURPOSE_END -->