### PR TITLE
Register medialistory.is-a.dev

### DIFF
--- a/domains/medialistory.json
+++ b/domains/medialistory.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Gr33nOps"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering `medialistory.is-a.dev` for my project MediaListory (a media-tracking web app). It points via CNAME to a Vercel deployment (`cname.vercel-dns.com`).