### PR TITLE
Remove markanthonyportfolio.is-a.dev

### DIFF
--- a/domains/markanthonyportfolio.json
+++ b/domains/markanthonyportfolio.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "imnrqzz",
-    "email": "markanthonyenriquezzz@gmail.com"
-  },
-  "records": {
-    "CNAME": "portfolio-murex-eta-qlzrmmbabo.vercel.app"
-  }
-}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS ENTIRE TEMPLATE FOR YOUR PR TO BE APPROVED!

DO NOT MODIFY OR REMOVE THIS TEMPLATE (INCLUDING REMOVING COMMENTS) OR YOUR PR WILL FAIL VALIDATION!
-->

# Requirements

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://portfolio-murex-eta-qlzrmmbabo.vercel.app/
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
Removing this old subdomain because I switched to markenrportfolio.is-a.dev for my portfolio website.
<!-- WEBSITE_PURPOSE_END -->