### PR TITLE
Add sandeep.json - register sandeep.is-a.dev

### DIFF
--- a/domains/sandeep.json
+++ b/domains/sandeep.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "contact-tsandeep",
+    "email": "243602728+contact-tsandeep@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "contact-tsandeep.github.io"
+  }
+}


### PR DESCRIPTION
Hi! I'd like to register `sandeep.is-a.dev` for my personal developer site.

**Site URL:** https://contact-tsandeep.github.io

**CNAME target:** contact-tsandeep.github.io

**About me:** I'm a software developer and the founder of Americanbusinessdeveloper. The site is a personal portfolio â€” non-commercial, software-development focused.

**Tech used:** GitHub Pages (static HTML/CSS/JS), served from `contact-tsandeep.github.io`.

Let me know if anything needs adjusting. Thanks for maintaining is-a.dev!