### PR TITLE
Update CNAME for mtalha.is-a.dev

### DIFF
--- a/domains/mtalha.json
+++ b/domains/mtalha.json
@@ -4,6 +4,6 @@
     "email": "talhasiddiqui433@gmail.com"
   },
   "records": {
-    "CNAME": "webora-398.netlify.app"
+    "CNAME": "warm-biscotti-668f5b.netlify.app"
   }
 }


### PR DESCRIPTION
Updates the CNAME record for `mtalha.is-a.dev` to point to the correct current Netlify subdomain (`warm-biscotti-668f5b.netlify.app`). The site was renamed on Netlify's side, and the previously merged record still pointed at the old, now-inactive `webora-398.netlify.app` subdomain.

- [x] I have read the [contribution guidelines](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md)
- [x] My PR follows the [naming convention](https://github.com/is-a-dev/register/blob/main/CONTRIBUTING.md#naming-guidelines)