### PR TITLE
Add icode.is-a.dev

### DIFF
--- a/domains/icode.is-a.dev.json
+++ b/domains/icode.is-a.dev.json
@@ -1,6 +1,7 @@
 {
   "owner": {
     "username": "irabizipaisiblevalentin"
+    "email": "irabizipaisiblevalentin@gmail.com"
   },
   "records": {
     "CNAME": "icode-s05p.onrender.com"

--- a/domains/icode.is-a.dev.json
+++ b/domains/icode.is-a.dev.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "irabizipaisiblevalentin"
+  },
+  "records": {
+    "CNAME": "icode-s05p.onrender.com"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering  icode.is-a.dev  for official ICODE website for ICODE coding Agent, CDN-hosted at icode-s05p.onrender.com
