### PR TITLE
Register mtalha.is-a.dev

### DIFF
--- a/domains/mtalha.json
+++ b/domains/mtalha.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "talha50819",
+    "email": "talhasiddiqui433@gmail.com"
+  },
+  "records": {
+    "CNAME": "webora-398.netlify.app"
+  }
+}


### PR DESCRIPTION
New personal-site subdomain for @talha50819, pointing at the same Netlify deployment currently serving webora.is-a.dev (which I already have registered here as an is-a.dev subdomain).

# Requirements

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://webora-398.netlify.app
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
This is my personal software developer portfolio and blog. It showcases projects I've built, my skills across web/mobile/cloud/security work, and lets people get in touch with me. I'm moving it from webora.is-a.dev (my previous is-a.dev subdomain) to a personal-name subdomain since I mistyped/misjudged the earlier one; webora.is-a.dev will redirect here once this is live.
<!-- WEBSITE_PURPOSE_END -->
