### PR TITLE
feat(domain): add loudandsound.is-a.dev

### DIFF
--- a/domains/_vercel.loudandsound.json
+++ b/domains/_vercel.loudandsound.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "PhaNtoM-GHosT-11101",
+        "email": "aditya.on.windows10@gmail.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=loudandsound.is-a.dev,3G9X8AczUn"
+    }
+}

--- a/domains/loudandsound.json
+++ b/domains/loudandsound.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "PhaNtoM-GHosT-11101",
+        "email": "aditya.on.windows10@gmail.com"
+    },
+    "records": {
+        "CNAME": "cname.vercel-dns.com"
+    }
+}


### PR DESCRIPTION
# Requirements
- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview
https://mss-feedback.vercel.app

# Website Purpose
Loud and sound (loudandsound.is-a.dev) is a full-stack web application built from scratch — a campus feedback board where students post, upvote, and track complaints (Vercel + Next.js frontend, Supabase/Postgres backend with auth, RLS policies, per-user daily rate limits, full-text + trigram search). It is a free, non-commercial student project; the domain will point to its production deployment on Vercel.