### PR TITLE
Add broyaseele3.is-a.dev

### DIFF
--- a/domains/broyaseele3.json
+++ b/domains/broyaseele3.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "sahitttsahit-sys"
+  },
+  "records": {
+    "NS": [
+      "gabriel.ns.cloudflare.com",
+      "ziggy.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
Registering broyaseele3.is-a.dev and delegating DNS to Cloudflare nameservers (gabriel.ns.cloudflare.com, ziggy.ns.cloudflare.com) for use with a Cloudflare Tunnel.