### PR TITLE
Register lumenon.is-a.dev

### DIFF
--- a/domains/lumenon.json
+++ b/domains/lumenon.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "alialzukabi-dotcom",
+        "email": "alialzukabi@gmail.com"
+    },
+    "records": {
+        "CNAME": "alialzukabi-dotcom.github.io"
+    }
+}


### PR DESCRIPTION
## Requirements
- [x] I have read and understood the [is-a.dev Documentation](https://docs.is-a.dev).
- [x] I have searched for existing pull requests and issues to make sure this domain is not already registered.
- [x] I have read and understood the [is-a.dev Terms of Service](https://is-a.dev/terms).
- [x] I understand that if I am not the owner of the domain, I must have permission from the owner to register it.
- [x] I understand that is-a.dev is not responsible for any content hosted on my domain.
- [x] I understand that my subdomain may be revoked at any time for any reason.

## Website Purpose
**Start:**
Lumenon Project is an independent research initiative that bridges Logic and Philosophy. It serves as a hub for exploring the intersection of mathematics, philosophy, and scientific reasoning. The website shares research areas, upcoming publications, and provides a way for researchers and thinkers to connect.
**End:**

## Website Preview
**Start:**
https://alialzukabi-dotcom.github.io/lumenon-project/
**End:**