### PR TITLE
Add TXT verification record for nuru.is-a.dev

### DIFF
--- a/domains/_vercel.nuru.json
+++ b/domains/_vercel.nuru.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "mohammednuruddin",
+    "email": "mohammednuruddin04@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=nuru.is-a.dev,cfb8fc795cc6e74dc945"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS ENTIRE TEMPLATE FOR YOUR PR TO BE APPROVED!

DO NOT MODIFY OR REMOVE THIS TEMPLATE (INCLUDING REMOVING COMMENTS) OR YOUR PR WILL FAIL VALIDATION!
-->

# Requirements
- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview
<!-- WEBSITE_PREVIEW_START -->
https://nuruddinalhassan.vercel.app/
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose
<!-- WEBSITE_PURPOSE_START -->
Adding Vercel ownership verification TXT record for existing registered domain nuru.is-a.dev.
<!-- WEBSITE_PURPOSE_END -->
