### PR TITLE
Add spontier.is-a.dev

### DIFF
--- a/domains/spontier.json
+++ b/domains/spontier.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "ramkrishna3245",
+    "email": "ramkrishna3240@gmail.com"
+  },
+  "records": {
+    "CNAME": "ramkrishna3245.github.io"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering semi-spontier.is-a.dev for a tech tutorials website. DNS: CNAME to ramkrishna3245.github.io (GitHub Pages).