### PR TITLE
Remove lucascfarias.is-a.dev registration

### DIFF
--- a/domains/lucascfarias.json
+++ b/domains/lucascfarias.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "devlucascfarias",
-    "email": "developer.lucasc@gmail.com"
-  },
-  "records": {
-    "CNAME": "cname.vercel-dns.com"
-  }
-}


### PR DESCRIPTION
Removes the registration record for lucascfarias.is-a.dev at the owner's request.