### PR TITLE
Register vilona.is-a.dev for Vilona Gold Trading EA

### DIFF
--- a/domains/vilona.json
+++ b/domains/vilona.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "DIRJEN-BOT"
+  },
+  "record": {
+    "CNAME": "dirjen-bot.github.io"
+  },
+  "description": "Vilona Gold Trading EA - Free MT5 Expert Advisor for XAUUSD",
+  "repo": "https://github.com/DIRJEN-BOT/mt5-gold-trading-ea"
+}


### PR DESCRIPTION
## Vilona Gold Trading EA
Free MT5 Expert Advisor for XAUUSD. Open-source + Pro EA with verified backtest evidence.

- **Domain:** vilona.is-a.dev
- **CNAME:** dirjen-bot.github.io
- **Repo:** https://github.com/DIRJEN-BOT/mt5-gold-trading-ea
- **Purpose:** Landing page for the gold trading EA project (GitHub Pages)

Requesting this subdomain to promote the open-source MT5 gold trading EA project. The GitHub Pages site is already deployed at https://dirjen-bot.github.io/mt5-gold-trading-ea/.