### PR TITLE
Register floodgap.is-a.dev

### DIFF
--- a/domains/floodgap.json
+++ b/domains/floodgap.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "cashredo",
+    "email": "julian.quevedo.houston@gmail.com"
+  },
+  "records": {
+    "CNAME": "cashredo.github.io"
+  }
+}


### PR DESCRIPTION
Registering `floodgap.is-a.dev` for **FloodGap**, a free, open-source flood-risk web app built in JavaScript and hosted on GitHub Pages.

- **Subdomain:** floodgap.is-a.dev
- **Target (CNAME):** cashredo.github.io  (repo: https://github.com/cashredo/floodgap)
- **Live site:** https://cashredo.github.io/floodgap/

The site is a complete application, not a placeholder: it looks up a home's FEMA flood zone, NFIP claim history, and runs a client-side Monte Carlo risk model, with a published methods page. I'll add the `CNAME` file (`floodgap.is-a.dev`) to the repo once this is merged and DNS is live.