### PR TITLE
Register stock-tracker-v2.is-a.dev

### DIFF
--- a/domains/stock-tracker-v2.json
+++ b/domains/stock-tracker-v2.json
@@ -1,0 +1,13 @@
+{
+  "description": "Personal stock tracking web app, self-hosted behind Cloudflare Tunnel.",
+  "owner": {
+    "username": "Anqarium",
+    "email": "demirtashakan08@gmail.com"
+  },
+  "records": {
+    "NS": [
+      "galilea.ns.cloudflare.com",
+      "kianchau.ns.cloudflare.com"
+    ]
+  }
+}


### PR DESCRIPTION
Registering stock-tracker-v2.is-a.dev to point to my Cloudflare zone (NS delegation) for a personal, self-hosted stock tracking app behind Cloudflare Tunnel.