### PR TITLE
Register youtube-shorts-studio.is-a.dev

### DIFF
--- a/domains/youtube-shorts-studio.json
+++ b/domains/youtube-shorts-studio.json
@@ -1,0 +1,12 @@
+{
+  "owner": {
+    "username": "butter-free",
+    "email": "comet5485@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "meadow.ns.cloudflare.com",
+      "trey.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
### Description
Registering `youtube-shorts-studio.is-a.dev` with NS records delegated to Cloudflare, for use with a Cloudflare Tunnel to expose a self-hosted app with a stable hostname.

### Checklist
- [x] I have read and understood the [guidelines](https://is-a.dev/docs/guidelines/)
- [x] My PR follows the [naming convention](https://is-a.dev/docs/naming-convention/)
- [x] I have not registered a subdomain that is a common word or brand name
- [x] I have tested my domain and it is working