### PR TITLE
Register blyx.is-a.dev

### DIFF
--- a/domains/_vercel.blyx.json
+++ b/domains/_vercel.blyx.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "2025200000316-byte"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=blyx.is-a.dev,b10240a88aae64e528d4"
+  }
+}

--- a/domains/blyx.json
+++ b/domains/blyx.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "2025200000316-byte"
+  },
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
+}


### PR DESCRIPTION
Registering blyx.is-a.dev for my project Blyx, a job board hiring platform. Points to my Vercel deployment via CNAME. Also includes a TXT record at _vercel.blyx.is-a.dev to verify domain ownership in Vercel (the hostname was previously added to a different unrelated Vercel account without ever having DNS configured for it).