### PR TITLE
Add Vercel TXT record for rafli.is-a.dev

### DIFF
--- a/domains/_vercel.rafli.json
+++ b/domains/_vercel.rafli.json
@@ -5,8 +5,8 @@
   },
   "records": {
     "TXT": [
-      "vc-domain-verify=rafli.is-a.dev,cb5d7fd33068788ddc16",
-      "vc-domain-verify=www.rafli.is-a.dev,7c3f6a02fb2dd4352b6a"
+      "vc-domain-verify=rafli.is-a.dev,8e503e734353458836ce",
+      "vc-domain-verify=www.rafli.is-a.dev,662c686a7f918c5f2af0"
     ]
   }
 }

--- a/domains/rafli.json
+++ b/domains/rafli.json
@@ -4,8 +4,6 @@
     "email": "avcl061202@gmail.com"
   },
   "records": {
-    "A": [
-      "216.198.79.1"
-    ]
+    "CNAME": "cname.vercel-dns.com"
   }
 }


### PR DESCRIPTION
### Requirements

- [x] I agree to the Terms of Service.
- [x] My file is following the domain structure.
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the owner key.
- [x] I have provided a link to my website below.

### Website Preview
<!-- WEBSITE PREVIEW START -->
https://portofolio-rafli-three.vercel.app
<!-- WEBSITE PREVIEW END -->

### Website Purpose
<!-- WEBSITE PURPOSE START -->
Personal developer portfolio showcasing my skills and projects in AI & IoT development, with a focus on TinyML, ESP32, and Next.js.
<!-- WEBSITE PURPOSE END -->

---
Hi, I have separated the Vercel TXT verification records into the `_vercel.rafli.json` file as requested, leaving `rafli.json` with just the CNAME. Thanks!