### PR TITLE
Register pasta.is-a.dev

### DIFF
--- a/domains/pasta.json
+++ b/domains/pasta.json
@@ -3,6 +3,6 @@
     "username": "petot-nodelet"
   },
   "records": {
-    "CNAME": "https://pasta-dxq.pages.dev/"
+    "CNAME": "pasta-dxq.pages.dev"
   }
 }

--- a/domains/pasta.json
+++ b/domains/pasta.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "petot-nodelet"
+  },
+  "records": {
+    "CNAME": "https://pasta-dxq.pages.dev/"
+  }
+}


### PR DESCRIPTION
## Description

Register pasta.is-a.dev for the PASTA website.

Website: https://pasta-dxq.pages.dev