### PR TITLE
Register mc164.is-a.dev

### DIFF
--- a/domains/mc164.json
+++ b/domains/mc164.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "MC164",
+    "email": "1736963589@qq.com"
+  },
+  "records": {
+    "CNAME": "mc164.github.io."
+  }
+}


### PR DESCRIPTION
I would like to register the subdomain `mc164.is-a.dev` for my Minecraft community website hosted on GitHub Pages.

- Owner: MC164
- Target: mc164.github.io (GitHub Pages)
- Purpose: Minecraft community download site