### PR TITLE
Update aurahub.is-a.dev to GitHub Pages (fix 403)

### DIFF
--- a/domains/aurahub.json
+++ b/domains/aurahub.json
@@ -1,12 +1,12 @@
 {
-  "owner": {
-    "username": "Gokulanand-art",
-    "email": "gokulanand744@gmail.com"
-  },
-  "description": "AURA Hub — an AI-native software engineering environment (IDE-style desktop app). Public project site.",
-  "repo": "https://github.com/Aura-hub-ai-native-workspace/aura-hub-website",
-  "records": {
-    "CNAME": "aura-hub-website-v2.pages.dev"
-  },
-  "proxied": true
+    "owner": {
+        "username": "Gokulanand-art",
+        "email": "gokulanand744@gmail.com"
+    },
+    "description": "AURA Hub — an AI-native software engineering environment (IDE-style desktop app). Public project site.",
+    "repo": "https://github.com/Aura-hub-ai-native-workspace/aura-hub-website",
+    "records": {
+        "CNAME": "aura-hub-ai-native-workspace.github.io"
+    },
+    "proxied": false
 }


### PR DESCRIPTION
# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://aura-hub-website-v2.pages.dev/
https://aura-hub-ai-native-workspace.github.io/aura-hub-website/

# Website Purpose
AURA Hub — an AI-native software engineering environment (IDE-style desktop app). Public project site showcasing the open-source AURA Hub platform, its architecture, workflows, and download links for Linux/Windows/macOS. Follow-up to #46453 to fix 403 CNAME Cross-User Banned (proxied true -> false, and CNAME to GitHub Pages hostname for native is-a.dev support; Cloudflare Pages custom domain rejected is-a.dev as invalid TLD via API).

