### PR TITLE
register vergel.is-a.dev (email forwarding with ImprovMX)

### DIFF
--- a/domains/vergel.json
+++ b/domains/vergel.json
@@ -1,0 +1,21 @@
+{
+  "owner": {
+    "username": "psqle22",
+    "email": "lazaba038@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "mx1.improvmx.com",
+        "priority": 10
+      },
+      {
+        "target": "mx2.improvmx.com",
+        "priority": 20
+      }
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  }
+}


### PR DESCRIPTION
Registering \ergel.is-a.dev\ for Vergel, a web agency for local businesses in Colombia. Adds MX + SPF records to receive email at hola@vergel.is-a.dev via ImprovMX; alternative CNAME/APEX can be added later to point the site here from GitHub Pages.