### PR TITLE
Ajout de gryphon.is-a.dev

### DIFF
--- a/domains/gryphon.json
+++ b/domains/gryphon.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "gricatan",
+        "email": "griffonluc7@gmail.com"
+    },
+    "records": {
+        "NS": [
+            "lee.ns.cloudflare.com",
+            "treasure.ns.cloudflare.com"
+        ]
+    }
+}


### PR DESCRIPTION
Demande d'enregistrement de `gryphon.is-a.dev`.

Enregistrements NS vers Cloudflare :
- `lee.ns.cloudflare.com`
- `treasure.ns.cloudflare.com`

La zone est déjà créée côté Cloudflare et répond.