### PR TITLE
Fix: set aurahub.is-a.dev to DNS-only for Pages

### DIFF
--- a/domains/aurahub.json
+++ b/domains/aurahub.json
@@ -8,5 +8,5 @@
     "records": {
         "CNAME": "aura-hub-website-v2.pages.dev"
     },
-    "proxied": true
+    "proxied": false
 }


### PR DESCRIPTION
Follow-up to #46453.

**Problem:**  returns  - Pages custom domain `aurahub.is-a.dev` not added and DNS is `proxied: true`, so request goes through `is-a.dev` zone proxy, not directly to Pages, and Pages rejects.

**Fix:** Set `proxied: false` (DNS-only) so `CNAME aura-hub-website-v2.pages.dev` resolves directly to Pages. Pages project `aura-hub-website-v2` will then serve it once custom domain ``aurahub.is-a.dev`` is added in Cloudflare Dashboard (Pages -> Custom domains). Without `proxied: false`, Pages API rejects `is-a.dev` as invalid TLD and `1014` persists.

No other records changed.