### PR TITLE
feat: add civicballot.tahiry29.is-a.dev

### DIFF
--- a/domains/_vercel.tahiry29.json
+++ b/domains/_vercel.tahiry29.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "tahiry-dev-29",
+    "email": "tahirydev29@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=civicballot.tahiry29.is-a.dev,64ea8ca86e5ac8ff8979"
+  }
+}

--- a/domains/civicballot.tahiry29.json
+++ b/domains/civicballot.tahiry29.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "tahiry-dev-29",
+    "email": "tahirydev29@gmail.com"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
Ajout du sous-domaine professionnel civicballot.tahiry29.is-a.dev pour la plateforme de vote sécurisée. Hebergement Vercel civicballot.vercel.app, records A 216.198.79.1 + TXT verification.