### PR TITLE
Register hydra-psie.is-a.dev

### DIFF
--- a/domains/hydra-psie.json
+++ b/domains/hydra-psie.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "bogdanstancu1119-maker",
+    "email": "bogdanstancu1119-maker@users.noreply.github.com"
+  },
+  "record": {
+    "CNAME": "bogdanstancu1119-maker.github.io"
+  }
+}


### PR DESCRIPTION
Registers **hydra-psie.is-a.dev** as a CNAME to `bogdanstancu1119-maker.github.io` — public static platform (GitHub Pages) for the Hydra Meta-Megaforma project, an open digital-organism framework. Will be set as the GitHub Pages custom domain once DNS propagates.