### PR TITLE
Add trustnode.is-a.dev

### DIFF
--- a/domains/trustnode.json
+++ b/domains/trustnode.json
@@ -1,0 +1,1 @@
+﻿{"owner":{"username":"TrustNodeLab","email":"mikhailpitolin@gmail.com"},"records":{"CNAME":"TrustNodeLab.github.io"}}


### PR DESCRIPTION
## Description

Adding `trustnode.is-a.dev` subdomain for TrustNodeLab project.

- **Website**: https://trustnodelab.github.io/
- **Project**: TrustNode — On-Device Anti-Fraud & Spam Shield (open-source security tool)
- **GitHub**: https://github.com/TrustNodeLab

## Domain file

```json
{
    "owner": {
        "username": "TrustNodeLab",
        "email": "mikhailpitolin@gmail.com"
    },
    "records": {
        "CNAME": "TrustNodeLab.github.io"
    }
}
```

## Screenshot

TrustNode landing page — on-device AI protection against scammers, spam, and phishing.

![TrustNode](https://trustnodelab.github.io/og-image.png)