### PR TITLE
Add aiagent.is-a.dev

### DIFF
--- a/domains/aiagent.json
+++ b/domains/aiagent.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "Brahmendra@118"
+  },
+  "records": {
+    "A": "20.219.81.19"
+  }
+}


### PR DESCRIPTION
I would like to register aiagent.is-a.dev for my Flask AI Agent project hosted on an Azure VM.

The domain points to my Azure VM public IP and is used to access my development project.