### PR TITLE
Add wordcount.is-a.dev

### DIFF
--- a/domains/wordcount.json
+++ b/domains/wordcount.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "18106322872",
+        "email": "1442828588@qq.com"
+    },
+    "records": {
+        "CNAME": "725e8979-0c61-4efb-925c-bc4e79787eec.cfargotunnel.com"
+    }
+}


### PR DESCRIPTION
## Request

Register `wordcount.is-a.dev` for WordCount web service.

## DNS

- **Type**: CNAME
- **Target**: `725e8979-0c61-4efb-925c-bc4e79787eec.cfargotunnel.com` (Cloudflare Named Tunnel)

## Owner

- **GitHub**: @18106322872
- **Email**: 1442828588@qq.com

## Use case

Personal word count web service (FastAPI + Cloudflare Tunnel). The CNAME points to a Cloudflare Named Tunnel which routes to localhost:8000.