### PR TITLE
feat: add trustnode.is-a.dev

### DIFF
--- a/domains/trustnode.json
+++ b/domains/trustnode.json
@@ -1,0 +1,1 @@
+{"owner":{"username":"TrustNodeLab"},"record":{"CNAME":"trustnodelab.github.io"}}


### PR DESCRIPTION
Requesting subdomain **trustnode.is-a.dev** for the TrustNode project (on-device Android anti-fraud).

- Owner: TrustNodeLab (org) ? I am an admin
- Record: CNAME trustnodelab.github.io
- Purpose: official project site