### PR TITLE
Register offline.is-a.dev

### DIFF
--- a/domains/offline.json
+++ b/domains/offline.json
@@ -1,0 +1,11 @@
+{
+  "owner": {
+    "username": "leonardoborgesdev",
+    "email": "caiosantosubatuba@gmail.com"
+  },
+  "records": {
+    "CNAME": "offline-network.suportebrazika.workers.dev"
+  },
+  "description": "OFFLINE — an offline-first social network that keeps working with no internet (local Wi-Fi station + peer sync).",
+  "repo": "https://github.com/leonardoborgesdev/offline-world-2000"
+}


### PR DESCRIPTION
### Description
Requesting `offline.is-a.dev` for OFFLINE, an offline-first social network — it keeps working with no internet via a local Wi-Fi station (ESP32 or an Android phone) and peer-to-peer sync, then syncs to the cloud whenever a connection comes back.

- Live site: https://offline-network.suportebrazika.workers.dev
- Source: https://github.com/leonardoborgesdev/offline-world-2000 (private for now)

### Checklist
- [x] I have read and understood the [terms of service](https://github.com/is-a-dev/register/blob/main/TERMS_OF_SERVICE.md).
- [x] I have not registered a domain for the purpose of phishing, spamming, malware, or other malicious purposes.
- [x] My PR title is in the format of `<Action> <domain>`.