### PR TITLE
rafli.is-a.dev: Add Vercel TXT verification

### DIFF
--- a/domains/rafli.json
+++ b/domains/rafli.json
@@ -4,6 +4,12 @@
     "email": "avcl061202@gmail.com"
   },
   "records": {
-    "URL": "https://github.com/appyx123"
+    "A": [
+      "216.198.79.1"
+    ],
+    "TXT": [
+      "vc-domain-verify=rafli.is-a.dev,8e503e734353458836ce",
+      "vc-domain-verify=www.rafli.is-a.dev,662c686a7f918c5f2af0"
+    ]
   }
 }


### PR DESCRIPTION
### Requirements

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the owner key.
- [x] I have provided a link to my website below.

### Website Preview
<!-- WEBSITE PREVIEW START -->
https://portofolio-rafli-three.vercel.app
<!-- WEBSITE PREVIEW END -->

### Website Purpose
<!-- WEBSITE PURPOSE START -->
Personal developer portfolio showcasing my skills and projects in AI & IoT development, with a focus on TinyML, ESP32, and Next.js.
<!-- WEBSITE PURPOSE END -->

---
**📝 Note for Reviewers:**
Updating my domain record to include the TXT verification strings required by Vercel. My CNAME configuration was previously merged, but Vercel flagged the domain as linked to another account and requires this TXT proof of ownership. Thank you!