### PR TITLE
Register meida.is-a.dev

### DIFF
--- a/domains/meida.json
+++ b/domains/meida.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "meidaist98",
+    "email": "219233775+meidaist98@users.noreply.github.com"
+  },
+  "records": {
+    "A": [
+      "43.153.208.233"
+    ]
+  }
+}


### PR DESCRIPTION
Registering `meida.is-a.dev` to point to my personal VPS for hosting my portfolio website.

- Record type: A
- Target: personal VPS (Ubuntu 24.04)
- Purpose: personal portfolio (GIS / remote sensing / AI automation projects)