### PR TITLE
Add terrorfibercraftark.is-a.dev

### DIFF
--- a/domains/terrorfibercraftark.json
+++ b/domains/terrorfibercraftark.json
@@ -1,0 +1,9 @@
+﻿{
+  "owner": {
+    "username": "Nortaq-PlayNexus",
+    "email": "311333767+Nortaq-PlayNexus@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "nortaq-playnexus.github.io"
+  }
+}


### PR DESCRIPTION
Claim free subdomain for Terror Fibercraft 1000x ARK cluster.

Target: CNAME -> nortaq-playnexus.github.io (GitHub Pages project https://nortaq-playnexus.github.io/terrorfibercraftark/ )
Owner: Nortaq-PlayNexus