### PR TITLE
Add kaptan-ai.is-a.dev

### DIFF
--- a/domains/kaptan-ai.json
+++ b/domains/kaptan-ai.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "TuuneForge",
+    "email": "adslerux@gmail.com"
+  },
+  "record": {
+    "CNAME": "tuuneforge.github.io"
+  }
+}

--- a/domains/kaptan-ai.json
+++ b/domains/kaptan-ai.json
@@ -3,7 +3,7 @@
     "username": "TuuneForge",
     "email": "adslerux@gmail.com"
   },
-  "record": {
+  "records": {
     "CNAME": "tuuneforge.github.io"
   }
 }


### PR DESCRIPTION
Register kaptan-ai.is-a.dev for @TuuneForge

- Domain: kaptan-ai.is-a.dev
- Owner: TuuneForge (adslerux@gmail.com)
- Target: tuuneforge.github.io (GitHub Pages for KAPTAN.AI)

Discord: https://discord.gg/BBhs9wzae7