### PR TITLE
Fix Vercel verification token for gururajkl.is-a.dev

### DIFF
--- a/domains/_vercel.gururajkl.json
+++ b/domains/_vercel.gururajkl.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "gururajkl"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=gururajkl.is-a.dev,35c7f0fb0e844b1f6220"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] <!-- TOS --> I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] <!-- DOMAIN_STRUCTURE --> My file follows the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] <!-- WEBSITE_REACHABLE --> My website is **reachable** and **completed**.
- [x] <!-- SOFTWARE_RELATED --> My website is **software development** related.
- [x] <!-- NON_COMMERCIAL --> My website is **not for commercial use**.
- [x] <!-- CONTACT_INFO --> I have provided sufficient contact information in the `owner` key.
- [x] <!-- WEBSITE_LINK --> I have provided a link to my website below.

# Website Preview

<!-- WEBSITE_PREVIEW_START -->
https://gururajkl.vercel.app/
<!-- WEBSITE_PREVIEW_END -->

# Website Purpose

<!-- WEBSITE_PURPOSE_START -->
This updates the Vercel ownership TXT record for my personal, non-commercial software engineering portfolio domain.
<!-- WEBSITE_PURPOSE_END -->