### PR TITLE
feat: register el-cognito.is-a.dev

### DIFF
--- a/domains/el-cognito.json
+++ b/domains/el-cognito.json
@@ -1,0 +1,11 @@
+{
+  "description": "El Cognito Symposium 2026 — Aalim Muhammed Salegh College of Engineering",
+  "repo": "https://github.com/mdhasim-1406/El-Cognito",
+  "owner": {
+    "username": "mdhasim-1406",
+    "email": "mdhasim-1406@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "el-cognito.vercel.app"
+  }
+}


### PR DESCRIPTION
Registering **el-cognito.is-a.dev** for the El Cognito Symposium 2026 website.

- Deployed on Vercel: `el-cognito.vercel.app`
- Repo: https://github.com/mdhasim-1406/El-Cognito
- CNAME record pointing to the Vercel deployment.