### PR TITLE
Update ruizzzp40.is-a.dev CNAME for MCP endpoint

### DIFF
--- a/domains/ruizzzp40.json
+++ b/domains/ruizzzp40.json
@@ -2,7 +2,7 @@
   "owner": {
     "username": "ruizzzp40"
   },
-  "records": {
-    "CNAME": "ruizzzp40.github.io"
+  "record": {
+    "CNAME": "kumamac-mini.tail9cf1bb.ts.net"
   }
 }


### PR DESCRIPTION
## Website Preview

<!-- website-preview-start -->
https://ruizzzp40.is-a.dev
<!-- website-preview-end -->

## Website Purpose

<!-- website-purpose-start -->
Personal developer endpoint for macOS local AI automation and MCP experiments.

This domain is used as a public MCP endpoint forwarding to my personal development machine.

Non-commercial personal developer project.
<!-- website-purpose-end -->

## Checklist

- [x] I have read and agree to follow the is-a.dev terms.
- [x] This pull request is for a personal developer project.
- [x] The domain is not used for commercial purposes.