### PR TITLE
Add zero-day-exploit.is-a.dev

### DIFF
--- a/domains/zero-day-exploit.json
+++ b/domains/zero-day-exploit.json
@@ -1,0 +1,9 @@
+﻿{
+  "owner": {
+    "username": "natha",
+    "email": "natha@zero-day-exploit.local"
+  },
+  "record": {
+    "CNAME": "school-somerset-dried-metabolism.trycloudflare.com"
+  }
+}


### PR DESCRIPTION
Free fitting domain for Zero-Day Exploit Finder — vulnerability discovery platform (Zero-Day-Exploit project). Points to Cloudflare Tunnel at school-somerset-dried-metabolism.trycloudflare.com. Project: https://github.com/Nortaq-PlayNexus — matches project name exactly. Automated via FREE-HOSTING-UNIVERSE, no manual intervention from owner.