### PR TITLE
Add radosoa.is-a.dev domain

### DIFF
--- a/domains/_vercel.radosoa.json
+++ b/domains/_vercel.radosoa.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Radosoa"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=radosoa.is-a.dev,01f8827da944b6401e35"
+  }
+}

--- a/domains/radosoa.json
+++ b/domains/radosoa.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Radosoa"
+  },
+  "records": {
+    "A": ["216.198.79.1"]
+  }
+}


### PR DESCRIPTION
## Add radosoa.is-a.dev domain

This pull request adds the configuration for `radosoa.is-a.dev`.

### Changes

* Added `domains/radosoa.json`
* Added Vercel domain verification record
* Configured the A record for Vercel

The domain is intended to point to my portfolio hosted on Vercel.

