### PR TITLE
Add az-consultants.is-a.dev

### DIFF
--- a/domains/az-consultants.json
+++ b/domains/az-consultants.json
@@ -1,0 +1,24 @@
+{
+  "description": "Business email for a small engineering consultancy",
+  "owner": {
+    "username": "Amz34",
+    "email": "azengineeringapp@gmail.com"
+  },
+  "records": {
+    "MX": [
+      {
+        "target": "mx.zoho.com",
+        "priority": 10
+      },
+      {
+        "target": "mx2.zoho.com",
+        "priority": 20
+      },
+      {
+        "target": "mx3.zoho.com",
+        "priority": 50
+      }
+    ],
+    "TXT": "v=spf1 include:zohomail.com ~all"
+  }
+}


### PR DESCRIPTION
Registers `az-consultants.is-a.dev` for a small engineering consultancy's business email.

- Mail-only subdomain (no website yet) - MX and SPF for Zoho Mail, same pattern as other Zoho users in this repo.
- Zoho domain-verification TXT record will follow in a small follow-up commit once Zoho issues the token.
