### PR TITLE
Add wordcount.is-a.dev

### DIFF
--- a/domains/wordcount.json
+++ b/domains/wordcount.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "18106322872",
+        "email": "1442828588@qq.com"
+    },
+    "records": {
+        "CNAME": "725e8979-0c61-4efb-925c-bc4e79787eec.cfargotunnel.com"
+    }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS ENTIRE TEMPLATE FOR YOUR PR TO BE APPROVED!
DO NOT MODIFY OR REMOVE THIS TEMPLATE (INCLUDING REMOVING COMMENTS) OR YOUR PR WILL FAIL VALIDATION!
-->

# Requirements
- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
<!-- WEBSITE_PREVIEW_START -->
https://github.com/18106322872/WordCountWebBridge
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose
<!-- WEBSITE_PURPOSE_START -->
WordCount is a free, open-source word counting tool supporting PDF, DOCX, DWG/DXF (CAD), Excel, RAR archives and more. It provides accurate character/word/page statistics across desktop (Python/tkinter), Android (Kotlin/Jetpack Compose), and web (FastAPI) platforms. This subdomain hosts the web version Cloudflare Tunnel public endpoint for stable mobile access.
<!-- WEBSITE_PURPOSE_END -->