### PR TITLE
feat: add sunflare94.is-a.dev

### DIFF
--- a/domains/sunflare94.json
+++ b/domains/sunflare94.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "SunFlare94",
+    "email": "mukulpramanik@outlook.com"
+  },
+  "records": {
+    "CNAME": "sunflare94website.onrender.com"
+  }
+}


### PR DESCRIPTION
Adding sunflare94.is-a.dev pointing to sunflare94website.onrender.com

- [x] I have read the [README](https://github.com/is-a-dev/register/blob/main/README.md)
- [x] I am not adding a profile (index.html) file