### PR TITLE
Delegate milankumawat.is-a.dev to Cloudflare nameservers

### DIFF
--- a/domains/milankumawat.json
+++ b/domains/milankumawat.json
@@ -4,8 +4,9 @@
     "email": "milankumawat01@gmail.com"
   },
   "records": {
-    "A": [
-      "152.67.14.19"
+    "NS": [
+      "colin.ns.cloudflare.com",
+      "crystal.ns.cloudflare.com"
     ]
   }
 }


### PR DESCRIPTION
Updates `domains/milankumawat.json` to delegate `milankumawat.is-a.dev` to Cloudflare nameservers, replacing the existing A record.

The A record (`152.67.14.19`) is now managed on the Cloudflare zone instead, so DNS is unchanged in effect.

- NS is the only record type in the file, per the record-combination rules
- No nested subdomains exist under this domain
- Owner is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5k78DUkEJcbrykt5wpFqi