### PR TITLE
Add bist-analiz.is-a.dev

### DIFF
--- a/domains/_github-pages-challenge-irfansahs.bist-analiz.json
+++ b/domains/_github-pages-challenge-irfansahs.bist-analiz.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "irfansahs",
+    "email": "irfansahsuvar@gmail.com"
+  },
+  "records": {
+    "TXT": "56097d9ce59d1a960937c9611058a4"
+  }
+}

--- a/domains/bist-analiz.json
+++ b/domains/bist-analiz.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "irfansahs",
+    "email": "irfansahsuvar@gmail.com"
+  },
+  "description": "Open-source BIST market analysis and anomaly radar dashboard (Python/FastAPI + React)",
+  "records": {
+    "A": ["16.170.245.74"]
+  }
+}


### PR DESCRIPTION
## Summary
- Register `bist-analiz.is-a.dev` for open-source BIST market analysis / anomaly radar dashboard (FastAPI + React)
- Add GitHub Pages ownership TXT challenge for `_github-pages-challenge-irfansahs.bist-analiz.is-a.dev`

## DNS
- A → `16.170.245.74` (self-hosted app server)
- TXT → GitHub Pages verification `56097d9ce59d1a960937c9611058a4`

## Checklist
- [x] I have read and accept the Terms of Service
- [x] Files are under `domains/`
- [x] Owner username matches GitHub account