### PR TITLE
tests: improve vercel verification tests further

### DIFF
--- a/tests/records.test.js
+++ b/tests/records.test.js
@@ -305,14 +305,9 @@ t("All files should have valid records", (t) => {
                 `${file}: Files starting with '_vercel' must have format '_vercel.<name>.json'`
             );
 
-            t.false(
-                recordKeys.includes("A"),
-                `${file}: Files starting with '_vercel' cannot have 'A' records`
-            );
-
-            t.false(
-                recordKeys.includes("CNAME"),
-                `${file}: Files starting with '_vercel' cannot have 'CNAME' records`
+            t.true(
+                recordKeys.includes("TXT") && recordKeys.length === 1,
+                `${file}: Files starting with '_vercel' can only have TXT records`
             );
 
             const txtRecords = data.records.TXT;

--- a/tests/records.test.js
+++ b/tests/records.test.js
@@ -305,6 +305,16 @@ t("All files should have valid records", (t) => {
                 `${file}: Files starting with '_vercel' must have format '_vercel.<name>.json'`
             );
 
+            t.false(
+                recordKeys.includes("A"),
+                `${file}: Files starting with '_vercel' cannot have 'A' records`
+            );
+
+            t.false(
+                recordKeys.includes("CNAME"),
+                `${file}: Files starting with '_vercel' cannot have 'CNAME' records`
+            );
+
             const txtRecords = data.records.TXT;
             const txtList = Array.isArray(txtRecords) ? txtRecords : [txtRecords];
 


### PR DESCRIPTION
disallow `A` and `CNAME` records in `_vercel` verification files
