### PR TITLE
Register gym-tracker.is-a.dev

### DIFF
--- a/domains/gym-tracker.json
+++ b/domains/gym-tracker.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Sumit-0610",
+    "email": "sumitjad36@gmail.com"
+  },
+  "records": {
+    "CNAME": "gym-tracker-d5ha.onrender.com"
+  }
+}


### PR DESCRIPTION
Registering gym-tracker.is-a.dev for my open-source workout tracker
(React + Node/Express + libSQL), deployed on Render.

Repo: https://github.com/Sumit-0610/gym-tracker
CNAME target: gym-tracker-d5ha.onrender.com