### PR TITLE
Add rufuf.json with owner and NS records

### DIFF
--- a/domains/rufuf.json
+++ b/domains/rufuf.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "ahmedkamel-73",
+    "email": "aa.ak73@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "leah.ns.cloudflare.com",
+      "derek.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided contact information in the `owner` key.
- [x] I have provided a preview of my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://rufuf.vidfactory.workers.dev
https://rufuf.vidfactory.workers.dev/preview.png
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
Rufuf is a software development tool hosted on Cloudflare Workers at rufuf.vidfactory.workers.dev. I want to map it to rufuf.is-a.dev using NS delegation (leah.ns.cloudflare.com, derek.ns.cloudflare.com) for custom domain.
<!-- WEBSITE_PURPOSE_END -->